### PR TITLE
ci: enables usage of r/o sstate cache

### DIFF
--- a/.github/workflows/pr-master-qemu86-64-glibc.yml
+++ b/.github/workflows/pr-master-qemu86-64-glibc.yml
@@ -53,6 +53,19 @@ jobs:
           ref: fc09f711624f66720cbf8eab175a674556bf38d9
           branch: none
           add-layer: "0"
+      - name: setup (caches)
+        run: |
+          mkdir -p ${WORKSPACE}/sstate-cache
+      - name: configure (caches)
+        uses: actions/cache@v2
+        with:
+          path: /opt/build/sstate-cache
+          key: rubygems-x86-64-glibc
+      - name: activate (caches)
+        uses: priv-kweihmann/meta-sca-ci-utils/addvar@latest
+        with:
+          variable: SSTATE_MIRRORS
+          value: "file://.* file:///${WORKSPACE}/sstate-cache/PATH"
       - if: env.BUILD_GLIBC == '1'
         name: build (glibc)
         uses: priv-kweihmann/meta-sca-ci-utils/buildstep@latest

--- a/.github/workflows/pr-master-qemu86-64-musl.yml
+++ b/.github/workflows/pr-master-qemu86-64-musl.yml
@@ -53,6 +53,19 @@ jobs:
           ref: fc09f711624f66720cbf8eab175a674556bf38d9
           branch: none
           add-layer: "0"
+      - name: setup (caches)
+        run: |
+          mkdir -p ${WORKSPACE}/sstate-cache
+      - name: configure (caches)
+        uses: actions/cache@v2
+        with:
+          path: /opt/build/sstate-cache
+          key: rubygems-x86-64-musl
+      - name: activate (caches)
+        uses: priv-kweihmann/meta-sca-ci-utils/addvar@latest
+        with:
+          variable: SSTATE_MIRRORS
+          value: "file://.* file:///${WORKSPACE}/sstate-cache/PATH"
       - if: env.BUILD_GLIBC == '1'
         name: build (glibc)
         uses: priv-kweihmann/meta-sca-ci-utils/buildstep@latest


### PR DESCRIPTION
for pull request pipeline, reuse the sstate caches created
in push pipeline in r/o mode by using SSTATE_MIRROR

Closes #21

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>