### PR TITLE
reek and rubycritic

### DIFF
--- a/classes/rubygems.bbclass
+++ b/classes/rubygems.bbclass
@@ -234,6 +234,7 @@ FILES_${PN} += "\
 "
 
 RDEPENDS_${PN}_append_class-target = " ruby"
+RDEPENDS_${PN}-tests_append_class-target = " ruby"
 
 UPSTREAM_CHECK_URI ?= "https://rubygems.org/gems/${GEM_NAME}/versions"
 UPSTREAM_CHECK_REGEX ?= "/gems/${GEM_NAME}/versions/(?P<pver>(\d+\.*)*\d+)$"

--- a/classes/rubygentest.bbclass
+++ b/classes/rubygentest.bbclass
@@ -30,7 +30,7 @@ python do_rubygems_gen_test() {
         __tests.add(_tpl_require.format(
             pn=sanitize_name(d.getVar("BPN")),
             require=_filename,
-            sanitize_name=sanitize_name(_filename)))
+            sanitize_name=sanitize_name(_filename).replace(".", "_")))
 
     for _file in glob.glob(d.expand("${PKGDEST}/${PN}/${bindir}/*")):
         _filename = os.path.basename(_file)

--- a/lib/oeqa/runtime/cases/rubygems_exceptions.py
+++ b/lib/oeqa/runtime/cases/rubygems_exceptions.py
@@ -7,11 +7,25 @@ class RubyGemsTestExceptions():
     }
 
     exec_wrapper_skips = {
+        "gauntlet": "some internal weirdness",
         "setup": "unknown issue with ruby load function"
     }
 
     loadable_skips = {
-        "syslog-formatter": "module needs upfront configuration of a logging provider"
+        "gauntlet_flay": "causes a SIGKILL",
+        "gauntlet_flog": "causes a SIGKILL",
+        "gauntlet_grep": "causes a SIGKILL",
+        "gauntlet_parser": "causes a SIGKILL",
+        "ruby20_parser": "not the parser you are looking for",
+        "ruby21_parser": "not the parser you are looking for",
+        "ruby22_parser": "not the parser you are looking for",
+        "ruby23_parser": "not the parser you are looking for",
+        "ruby24_parser": "not the parser you are looking for",
+        "ruby25_parser": "not the parser you are looking for",
+        "ruby26_parser": "not the parser you are looking for",
+        "ruby27_parser": "not the parser you are looking for",
+        "simplecov-html": "needs extra configuration -> uninitialized constant SimpleCov (NameError)",
+        "syslog-formatter": "module needs upfront configuration of a logging provider",
     }
 
     gem_list_skips = {

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_ast.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_ast.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_ast(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_ast(self):
+        self.gem_is_installed("ast")
+
+    def test_load_ast(self):
+        self.gem_is_loadable("ast")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_axiom_types.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_axiom_types.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_axiom_types(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_axiom_types(self):
+        self.gem_is_installed("axiom-types")
+
+    def test_load_axiom_types(self):
+        self.gem_is_loadable("axiom-types")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_codeclimate_engine_rb.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_codeclimate_engine_rb.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_codeclimate_engine_rb(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_codeclimate_engine_rb(self):
+        self.gem_is_installed("codeclimate-engine-rb")
+
+    def test_load_codeclimate_engine(self):
+        self.gem_is_loadable("codeclimate_engine")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_coercible.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_coercible.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_coercible(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_coercible(self):
+        self.gem_is_installed("coercible")
+
+    def test_load_coercible(self):
+        self.gem_is_loadable("coercible")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_connection_pool.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_connection_pool.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_connection_pool(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_connection_pool(self):
+        self.gem_is_installed("connection_pool")
+
+    def test_load_connection_pool(self):
+        self.gem_is_loadable("connection_pool")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_descendants_tracker.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_descendants_tracker.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_descendants_tracker(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_descendants_tracker(self):
+        self.gem_is_installed("descendants_tracker")
+
+    def test_load_descendants_tracker(self):
+        self.gem_is_loadable("descendants_tracker")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_docile.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_docile.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_docile(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_docile(self):
+        self.gem_is_installed("docile")
+
+    def test_load_docile(self):
+        self.gem_is_loadable("docile")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_equalizer.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_equalizer.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_equalizer(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_equalizer(self):
+        self.gem_is_installed("equalizer")
+
+    def test_load_equalizer(self):
+        self.gem_is_loadable("equalizer")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_flay.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_flay.py
@@ -1,0 +1,22 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_flay(RubyGemsTestUtils):
+
+    def test_exec_flay(self):
+        self.gem_exec_wrapper("flay")
+
+    def test_gem_list_rubygems_flay(self):
+        self.gem_is_installed("flay")
+
+    def test_load_flay(self):
+        self.gem_is_loadable("flay")
+
+    def test_load_flay_erb(self):
+        self.gem_is_loadable("flay_erb")
+
+    def test_load_flay_task(self):
+        self.gem_is_loadable("flay_task")
+
+    def test_load_gauntlet_flay(self):
+        self.gem_is_loadable("gauntlet_flay")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_flog.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_flog.py
@@ -1,0 +1,22 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_flog(RubyGemsTestUtils):
+
+    def test_exec_flog(self):
+        self.gem_exec_wrapper("flog")
+
+    def test_gem_list_rubygems_flog(self):
+        self.gem_is_installed("flog")
+
+    def test_load_flog(self):
+        self.gem_is_loadable("flog")
+
+    def test_load_flog_cli(self):
+        self.gem_is_loadable("flog_cli")
+
+    def test_load_flog_task(self):
+        self.gem_is_loadable("flog_task")
+
+    def test_load_gauntlet_flog(self):
+        self.gem_is_loadable("gauntlet_flog")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_gauntlet.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_gauntlet.py
@@ -1,0 +1,16 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_gauntlet(RubyGemsTestUtils):
+
+    def test_exec_gauntlet(self):
+        self.gem_exec_wrapper("gauntlet")
+
+    def test_gem_list_rubygems_gauntlet(self):
+        self.gem_is_installed("gauntlet")
+
+    def test_load_gauntlet(self):
+        self.gem_is_loadable("gauntlet")
+
+    def test_load_gauntlet_grep(self):
+        self.gem_is_loadable("gauntlet_grep")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_ice_nine.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_ice_nine.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_ice_nine(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_ice_nine(self):
+        self.gem_is_installed("ice_nine")
+
+    def test_load_ice_nine(self):
+        self.gem_is_loadable("ice_nine")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_kwalify.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_kwalify.py
@@ -1,0 +1,13 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_kwalify(RubyGemsTestUtils):
+
+    def test_exec_kwalify(self):
+        self.gem_exec_wrapper("kwalify")
+
+    def test_gem_list_rubygems_kwalify(self):
+        self.gem_is_installed("kwalify")
+
+    def test_load_kwalify(self):
+        self.gem_is_loadable("kwalify")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_launchy.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_launchy.py
@@ -1,0 +1,13 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_launchy(RubyGemsTestUtils):
+
+    def test_exec_launchy(self):
+        self.gem_exec_wrapper("launchy")
+
+    def test_gem_list_rubygems_launchy(self):
+        self.gem_is_installed("launchy")
+
+    def test_load_launchy(self):
+        self.gem_is_loadable("launchy")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_net_http_persistent.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_net_http_persistent.py
@@ -1,0 +1,7 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_net_http_persistent(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_net_http_persistent(self):
+        self.gem_is_installed("net-http-persistent")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_parser.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_parser.py
@@ -1,0 +1,19 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_parser(RubyGemsTestUtils):
+
+    def test_exec_ruby_parse(self):
+        self.gem_exec_wrapper("ruby-parse")
+
+    def test_exec_ruby_rewrite(self):
+        self.gem_exec_wrapper("ruby-rewrite")
+
+    def test_gem_list_rubygems_parser(self):
+        self.gem_is_installed("parser")
+
+    def test_load_gauntlet_parser(self):
+        self.gem_is_loadable("gauntlet_parser")
+
+    def test_load_parser(self):
+        self.gem_is_loadable("parser")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_path_expander.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_path_expander.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_path_expander(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_path_expander(self):
+        self.gem_is_installed("path_expander")
+
+    def test_load_path_expander(self):
+        self.gem_is_loadable("path_expander")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_rainbow.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_rainbow.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_rainbow(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_rainbow(self):
+        self.gem_is_installed("rainbow")
+
+    def test_load_rainbow(self):
+        self.gem_is_loadable("rainbow")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_reek.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_reek.py
@@ -1,0 +1,16 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_reek(RubyGemsTestUtils):
+
+    def test_exec_code_climate_reek(self):
+        self.gem_exec_wrapper("code_climate_reek")
+
+    def test_exec_reek(self):
+        self.gem_exec_wrapper("reek")
+
+    def test_gem_list_rubygems_reek(self):
+        self.gem_is_installed("reek")
+
+    def test_load_reek(self):
+        self.gem_is_loadable("reek")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_ruby_parser.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_ruby_parser.py
@@ -1,0 +1,55 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_ruby_parser(RubyGemsTestUtils):
+
+    def test_exec_ruby_parse(self):
+        self.gem_exec_wrapper("ruby_parse")
+
+    def test_exec_ruby_parse_extract_error(self):
+        self.gem_exec_wrapper("ruby_parse_extract_error")
+
+    def test_gem_list_rubygems_ruby_parser(self):
+        self.gem_is_installed("ruby_parser")
+
+    def test_load_rp_extensions(self):
+        self.gem_is_loadable("rp_extensions")
+
+    def test_load_rp_stringscanner(self):
+        self.gem_is_loadable("rp_stringscanner")
+
+    def test_load_ruby20_parser(self):
+        self.gem_is_loadable("ruby20_parser")
+
+    def test_load_ruby21_parser(self):
+        self.gem_is_loadable("ruby21_parser")
+
+    def test_load_ruby22_parser(self):
+        self.gem_is_loadable("ruby22_parser")
+
+    def test_load_ruby23_parser(self):
+        self.gem_is_loadable("ruby23_parser")
+
+    def test_load_ruby24_parser(self):
+        self.gem_is_loadable("ruby24_parser")
+
+    def test_load_ruby25_parser(self):
+        self.gem_is_loadable("ruby25_parser")
+
+    def test_load_ruby26_parser(self):
+        self.gem_is_loadable("ruby26_parser")
+
+    def test_load_ruby27_parser(self):
+        self.gem_is_loadable("ruby27_parser")
+
+    def test_load_ruby_lexer(self):
+        self.gem_is_loadable("ruby_lexer")
+
+    def test_load_ruby_lexer_rex(self):
+        self.gem_is_loadable("ruby_lexer.rex")
+
+    def test_load_ruby_parser(self):
+        self.gem_is_loadable("ruby_parser")
+
+    def test_load_ruby_parser_extras(self):
+        self.gem_is_loadable("ruby_parser_extras")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_rubycritic.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_rubycritic.py
@@ -1,0 +1,13 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_rubycritic(RubyGemsTestUtils):
+
+    def test_exec_rubycritic(self):
+        self.gem_exec_wrapper("rubycritic")
+
+    def test_gem_list_rubygems_rubycritic(self):
+        self.gem_is_installed("rubycritic")
+
+    def test_load_rubycritic(self):
+        self.gem_is_loadable("rubycritic")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_sexp_processor.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_sexp_processor.py
@@ -1,0 +1,28 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_sexp_processor(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_sexp_processor(self):
+        self.gem_is_installed("sexp_processor")
+
+    def test_load_composite_sexp_processor(self):
+        self.gem_is_loadable("composite_sexp_processor")
+
+    def test_load_pt_testcase(self):
+        self.gem_is_loadable("pt_testcase")
+
+    def test_load_sexp(self):
+        self.gem_is_loadable("sexp")
+
+    def test_load_sexp_matcher(self):
+        self.gem_is_loadable("sexp_matcher")
+
+    def test_load_sexp_processor(self):
+        self.gem_is_loadable("sexp_processor")
+
+    def test_load_strict_sexp(self):
+        self.gem_is_loadable("strict_sexp")
+
+    def test_load_unique(self):
+        self.gem_is_loadable("unique")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_simplecov.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_simplecov.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_simplecov(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_simplecov(self):
+        self.gem_is_installed("simplecov")
+
+    def test_load_simplecov(self):
+        self.gem_is_loadable("simplecov")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_simplecov_html.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_simplecov_html.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_simplecov_html(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_simplecov_html(self):
+        self.gem_is_installed("simplecov-html")
+
+    def test_load_simplecov_html(self):
+        self.gem_is_loadable("simplecov-html")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_simplecov_json_formatter.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_simplecov_json_formatter.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_simplecov_json_formatter(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_simplecov_json_formatter(self):
+        self.gem_is_installed("simplecov_json_formatter")
+
+    def test_load_simplecov_json_formatter(self):
+        self.gem_is_loadable("simplecov_json_formatter")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_tty_which.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_tty_which.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_tty_which(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_tty_which(self):
+        self.gem_is_installed("tty-which")
+
+    def test_load_tty_which(self):
+        self.gem_is_loadable("tty-which")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_virtus.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_virtus.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_virtus(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_virtus(self):
+        self.gem_is_installed("virtus")
+
+    def test_load_virtus(self):
+        self.gem_is_loadable("virtus")
+

--- a/packagegroups-rubygems/packagegroup-rubygems.bb
+++ b/packagegroups-rubygems/packagegroup-rubygems.bb
@@ -6,10 +6,12 @@ RDEPENDS_${PN} += "\
     rubygems-activemodel \
     rubygems-activesupport \
     rubygems-addressable \
+    rubygems-ast \
     rubygems-aws-eventstream \
     rubygems-aws-partitions \
     rubygems-aws-sdk-core \
     rubygems-aws-sigv4 \
+    rubygems-axiom-types \
     rubygems-bcrypt-pbkdf \
     rubygems-builder \
     rubygems-chef \
@@ -18,11 +20,17 @@ RDEPENDS_${PN} += "\
     rubygems-chef-utils \
     rubygems-chef-vault \
     rubygems-chef-zero \
+    rubygems-codeclimate-engine-rb \
     rubygems-coderay \
+    rubygems-coercible \
     rubygems-concurrent-ruby \
+    rubygems-connection-pool \
     rubygems-deep-merge \
+    rubygems-descendants-tracker \
     rubygems-diff-lcs \
+    rubygems-docile \
     rubygems-ed25519 \
+    rubygems-equalizer \
     rubygems-erubi \
     rubygems-erubis \
     rubygems-facter \
@@ -33,7 +41,10 @@ RDEPENDS_${PN} += "\
     rubygems-ffi \
     rubygems-ffi-libarchive \
     rubygems-ffi-yajl \
+    rubygems-flay \
+    rubygems-flog \
     rubygems-fuzzyurl \
+    rubygems-gauntlet \
     rubygems-gssapi \
     rubygems-gyoku \
     rubygems-hashie \
@@ -42,11 +53,14 @@ RDEPENDS_${PN} += "\
     rubygems-hocon \
     rubygems-httpclient \
     rubygems-i18n \
+    rubygems-ice-nine \
     rubygems-iniparse \
     rubygems-inspec-core \
     rubygems-ipaddress \
     rubygems-jmespath \
     rubygems-json \
+    rubygems-kwalify \
+    rubygems-launchy \
     rubygems-libyajl2 \
     rubygems-license-acceptance \
     rubygems-little-plugger \
@@ -65,6 +79,7 @@ RDEPENDS_${PN} += "\
     rubygems-mixlib-shellout \
     rubygems-multi-json \
     rubygems-multipart-post \
+    rubygems-net-http-persistent \
     rubygems-net-netconf \
     rubygems-net-scp \
     rubygems-net-sftp \
@@ -76,8 +91,10 @@ RDEPENDS_${PN} += "\
     rubygems-nori \
     rubygems-ohai \
     rubygems-parallel \
+    rubygems-parser \
     rubygems-parslet \
     rubygems-pastel \
+    rubygems-path-expander \
     rubygems-plist \
     rubygems-proxifier \
     rubygems-pry \
@@ -86,6 +103,8 @@ RDEPENDS_${PN} += "\
     rubygems-puppet-resource-api \
     rubygems-puppetmodule-netdev-stdlib \
     rubygems-rack \
+    rubygems-rainbow \
+    rubygems-reek \
     rubygems-rspec \
     rubygems-rspec-core \
     rubygems-rspec-expectations \
@@ -93,14 +112,20 @@ RDEPENDS_${PN} += "\
     rubygems-rspec-junit-formatter \
     rubygems-rspec-mocks \
     rubygems-rspec-support \
+    rubygems-ruby-parser \
     rubygems-ruby2-keywords \
+    rubygems-rubycritic \
     rubygems-rubyntlm \
     rubygems-rubyzip \
     rubygems-scanf \
     rubygems-semantic-puppet \
     rubygems-semverse \
     rubygems-serverspec \
+    rubygems-sexp-processor \
     rubygems-sfl \
+    rubygems-simplecov \
+    rubygems-simplecov-html \
+    rubygems-simplecov-json-formatter \
     rubygems-slop \
     rubygems-specinfra \
     rubygems-sslshake \
@@ -121,10 +146,12 @@ RDEPENDS_${PN} += "\
     rubygems-tty-reader \
     rubygems-tty-screen \
     rubygems-tty-table \
+    rubygems-tty-which \
     rubygems-tzinfo \
     rubygems-unicode-display-width \
     rubygems-unicode-utils \
     rubygems-uuidtools \
+    rubygems-virtus \
     rubygems-webrick \
     rubygems-winrm \
     rubygems-winrm-elevated \

--- a/recipes-rubygems/rubygems-ast_2.4.2.bb
+++ b/recipes-rubygems/rubygems-ast_2.4.2.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: ast"
+DESCRIPTION = "A library for working with Abstract Syntax Trees."
+HOMEPAGE = "https://whitequark.github.io/ast/"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.MIT;md5=b46ff44655f29020fc7542adda3ad781"
+
+SRC_URI[md5sum] = "f34e4eebd2f1d443a90a2aff11a08c73"
+SRC_URI[sha256sum] = "1e280232e6a33754cde542bc5ef85520b74db2aac73ec14acef453784447cc12"
+
+GEM_NAME = "ast"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-axiom-types_0.1.1.bb
+++ b/recipes-rubygems/rubygems-axiom-types_0.1.1.bb
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: axiom-types"
+DESCRIPTION = "Define types with optional constraints for use within axiom and other libraries."
+HOMEPAGE = "https://github.com/dkubb/axiom-types"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=bb2f5305df40093372eea3bbf265a14c"
+
+DEPENDS_class-native += "\
+    rubygems-descendants-tracker-native \
+    rubygems-ice-nine-native \
+    rubygems-thread-safe-native \
+"
+
+SRC_URI[md5sum] = "728d702cf0f3f31b49b41a4019afba56"
+SRC_URI[sha256sum] = "c1ff113f3de516fa195b2db7e0a9a95fd1b08475a502ff660d04507a09980383"
+
+GEM_NAME = "axiom-types"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-descendants-tracker \
+    rubygems-ice-nine \
+    rubygems-thread-safe \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-codeclimate-engine-rb_0.4.1.bb
+++ b/recipes-rubygems/rubygems-codeclimate-engine-rb_0.4.1.bb
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: codeclimate-engine-rb"
+DESCRIPTION = "JSON issue formatter for the Code Climate engine"
+HOMEPAGE = "https://github.com/andyw8/codeclimate-engine-rb"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=56b47d379805ed45bc0c1aff19d7364b"
+
+EXTRA_RDEPENDS += "bash"
+
+DEPENDS_class-native += "\
+    rubygems-virtus-native \
+"
+
+SRC_URI[md5sum] = "050479d0b1bc1ca9f7349d9307f0e03f"
+SRC_URI[sha256sum] = "ae72b9dfe246d3cd3592cec0f98a9dab06ba655adbb66a51559ca0f3cee0a56c"
+
+GEM_NAME = "codeclimate-engine-rb"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-virtus \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-coercible_1.0.0.bb
+++ b/recipes-rubygems/rubygems-coercible_1.0.0.bb
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: coercible"
+DESCRIPTION = "Powerful, flexible and configurable coercion library"
+HOMEPAGE = "https://github.com/solnic/coercible"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=a2f3cab50161b5e2aaef2d9570e55703"
+
+DEPENDS_class-native += "\
+    rubygems-descendants-tracker-native \
+"
+
+SRC_URI[md5sum] = "cf1636c69f5c175d41b355abf733ea19"
+SRC_URI[sha256sum] = "5081ad24352cc8435ce5472bc2faa30260c7ea7f2102cc6a9f167c4d9bffaadc"
+
+GEM_NAME = "coercible"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-descendants-tracker \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-connection-pool_2.2.3.bb
+++ b/recipes-rubygems/rubygems-connection-pool_2.2.3.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: connection_pool"
+DESCRIPTION = "Generic connection pool for Ruby"
+HOMEPAGE = "https://github.com/mperham/connection_pool"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=52789255e9a79d4ae4a5ab6831d80fd1"
+
+SRC_URI[md5sum] = "1ccc96dc7feb55947fe7ec6799ba19b3"
+SRC_URI[sha256sum] = "8e5bf44b6bfa96f5c94a5c30ae2447fce3dbcc0828a855a6c513fdb015a133e2"
+
+GEM_NAME = "connection_pool"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-descendants-tracker_0.0.4.bb
+++ b/recipes-rubygems/rubygems-descendants-tracker_0.0.4.bb
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: descendants_tracker"
+DESCRIPTION = "Module that adds descendant tracking to a class"
+HOMEPAGE = "https://github.com/dkubb/descendants_tracker"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=a424947e9eb86ed8d34d6b437a077b9b"
+
+DEPENDS_class-native += "\
+    rubygems-thread-safe-native \
+"
+
+SRC_URI[md5sum] = "8653c98e777eddaddf369109af107b0f"
+SRC_URI[sha256sum] = "e9c41dd4cfbb85829a9301ea7e7c48c2a03b26f09319db230e6479ccdc780897"
+
+GEM_NAME = "descendants_tracker"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-thread-safe \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-docile_1.3.5.bb
+++ b/recipes-rubygems/rubygems-docile_1.3.5.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: docile"
+DESCRIPTION = "Docile treats the methods of a given ruby object as a DSL (domain specific language) within a given block"
+HOMEPAGE = "https://ms-ati.github.io/docile/"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e74ce31842082484e7525142a0cae01f"
+
+SRC_URI[md5sum] = "b07475d7f767d0b3f260223721369986"
+SRC_URI[sha256sum] = "7f980b18ea99e95aed225efdd1694d9d8e10e3fdbd133718c6006d8e9bceedae"
+
+GEM_NAME = "docile"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-equalizer_0.0.11.bb
+++ b/recipes-rubygems/rubygems-equalizer_0.0.11.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: equalizer"
+DESCRIPTION = "Module to define equality, equivalence and inspection methods"
+HOMEPAGE = "https://github.com/dkubb/equalizer"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=91ed5f459e9d906d6b9b00c567d8dc19"
+
+SRC_URI[md5sum] = "c1e314f1e4c659aebdf7c16892180b32"
+SRC_URI[sha256sum] = "44e5bc46f49883e83d159ee9b1f7320b4ae8283bb6329e5d9716f5e7dde855ce"
+
+GEM_NAME = "equalizer"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-flay_2.12.1.bb
+++ b/recipes-rubygems/rubygems-flay_2.12.1.bb
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: flay"
+DESCRIPTION = "Flay analyzes code for structural similarities"
+HOMEPAGE = "http://ruby.sadi.st/"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://README.rdoc;beginline=100;endline=123;md5=9729e7cc2f0b6cd88813876ac0335063"
+
+EXTRA_RDEPENDS += "rubygems-gauntlet"
+
+DEPENDS_class-native += "\
+    rubygems-erubis-native \
+    rubygems-path-expander-native \
+    rubygems-ruby-parser-native \
+    rubygems-sexp-processor-native \
+"
+
+SRC_URI[md5sum] = "b2c4d45c0654ac18a13288697c512a37"
+SRC_URI[sha256sum] = "677ff6fc3727ee297a25357e908dc9cf1243eb7e61b8852d595873a4907ac4d7"
+
+GEM_NAME = "flay"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-erubis \
+    rubygems-path-expander \
+    rubygems-ruby-parser \
+    rubygems-sexp-processor \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-flog_4.6.4.bb
+++ b/recipes-rubygems/rubygems-flog_4.6.4.bb
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: flog"
+DESCRIPTION = "Flog reports the most tortured code in an easy to read painreport"
+HOMEPAGE = "http://ruby.sadi.st/"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://README.rdoc;beginline=42;endline=65;md5=5db85eba7780ac1765a03fe0e5ec1657"
+
+EXTRA_RDEPENDS += "rubygems-gauntlet"
+
+DEPENDS_class-native += "\
+    rubygems-path-expander-native \
+    rubygems-ruby-parser-native \
+    rubygems-sexp-processor-native \
+"
+
+SRC_URI[md5sum] = "0c4d4707090126e0faa43063c089f24c"
+SRC_URI[sha256sum] = "b5aa03696c075a7d672cd5e24cee36e4b76c23e200a2add0618b834270d1c763"
+
+GEM_NAME = "flog"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+do_install_append() {
+    # some scripts point to wrong ruby intepreter, propably hardcoded
+    find ${D} -type f -exec sed -i "s#/usr/local/bin/ruby#${bindir}/ruby#g" {} \;
+}
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-path-expander \
+    rubygems-ruby-parser \
+    rubygems-sexp-processor \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-gauntlet_2.1.0.bb
+++ b/recipes-rubygems/rubygems-gauntlet_2.1.0.bb
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: gauntlet"
+DESCRIPTION = "Gauntlet is a pluggable means of running code against all the latestgems and storing off the data."
+HOMEPAGE = "https://github.com/seattlerb/gauntlet"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://README.txt;beginline=46;endline=69;md5=9729e7cc2f0b6cd88813876ac0335063"
+
+DEPENDS_class-native += "\
+    rubygems-net-http-persistent-native \
+"
+
+SRC_URI[md5sum] = "17e5c5c9cf8fd39b0bb171e070f091d6"
+SRC_URI[sha256sum] = "f4e78297c81a7f0b242d169615a7a869f7e8cb2ac28d638b31ae7c9ef49522eb"
+
+GEM_NAME = "gauntlet"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-net-http-persistent \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-ice-nine_0.11.2.bb
+++ b/recipes-rubygems/rubygems-ice-nine_0.11.2.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: ice_nine"
+DESCRIPTION = "Deep Freeze Ruby Objects"
+HOMEPAGE = "https://github.com/dkubb/ice_nine"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=957c3fa8227461c40374691312e5e454"
+
+SRC_URI[md5sum] = "4b7032c80c422e45cdd614e066f3b8b6"
+SRC_URI[sha256sum] = "5d506a7d2723d5592dc121b9928e4931742730131f22a1a37649df1c1e2e63db"
+
+GEM_NAME = "ice_nine"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-kwalify_0.7.2.bb
+++ b/recipes-rubygems/rubygems-kwalify_0.7.2.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: kwalify"
+DESCRIPTION = "Kwalify is a parser, schema validator, and data binding tool for YAML and JSON."
+HOMEPAGE = "http://www.kuwata-lab.com/kwalify/"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://MIT-LICENSE;md5=a117fe398d6b4c0f083f73459da1bae2"
+
+SRC_URI[md5sum] = "54e03aa70a07a8cb6941fa191e5176a8"
+SRC_URI[sha256sum] = "4eee60e7dc2c4f182af30e1a64639bc1787a985462b4615bba7117acfd78fdd9"
+
+GEM_NAME = "kwalify"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-launchy_2.5.0.bb
+++ b/recipes-rubygems/rubygems-launchy_2.5.0.bb
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: launchy"
+DESCRIPTION = "Launchy is helper class for launching cross-platform applications in a fire and forget manner"
+HOMEPAGE = "https://github.com/copiousfreetime/launchy"
+
+LICENSE = "ISC"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=631319c3fb7bf218f4538f4c4d406090"
+
+DEPENDS_class-native += "\
+    rubygems-addressable-native \
+"
+
+SRC_URI[md5sum] = "598b4b3fa4d96173595a19e8287c9a93"
+SRC_URI[sha256sum] = "954243c4255920982ce682f89a42e76372dba94770bf09c23a523e204bdebef5"
+
+GEM_NAME = "launchy"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-addressable \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-net-http-persistent_4.0.1.bb
+++ b/recipes-rubygems/rubygems-net-http-persistent_4.0.1.bb
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: net-http-persistent"
+DESCRIPTION = "Manages persistent connections using Net::HTTP including a thread pool forconnecting to multiple hosts.Using persistent HTTP connections can dramatically increase the speed of HTTP.Creating a new HTTP connection for every request involves an extra TCPround-trip and causes TCP congestion avoidance negotiation to start over.Net::HTTP supports persistent connections with some API methods but does notmake setting up a single persistent connection or managing multipleconnections easy"
+HOMEPAGE = "https://github.com/drbrain/net-http-persistent"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://README.rdoc;beginline=59;endline=82;md5=e3fe655d8a232a8b4e8bde0439a4518f"
+
+DEPENDS_class-native += "\
+    rubygems-connection-pool-native \
+"
+
+SRC_URI[md5sum] = "42857574ef30faa06e646a7f45292f4b"
+SRC_URI[sha256sum] = "2752f4cce05fd1c45e0537c6f3a98fa5a4899efd5f88e63c104ed5f05cbddef9"
+
+GEM_NAME = "net-http-persistent"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-connection-pool \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-parser_3.0.0.0.bb
+++ b/recipes-rubygems/rubygems-parser_3.0.0.0.bb
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: parser"
+DESCRIPTION = "A Ruby parser written in pure Ruby."
+HOMEPAGE = "https://github.com/whitequark/parser"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=c66fb0a7723eeead586d670198ad6a34"
+
+EXTRA_RDEPENDS += "rubygems-gauntlet"
+
+DEPENDS_class-native += "\
+    rubygems-ast-native \
+"
+
+SRC_URI[md5sum] = "19b109f305cea837b85573a5385e12a7"
+SRC_URI[sha256sum] = "b4963d5502dc4912f4f2ec6d93f3f6d9db075bced28195032b12f8fafd543dca"
+
+GEM_NAME = "parser"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-ast \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-path-expander_1.1.0.bb
+++ b/recipes-rubygems/rubygems-path-expander_1.1.0.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: path_expander"
+DESCRIPTION = "PathExpander helps pre-process command-line arguments expandingdirectories into their constituent files"
+HOMEPAGE = "https://github.com/seattlerb/path_expander"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://README.rdoc;beginline=51;endline=74;md5=5db85eba7780ac1765a03fe0e5ec1657"
+
+SRC_URI[md5sum] = "dcf4aae5c127cfd3ecc2f5271c13c5f8"
+SRC_URI[sha256sum] = "fb81a1f665f17579f8b450412e79009809584e25dab154cb5c88a59222b280d0"
+
+GEM_NAME = "path_expander"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-rainbow_3.0.0.bb
+++ b/recipes-rubygems/rubygems-rainbow_3.0.0.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: rainbow"
+DESCRIPTION = "Colorize printed text on ANSI terminals"
+HOMEPAGE = "https://github.com/sickill/rainbow"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d8b3dd1cdfc682803de86f82b443bcd3"
+
+SRC_URI[md5sum] = "a4959de1d41c77d25eb56dbeeb37cf39"
+SRC_URI[sha256sum] = "13ce4ffc3c94fb7a842117ecabdcdc5ff7fa27bec15ea44137b9f9abe575622d"
+
+GEM_NAME = "rainbow"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-reek_6.0.3.bb
+++ b/recipes-rubygems/rubygems-reek_6.0.3.bb
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: reek"
+DESCRIPTION = "Reek is a tool that examines Ruby classes, modules and methods and reports any code smells it finds."
+HOMEPAGE = "https://github.com/troessner/reek"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://License.txt;md5=59252b93b9ae85dab91487d72990f77c"
+
+EXTRA_RDEPENDS += "rubygems-codeclimate-engine-rb"
+
+DEPENDS_class-native += "\
+    rubygems-kwalify-native \
+    rubygems-parser-native \
+    rubygems-psych-native \
+    rubygems-rainbow-native \
+"
+
+SRC_URI[md5sum] = "946ff94aaf22808e07117f0dd912251e"
+SRC_URI[sha256sum] = "e262cc8ce4cce4ea259bcdcc50f9c4a90d39f3e0e93b9d42f0c400d882dc8efe"
+
+GEM_NAME = "reek"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-kwalify \
+    rubygems-parser \
+    rubygems-psych \
+    rubygems-rainbow \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-ruby-parser_3.15.1.bb
+++ b/recipes-rubygems/rubygems-ruby-parser_3.15.1.bb
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: ruby_parser"
+DESCRIPTION = "ruby_parser (RP) is a ruby parser written in pure ruby (utilizingracc--which does by default use a C extension)"
+HOMEPAGE = "https://github.com/seattlerb/ruby_parser"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://README.rdoc;beginline=86;endline=109;md5=5db85eba7780ac1765a03fe0e5ec1657"
+
+DEPENDS_class-native += "\
+    rubygems-sexp-processor-native \
+"
+
+SRC_URI[md5sum] = "12251efe73812ecb53410fab089997e1"
+SRC_URI[sha256sum] = "08483a56975d30115eb44749ae357773bab90264692c004422277fe0e760beb8"
+
+GEM_NAME = "ruby_parser"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-sexp-processor \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-rubycritic_4.6.0.bb
+++ b/recipes-rubygems/rubygems-rubycritic_4.6.0.bb
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: rubycritic"
+DESCRIPTION = "RubyCritic is a tool that wraps around various static analysis gems to provide a quality report of your Ruby code."
+HOMEPAGE = "https://github.com/whitesmith/rubycritic"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=ebcb01890999ed287441ae4afce9a346"
+
+DEPENDS_class-native += "\
+    rubygems-flay-native \
+    rubygems-flog-native \
+    rubygems-launchy-native \
+    rubygems-parser-native \
+    rubygems-rainbow-native \
+    rubygems-reek-native \
+    rubygems-ruby-parser-native \
+    rubygems-simplecov-native \
+    rubygems-tty-which-native \
+    rubygems-virtus-native \
+"
+
+SRC_URI[md5sum] = "39350f134adc043928b94a1b296cce3f"
+SRC_URI[sha256sum] = "c1e362d4552fab9aca3133417a31e55924df1848ff5541c0cef11249f9b1c1c0"
+
+GEM_NAME = "rubycritic"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-flay \
+    rubygems-flog \
+    rubygems-launchy \
+    rubygems-parser \
+    rubygems-rainbow \
+    rubygems-reek \
+    rubygems-ruby-parser \
+    rubygems-simplecov \
+    rubygems-tty-which \
+    rubygems-virtus \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-sexp-processor_4.15.2.bb
+++ b/recipes-rubygems/rubygems-sexp-processor_4.15.2.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: sexp_processor"
+DESCRIPTION = "sexp_processor branches from ParseTree bringing all the generic sexpprocessing tools with it"
+HOMEPAGE = "https://github.com/seattlerb/sexp_processor"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://README.rdoc;beginline=70;endline=93;md5=5db85eba7780ac1765a03fe0e5ec1657"
+
+SRC_URI[md5sum] = "82b604f3dbc34c220552a8b35c1eb343"
+SRC_URI[sha256sum] = "0684494bd59480fc5c9c589871080f37adc5384c339be2a9b8a0369fd300cf68"
+
+GEM_NAME = "sexp_processor"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-simplecov-html_0.12.3.bb
+++ b/recipes-rubygems/rubygems-simplecov-html_0.12.3.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: simplecov-html"
+DESCRIPTION = "Default HTML formatter for SimpleCov code coverage tool for ruby 2.4+"
+HOMEPAGE = "https://github.com/simplecov-ruby/simplecov-html"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=23973b4bd84f8a5e081dd23bb739394d"
+
+SRC_URI[md5sum] = "2f0241c3a12f5af62bd84c1f1914a722"
+SRC_URI[sha256sum] = "4b1aad33259ffba8b29c6876c12db70e5750cb9df829486e4c6e5da4fa0aa07b"
+
+GEM_NAME = "simplecov-html"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-simplecov-json-formatter_0.1.2.bb
+++ b/recipes-rubygems/rubygems-simplecov-json-formatter_0.1.2.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: simplecov_json_formatter"
+DESCRIPTION = "JSON formatter for SimpleCov"
+HOMEPAGE = "https://github.com/fede-moya/simplecov_json_formatter"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI[md5sum] = "f2a81a45c4bf7caf628f4f3e080f2c09"
+SRC_URI[sha256sum] = "d23cd340bc10d78c11f874a99ed233bdb01a111b46edd075d7079735ee918332"
+
+GEM_NAME = "simplecov_json_formatter"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-simplecov_0.21.2.bb
+++ b/recipes-rubygems/rubygems-simplecov_0.21.2.bb
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: simplecov"
+DESCRIPTION = "Code coverage for Ruby with a powerful configuration library and automatic merging of coverage across test suites"
+HOMEPAGE = "https://github.com/simplecov-ruby/simplecov"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=0372eac36f921e2a3d78dcb0bb6c4f76"
+
+DEPENDS_class-native += "\
+    rubygems-docile-native \
+    rubygems-simplecov-html-native \
+    rubygems-simplecov-json-formatter-native \
+"
+
+SRC_URI[md5sum] = "575c6c7861cb467292671ee37e5b795c"
+SRC_URI[sha256sum] = "990db6aedb55086d6bf8874993ff1f796e4830abfa11937468ca502a0d013bc3"
+
+GEM_NAME = "simplecov"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-docile \
+    rubygems-simplecov-html \
+    rubygems-simplecov-json-formatter \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-tty-which_0.4.2.bb
+++ b/recipes-rubygems/rubygems-tty-which_0.4.2.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: tty-which"
+DESCRIPTION = "Platform independent implementation of Unix which command."
+HOMEPAGE = "https://ttytoolkit.org"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=c9f5a91217b4b11751b2084dda90ff19"
+
+SRC_URI[md5sum] = "2418a6f6dbe3eda6d1af13c11b3e4f3e"
+SRC_URI[sha256sum] = "0ac45f416555041882c632602aeb733379fec08b08a3123d92e78283741823ce"
+
+GEM_NAME = "tty-which"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-virtus_1.0.5.bb
+++ b/recipes-rubygems/rubygems-virtus_1.0.5.bb
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: virtus"
+DESCRIPTION = "Attributes on Steroids for Plain Old Ruby Objects"
+HOMEPAGE = "https://github.com/solnic/virtus"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3e82a465aa1c29f8f04f81d00041f1cf"
+
+DEPENDS_class-native += "\
+    rubygems-axiom-types-native \
+    rubygems-coercible-native \
+    rubygems-descendants-tracker-native \
+    rubygems-equalizer-native \
+"
+
+SRC_URI[md5sum] = "83051103a3439993d685a0c023b5f9f2"
+SRC_URI[sha256sum] = "d3053b9ff62d3f8b7b233f7e1aa9530b73ed7e541bee2c62f2c711362287371a"
+
+GEM_NAME = "virtus"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-axiom-types \
+    rubygems-coercible \
+    rubygems-descendants-tracker \
+    rubygems-equalizer \
+"
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
adds reek and rubycritic and all of the needed dependencies.

+ let tests-package depend on ruby by default
+ fix name sanitation for gems containing a dot