### PR TITLE
ruby-gen: compare 4 cells in fallback mode

### DIFF
--- a/scripts/ruby-gen
+++ b/scripts/ruby-gen
@@ -167,6 +167,12 @@ def get_license(desc, old_recipes):
         return "TODO"
     return " & ".join(desc["licenses"])
 
+def __sanitizies_version(_input):
+    _dotcnt = sum(1 for x in _input if x == ".")
+    _ver = _input.replace(".", "")
+    _ver += "0" * (3 - _dotcnt)
+    return int(_ver)
+
 
 def check_existing(args, pkgname, version, _naming_pattern):
     _matches = glob.glob(os.path.join(
@@ -180,9 +186,8 @@ def check_existing(args, pkgname, version, _naming_pattern):
                 m).replace(".bb", "").split("_")[1])
             cversion = Version(version)
         except ValueError:
-            mversion = int(os.path.basename(m).replace(
-                ".bb", "").split("_")[1].replace(".", ""))
-            cversion = int(version.replace(".", ""))
+            mversion = int(__sanitizies_version(os.path.basename(m).replace(".bb", "").split("_")[1]))
+            cversion = int(__sanitizies_version(version))
         if mversion >= cversion and not args.force:
             return []
         if mversion < cversion:


### PR DESCRIPTION
if a version is not parsable by semantic-version,
align all input to a 4 cell value and then compare it.
This avoid version 1.2.3.4 being wrongfully interpreted higher
than 1.3.0

Closes #62

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>