### PR TITLE
CI: disable test run on push pipeline

### DIFF
--- a/.github/workflows/push-master-qemu86-64-glibc.yml
+++ b/.github/workflows/push-master-qemu86-64-glibc.yml
@@ -94,8 +94,3 @@ jobs:
         uses: priv-kweihmann/meta-sca-ci-utils/buildstep@latest
         with:
           target: core-image-minimal-rubygems
-      - name: test (core-image-minimal-rubygems)
-        uses: priv-kweihmann/meta-sca-ci-utils/testimage@latest
-        with:
-          target: core-image-minimal-rubygems
-          tapgen: "0"

--- a/.github/workflows/push-master-qemu86-64-musl.yml
+++ b/.github/workflows/push-master-qemu86-64-musl.yml
@@ -94,8 +94,3 @@ jobs:
         uses: priv-kweihmann/meta-sca-ci-utils/buildstep@latest
         with:
           target: core-image-minimal-rubygems
-      - name: test (core-image-minimal-rubygems)
-        uses: priv-kweihmann/meta-sca-ci-utils/testimage@latest
-        with:
-          target: core-image-minimal-rubygems
-          tapgen: "0"


### PR DESCRIPTION
as the necessary check already have been done on PR pipeline
and this test is very time consuming and likely lead to a
pipeline timeout in edge cases

Closes #73

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>