### PR TITLE
rubygems: inject proper compiler flags

### DIFF
--- a/classes/rubygems.bbclass
+++ b/classes/rubygems.bbclass
@@ -105,6 +105,46 @@ do_generate_spec() {
 do_generate_spec[vardepsexclude] += "prefix_native"
 addtask generate_spec after do_unpack_gem before do_patch
 
+python do_patch_arch_config() {
+    import re
+    if bb.data.inherits_class('native', d):
+        return
+    _map = {
+        "AR": d.expand("${AR}"),
+        "AS": d.expand("${AS}"),
+        "CC": d.expand("${CC}"),
+        "CFLAGS": d.expand("${CFLAGS}"),
+        "CPP": d.expand("${CPP}"),
+        "CPPFLAGS": d.expand("${CPPFLAGS}"),
+        "CXX": d.expand("${CXX}"),
+        "CXXFLAGS": d.expand("${CFLAGS}"),
+        "LDFLAGS": d.expand("${LDFLAGS}"),
+        "NM": d.expand("${NM}"),
+        "OBJDUMP": d.expand("${OBJDUMP}"),
+        "RANLIB": d.expand("${RANLIB}"),
+        "STRIP": d.expand("${STRIP}"),
+        "cppflags": d.expand("${CPPFLAGS}"),
+        "SOEXT": d.expand("so.${PV}"),
+        "DLEXT": d.expand("so.${PV}"),
+    }
+
+    cnt = ""
+    with open(d.expand("${RUBYLIB}/rbconfig.rb")) as i:
+        cnt = i.read()
+
+    for m in re.finditer(r'^(\s+|\t+)CONFIG\[\"(?P<var>.*)\"\]\s+=\s+\"(?P<value>.*)\"$', cnt, re.MULTILINE):
+        if m.group("var") in _map:
+            _rpl = '  CONFIG["{}"] = "{}"'.format(m.group("var"), _map[m.group("var")])
+            bb.note("Replace {} by {}".format(m.group(0), _rpl))
+            cnt = cnt.replace(m.group(0), _rpl)
+
+    with open(d.expand("${RUBYLIB}/rbconfig.rb"), "w") as o:
+        o.write(cnt)
+}
+
+do_patch_arch_config[doc] = "patches the correct compiler settings into the cross template"
+addtask do_patch_arch_config after generate_spec do_unpack_gem before do_compile
+
 rubygems_do_compile() {
     export GEM_PATH=${GEM_PATH}
     export GEM_HOME=${GEM_HOME}
@@ -115,9 +155,25 @@ rubygems_do_compile() {
     export LANGUAGE="en_US.UTF-8"
     export LC_ALL="en_US.UTF-8"
 
-    # Older versions of gem build don't understand -o flag, so try it once more without 
+    # Older versions of gem build don't understand -o flag, so try it once more without
     # it, if the command is failing
     gem build -V ${GEM_SPEC_FILE} -o ${GEM_BUILT_FILE} || gem build -V ${GEM_SPEC_FILE}
+}
+
+python do_rubygems_fix_libs() {
+    # as ruby dynloader expects the shared .so files
+    # without extension we will create symlinks to the
+    # properly versioned file
+    for root, dirs, files in os.walk(d.expand("${GEM_HOME}")):
+        for f in files:
+            if f.endswith(d.expand("so.${PV}")):
+                _filename = os.path.basename(f)
+                while "." in _filename:
+                    try:
+                        os.symlink(os.path.basename(f), os.path.join(root, _filename))
+                    except:
+                        pass
+                    _filename, _ = os.path.splitext(_filename)
 }
 
 rubygems_do_install() {
@@ -129,15 +185,12 @@ rubygems_do_install() {
 
     gem install --local --bindir ${D}${bindir} ${GEM_BUILT_FILE} --install-dir=${GEM_HOME} -E --no-user-install --ignore-dependencies --force --conservative -V -- ${GEM_INSTALL_FLAGS}
 
-    install -d ${D}${RUBY_SITEDIR}/${GEM_NAME}
-    find ${GEM_HOME} -name "*.so" -type f -exec sh -c "cp {} ${D}${RUBY_SITEDIR}/${GEM_NAME}/\$(basename {})" \;
-
     # remove all object files
     find ${GEM_HOME} -name "*.o" -type f -exec rm -f {} \;
-
 }
 
 EXPORT_FUNCTIONS do_compile do_install
+do_install[postfuncs] += "do_rubygems_fix_libs"
 
 PACKAGES =+ "${PN}-examples ${PN}-tests"
 
@@ -185,9 +238,10 @@ RDEPENDS_${PN}_append_class-target = " ruby"
 UPSTREAM_CHECK_URI ?= "https://rubygems.org/gems/${GEM_NAME}/versions"
 UPSTREAM_CHECK_REGEX ?= "/gems/${GEM_NAME}/versions/(?P<pver>(\d+\.*)*\d+)$"
 
-# Skip automatically, as this is an intended side effect
+# the ruby dynamic linker just uses plain .so files
+# so we have to supply symlinks as part of the base package
 INSANE_SKIP_${PN} += "dev-so"
 # we don't care what is actually needed for the dev-package
-INSANE_SKIP_${PN}-dev += "file-rdeps dev-elf ldflags"
+INSANE_SKIP_${PN}-dev += "file-rdeps"
 
 inherit rubygentest

--- a/recipes-devtools/ruby-cross/0001-Makefile-cross-compile-fixes.patch
+++ b/recipes-devtools/ruby-cross/0001-Makefile-cross-compile-fixes.patch
@@ -1,4 +1,4 @@
-From 505bc69aeac0065184a0fc95b843a8dbed6f36a9 Mon Sep 17 00:00:00 2001
+From 5287d03b6fa87963c433e2f0feefeaced8dc9f94 Mon Sep 17 00:00:00 2001
 From: Konrad Weihmann <kweihmann@outlook.com>
 Date: Wed, 16 Dec 2020 21:14:51 +0100
 Subject: [PATCH] Makefile: cross compile fixes
@@ -6,14 +6,14 @@ Subject: [PATCH] Makefile: cross compile fixes
 Upstream-Status: Inappropriate [oe-specific]
 Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>
 ---
- template/Makefile.in | 29 ++++++++++++++++++++++-------
- 1 file changed, 22 insertions(+), 7 deletions(-)
+ template/Makefile.in | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
 
 diff --git a/template/Makefile.in b/template/Makefile.in
-index 940ee07..882af9d 100644
+index d2df569..3ad6896 100644
 --- a/template/Makefile.in
 +++ b/template/Makefile.in
-@@ -320,19 +320,34 @@ rbconfig.rb: $(RBCONFIG)
+@@ -324,19 +324,20 @@ rbconfig.rb: $(RBCONFIG)
  install-cross: $(arch)-fake.rb $(RBCONFIG) rbconfig.rb $(arch_hdrdir)/ruby/config.h \
  	$(LIBRUBY_A) $(LIBRUBY_SO) $(ARCHFILE)
  	$(ECHO) installing cross-compiling stuff
@@ -26,20 +26,6 @@ index 940ee07..882af9d 100644
  	rbconfig.rb > fake-rbconfig.rb
 -	$(INSTALL_SCRIPT) fake.rb $(XRUBY_RUBYLIBDIR)/$(arch)/fake.rb
 -	$(INSTALL_SCRIPT) fake-rbconfig.rb $(XRUBY_RUBYLIBDIR)/$(arch)/rbconfig.rb
-+	sed -i "\#CONFIG\[\"cppflags\"\]#s#${CPPFLAGS_FROM_CROSS}#${CPPFLAGS_FOR_TARGET}#" fake-rbconfig.rb
-+	sed -i "\#CONFIG\[\"STRIP\"\]#s#${STRIP}#${STRIP_FOR_TARGET}#" fake-rbconfig.rb
-+	sed -i "\#CONFIG\[\"NM\"\]#s#${NM}#${NM_FOR_TARGET}#" fake-rbconfig.rb
-+	sed -i "\#CONFIG\[\"OBJDUMP\"\]#s#${OBJDUMP}#${OBJDUMP_FOR_TARGET}#" fake-rbconfig.rb
-+	sed -i "\#CONFIG\[\"AS\"\]#s#${AS}#${AS_FOR_TARGET}#" fake-rbconfig.rb
-+	sed -i "\#CONFIG\[\"AR\"\]#s#${AR}#${AR_FOR_TARGET}#" fake-rbconfig.rb
-+	sed -i "\#CONFIG\[\"RANLIB\"\]#s#${RANLIB}#${RANLIB_FOR_TARGET}#" fake-rbconfig.rb
-+	sed -i "\#CONFIG\[\"CPP\"\]#s#${CPP}#${CPP_FOR_TARGET}#" fake-rbconfig.rb
-+	sed -i "\#CONFIG\[\"CXXFLAGS\"\]#s#${CXXFLAGS_FROM_CROSS}#${CXXFLAGS_FOR_TARGET}#" fake-rbconfig.rb
-+	sed -i "\#CONFIG\[\"CXX\"\]#s#${CXX}#${CXX_FOR_TARGET}#" fake-rbconfig.rb
-+	sed -i "\#CONFIG\[\"CPPFLAGS\"\]#s#${CPPFLAGS_FROM_CROSS}##" fake-rbconfig.rb
-+	sed -i "\#CONFIG\[\"LDFLAGS\"\]#s#${LDFLAGS_FROM_CROSS}#${LDFLAGS_FOR_TARGET}#" fake-rbconfig.rb
-+	sed -i "\#CONFIG\[\"CFLAGS\"\]#s#${CFLAGS_FROM_CROSS}#${CFLAGS_FOR_TARGET}#" fake-rbconfig.rb
-+	sed -i "\#CONFIG\[\"CC\"\]#s#${CC}#${CC_FOR_TARGET}#" fake-rbconfig.rb
 +
 +	$(INSTALL_SCRIPT) fake.rb $(DESTDIR)$(XRUBY_RUBYLIBDIR)/$(arch)-cross/fake.rb
 +	$(INSTALL_SCRIPT) fake-rbconfig.rb $(DESTDIR)$(XRUBY_RUBYLIBDIR)/$(arch)-cross/rbconfig.rb

--- a/recipes-rubygems/rubygems-bcrypt-pbkdf_1.1.0.bb
+++ b/recipes-rubygems/rubygems-bcrypt-pbkdf_1.1.0.bb
@@ -18,4 +18,3 @@ inherit rubygentest
 inherit pkgconfig
 
 BBCLASSEXTEND = "native"
-INSANE_SKIP_${PN} += "ldflags"

--- a/recipes-rubygems/rubygems-ed25519_1.2.4.bb
+++ b/recipes-rubygems/rubygems-ed25519_1.2.4.bb
@@ -18,4 +18,3 @@ inherit rubygentest
 inherit pkgconfig
 
 BBCLASSEXTEND = "native"
-INSANE_SKIP_${PN} += "ldflags"

--- a/recipes-rubygems/rubygems-ffi-yajl_2.3.4.bb
+++ b/recipes-rubygems/rubygems-ffi-yajl_2.3.4.bb
@@ -33,5 +33,3 @@ inherit rubygentest
 inherit pkgconfig
 
 BBCLASSEXTEND = "native"
-
-INSANE_SKIP_${PN} += "ldflags"

--- a/recipes-rubygems/rubygems-ffi_1.14.2.bb
+++ b/recipes-rubygems/rubygems-ffi_1.14.2.bb
@@ -23,4 +23,3 @@ GEM_INSTALL_FLAGS += "\
 "
 
 BBCLASSEXTEND = "native"
-INSANE_SKIP_${PN} += "ldflags"

--- a/recipes-rubygems/rubygems-json_2.5.1.bb
+++ b/recipes-rubygems/rubygems-json_2.5.1.bb
@@ -16,4 +16,3 @@ inherit rubygentest
 inherit pkgconfig
 
 BBCLASSEXTEND = "native"
-INSANE_SKIP_${PN} += "ldflags"

--- a/recipes-rubygems/rubygems-libyajl2_2.0.0.bb
+++ b/recipes-rubygems/rubygems-libyajl2_2.0.0.bb
@@ -18,5 +18,3 @@ inherit rubygentest
 inherit pkgconfig
 
 BBCLASSEXTEND = "native"
-
-INSANE_SKIP_${PN} += "ldflags"

--- a/recipes-rubygems/rubygems-yajl-ruby_1.4.1.bb
+++ b/recipes-rubygems/rubygems-yajl-ruby_1.4.1.bb
@@ -16,4 +16,3 @@ inherit rubygentest
 inherit pkgconfig
 
 BBCLASSEXTEND = "native"
-INSANE_SKIP_${PN} += "ldflags"


### PR DESCRIPTION
by patching the cross rbconfig.rb on the fly.
also introduce properly versioned so-files.
as the ruby dynlinker only seems to handle plain .so files correctly, create symlinks and package them to the
base package.
remove the moving of shared objects to the site-dir, as this isn't needed anymore

This patch removes the need to INSANE_SKIP ldflags and dev-elf