### PR TITLE
CI: use github.sha as unique marker for cron/push

### DIFF
--- a/.github/workflows/cron-master-qemu86-64-pkgupdate.yml
+++ b/.github/workflows/cron-master-qemu86-64-pkgupdate.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /opt/build/sstate-cache
-          key: rubygems-x86-64-glibc
+          key: rubygems-x86-64-glibc-${{ github.sha }}
       - name: checkout (poky)
         uses: priv-kweihmann/meta-sca-ci-utils/addlayer@latest
         with:

--- a/.github/workflows/pr-master-qemu86-64-glibc.yml
+++ b/.github/workflows/pr-master-qemu86-64-glibc.yml
@@ -46,6 +46,7 @@ jobs:
           branch: auto-determine
           gh-event-file: "1"
           add-layer: "0"
+          remove-git: "0"
       - name: checkout (meta-openembedded)
         uses: priv-kweihmann/meta-sca-ci-utils/addlayer@latest
         with:
@@ -55,12 +56,15 @@ jobs:
           add-layer: "0"
       - name: setup (caches)
         run: |
+          sudo mkdir -p /__w/_temp/_runner_file_commands
+          sudo chmod -R 0777 /__w/_temp/_runner_file_commands
+          sudo echo "rubygems_master_rev=$(git -C /opt/build/sources/meta-rubygems/ rev-parse ${{ github.base_ref }})" >> $GITHUB_ENV
           mkdir -p ${WORKSPACE}/sstate-cache
       - name: configure (caches)
         uses: actions/cache@v2
         with:
           path: /opt/build/sstate-cache
-          key: rubygems-x86-64-glibc
+          key: rubygems-x86-64-glibc-${{ env.rubygems_master_rev }}
       - name: activate (caches)
         uses: priv-kweihmann/meta-sca-ci-utils/addvar@latest
         with:

--- a/.github/workflows/pr-master-qemu86-64-musl.yml
+++ b/.github/workflows/pr-master-qemu86-64-musl.yml
@@ -53,14 +53,18 @@ jobs:
           ref: c5acdbe0939981aa6a4919620aab93ac2b2e14af
           branch: none
           add-layer: "0"
+          remove-git: "0"
       - name: setup (caches)
         run: |
+          sudo mkdir -p /__w/_temp/_runner_file_commands
+          sudo chmod -R 0777 /__w/_temp/_runner_file_commands
+          sudo echo "rubygems_master_rev=$(git -C /opt/build/sources/meta-rubygems/ rev-parse ${{ github.base_ref }})" >> $GITHUB_ENV
           mkdir -p ${WORKSPACE}/sstate-cache
       - name: configure (caches)
         uses: actions/cache@v2
         with:
           path: /opt/build/sstate-cache
-          key: rubygems-x86-64-musl
+          key: rubygems-x86-64-musl-${{ env.rubygems_master_rev }}
       - name: activate (caches)
         uses: priv-kweihmann/meta-sca-ci-utils/addvar@latest
         with:

--- a/.github/workflows/push-master-qemu86-64-glibc.yml
+++ b/.github/workflows/push-master-qemu86-64-glibc.yml
@@ -43,8 +43,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /opt/build/sstate-cache
-          key: rubygems-x86-64-glibc-${{ github.run_id }}
-          restore-keys: rubygems-x86-64-glibc
+          key: rubygems-x86-64-glibc-${{ github.sha }}
       - name: checkout (poky)
         uses: priv-kweihmann/meta-sca-ci-utils/addlayer@latest
         with:

--- a/.github/workflows/push-master-qemu86-64-musl.yml
+++ b/.github/workflows/push-master-qemu86-64-musl.yml
@@ -43,8 +43,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /opt/build/sstate-cache
-          key: rubygems-x86-64-musl-${{ github.run_id }}
-          restore-keys: rubygems-x86-64-musl
+          key: rubygems-x86-64-musl-${{ github.sha }}
       - name: checkout (poky)
         uses: priv-kweihmann/meta-sca-ci-utils/addlayer@latest
         with:


### PR DESCRIPTION
and github.base_ref for the pull request pipelines.
remove restore-keys feature to avoid old caches being used.

Closes to #57

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>