### PR TITLE
CI: use github.run_id to generate a unique marker

### DIFF
--- a/.github/workflows/push-master-qemu86-64-glibc.yml
+++ b/.github/workflows/push-master-qemu86-64-glibc.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /opt/build/sstate-cache
-          key: rubygems-x86-64-glibc-${{ github.head_ref }}
+          key: rubygems-x86-64-glibc-${{ github.run_id }}
           restore-keys: rubygems-x86-64-glibc
       - name: checkout (poky)
         uses: priv-kweihmann/meta-sca-ci-utils/addlayer@latest

--- a/.github/workflows/push-master-qemu86-64-musl.yml
+++ b/.github/workflows/push-master-qemu86-64-musl.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /opt/build/sstate-cache
-          key: rubygems-x86-64-musl-${{ github.head_ref }}
+          key: rubygems-x86-64-musl-${{ github.run_id }}
           restore-keys: rubygems-x86-64-musl
       - name: checkout (poky)
         uses: priv-kweihmann/meta-sca-ci-utils/addlayer@latest


### PR DESCRIPTION
previously used github.head_ref doesn't return data when used in push
pipelines

Closes #53

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>