### PR TITLE
CI: generate a fresh cache for each push

### DIFF
--- a/.github/workflows/push-master-qemu86-64-glibc.yml
+++ b/.github/workflows/push-master-qemu86-64-glibc.yml
@@ -43,7 +43,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /opt/build/sstate-cache
-          key: rubygems-x86-64-glibc
+          key: rubygems-x86-64-glibc-${{ github.head_ref }}
+          restore-keys: rubygems-x86-64-glibc
       - name: checkout (poky)
         uses: priv-kweihmann/meta-sca-ci-utils/addlayer@latest
         with:

--- a/.github/workflows/push-master-qemu86-64-musl.yml
+++ b/.github/workflows/push-master-qemu86-64-musl.yml
@@ -43,7 +43,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /opt/build/sstate-cache
-          key: rubygems-x86-64-musl
+          key: rubygems-x86-64-musl-${{ github.head_ref }}
+          restore-keys: rubygems-x86-64-musl
       - name: checkout (poky)
         uses: priv-kweihmann/meta-sca-ci-utils/addlayer@latest
         with:


### PR DESCRIPTION
add the head_ref of master branch to the cache key to enforce
a refresh.
create a common alias using restore-keys to let the other
pipelines use it without knowing the details

Closes #51

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>