### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-sdk-apigateway_1.61.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-apigateway_1.61.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "2dd6fc4be24d4bbf408592f584028031"
-SRC_URI[sha256sum] = "c74a74e3a7b9b2d3db872dca694c3a2186f2952544055c87c06fb6a67676b468"
+SRC_URI[md5sum] = "17f5f2cf083a9291c2349ea85ac2da5e"
+SRC_URI[sha256sum] = "dcae182787d971479fa5380efd84ec5054939be5d78b4d9952092dee71d3be7a"
 
 GEM_NAME = "aws-sdk-apigateway"
 

--- a/recipes-rubygems/rubygems-aws-sdk-apigatewayv2_1.32.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-apigatewayv2_1.32.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AmazonApiGatewayV2"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "9d6f602f8148d17d3c5c1728ecdd4836"
-SRC_URI[sha256sum] = "87e5e368c0a3ff5866bf03432a2494c4857f73227bc78c6d98d0c0f26c073b9c"
+SRC_URI[md5sum] = "1531b648ffe4ac93c22d929b43239b17"
+SRC_URI[sha256sum] = "d9ed93d220c8c40eacae93f29c0ec5f651fed094ea930a9ac5f7a619ed109106"
 
 GEM_NAME = "aws-sdk-apigatewayv2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-applicationautoscaling_1.51.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-applicationautoscaling_1.51.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Application Auto Scaling"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "eb38f351589a616817dba9c4f3f1546b"
-SRC_URI[sha256sum] = "3436b3feb7b67e8595ad0bd96c9922ed56ec855a9ebd0a194cb649e8000ab24f"
+SRC_URI[md5sum] = "a7abe8aaf3f6167cdaef5ff729a3f71c"
+SRC_URI[sha256sum] = "d6594250212f93f0b90f16349809988ff921fa6b65b2e940fa0c47cf1a02e052"
 
 GEM_NAME = "aws-sdk-applicationautoscaling"
 

--- a/recipes-rubygems/rubygems-aws-sdk-athena_1.37.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-athena_1.37.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "fcd29591bee09c5c7b63ffc992529aa7"
-SRC_URI[sha256sum] = "a9ba6fb027bc6a07da025e7fae51c787514fdc3ff815b098ac1950467e03e534"
+SRC_URI[md5sum] = "8ed407af8c54f7b7c3e0dca830b15fb2"
+SRC_URI[sha256sum] = "1203ef5959c898fe29e895cd13d307ab76ba5ad5b9f73b037eb92bfa9017dd93"
 
 GEM_NAME = "aws-sdk-athena"
 

--- a/recipes-rubygems/rubygems-aws-sdk-autoscaling_1.58.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-autoscaling_1.58.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Auto Scaling"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "bff5830a715cccb9949d9102bb84b04f"
-SRC_URI[sha256sum] = "3d1e09894b76c18423b1d57602c7c5aa7e2d9c5f25a40920f08b11b4452cac98"
+SRC_URI[md5sum] = "0295336e10c04378c57ac0228430e88f"
+SRC_URI[sha256sum] = "e52b1fc527ce847a2c6799f465a1ca759727534da0c5f2df2deb8370b0d96aaa"
 
 GEM_NAME = "aws-sdk-autoscaling"
 

--- a/recipes-rubygems/rubygems-aws-sdk-batch_1.45.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-batch_1.45.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Batch"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "630117727399fe065828cfb907c66fbf"
-SRC_URI[sha256sum] = "b14a951b7fabf75da5f25243bc03192d0565e79e403041cba4847580fba6a532"
+SRC_URI[md5sum] = "2acb4ae62955b17ab197a3b6ac24f99f"
+SRC_URI[sha256sum] = "68787eb070f1df49f59a266329c3bc3cc93ecdf1f904f5d52c27ec6110fd0886"
 
 GEM_NAME = "aws-sdk-batch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-budgets_1.38.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-budgets_1.38.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Budgets (AWSBudgets)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "e3185df740115be15f9c80b14f32d761"
-SRC_URI[sha256sum] = "825c6f47c424816ca4967c8e27785dc63ab4fb600e86fdadca5496eb12a8a752"
+SRC_URI[md5sum] = "200244da9dffacabf60eee838ece9891"
+SRC_URI[sha256sum] = "dd841360e99583c877344cfc9ba12f9d0415cda713729620795deeb32bb10b13"
 
 GEM_NAME = "aws-sdk-budgets"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudformation_1.49.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudformation_1.49.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS CloudFormation"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "70eb233a9df8aecb5c465dc5c8267bbf"
-SRC_URI[sha256sum] = "6e604090efdaf08cdc885b45c0a742e4e6e26b7a0fb16f4c920489521965669d"
+SRC_URI[md5sum] = "beb2ff03f7bcad53b43d6e512d3343ae"
+SRC_URI[sha256sum] = "e437f70a825a439c68d54d787c3bfb42773d7da049b711424ec1d53749389fda"
 
 GEM_NAME = "aws-sdk-cloudformation"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.49.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.49.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon CloudFront (CloudFront)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "f8ad06bbb22f234435249ec9fd4b8422"
-SRC_URI[sha256sum] = "66dd6d3b931f605e97315397b757efe03396a54302617f79b968b1b2396ae0f0"
+SRC_URI[md5sum] = "3f8bef7db92b73b116106aa0ea4b3638"
+SRC_URI[sha256sum] = "ee5bb2bf72c71376988ae7b1467a3e65721c8318a3b884ef80d0711257c9a242"
 
 GEM_NAME = "aws-sdk-cloudfront"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudhsm_1.29.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudhsm_1.29.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon CloudHSM (CloudHSM)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "8442baf25cee394614b0f03ab1dc8d2e"
-SRC_URI[sha256sum] = "0e531e88d9f28c0e03a35207b57cbdc85142379b9d33ca085ca6419501af9128"
+SRC_URI[md5sum] = "a22725345ed3316ba655a7b66c2fd723"
+SRC_URI[sha256sum] = "f406db5747bafaae0cd40124dec158735dd49355b650b01f30fc91ababa40571"
 
 GEM_NAME = "aws-sdk-cloudhsm"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudhsmv2_1.33.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudhsmv2_1.33.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS CloudHSM V2 (CloudHSM V2)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "4ee1ab927e83a45f76337c3e438d22ee"
-SRC_URI[sha256sum] = "ba29fc80570a6d2d516b4cb2e1d771b5b0350a793163995c8a3bbf653bc06d8e"
+SRC_URI[md5sum] = "3dee6b27d9d608863402eadc7e2c55eb"
+SRC_URI[sha256sum] = "7a7a06c174a7c4c1fe386d6f0ba056df38d17ad9497826cc239987464e1bbee4"
 
 GEM_NAME = "aws-sdk-cloudhsmv2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.34.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.34.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS CloudTrail (CloudTrail)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "860e21fe81d4c5f46b95794043c4f67f"
-SRC_URI[sha256sum] = "8f87a2e4a2603417338e3332d0677a313e4a3a6d995770457674221d52a37620"
+SRC_URI[md5sum] = "480adfc40cf69f3ad5c6ab18f08809ab"
+SRC_URI[sha256sum] = "abbf89e423219fafb3d7ae41e00151d7ee1ad988b3d3167cc507c62b94335d05"
 
 GEM_NAME = "aws-sdk-cloudtrail"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatch_1.50.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatch_1.50.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon CloudWatch (CloudWatch)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "a2bc5c20767bf87396abc8f05edf1e8e"
-SRC_URI[sha256sum] = "44af37557aad02537118044022a1ec01d9c13de8b170dff41f5317c46d004bef"
+SRC_URI[md5sum] = "4762da6bcbde6b038826028318c0157b"
+SRC_URI[sha256sum] = "0ce46e9a34c294478fa054dfb470036046a5c838ee8b4bfe73b988641b00ea75"
 
 GEM_NAME = "aws-sdk-cloudwatch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatchevents_1.44.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatchevents_1.44.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "008db95c813b46b24a58e919394f04dd"
-SRC_URI[sha256sum] = "2b8d9549e99b2005d0682e18557134bf737c2d1614215a6a4bf3ffe9e068706d"
+SRC_URI[md5sum] = "470229668faabd16f07cfb5621a2e4d0"
+SRC_URI[sha256sum] = "71f07a2b6eb83e20f8113310a6cb6e6f186733a7882c6afb1334895788164509"
 
 GEM_NAME = "aws-sdk-cloudwatchevents"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.40.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.40.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon CloudWatch Logs"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "c6673d94e940e1e83d169cdc0ce979ef"
-SRC_URI[sha256sum] = "1e59a9ff33128f9eb0d4975cf05f39d9f9d80bf96780a7d434085d2b7bde2a2b"
+SRC_URI[md5sum] = "3b990d82fbaa3ede466a33736f1ede53"
+SRC_URI[sha256sum] = "5ad557789318977a91193618e8d37c2ab964b02515b8059bb518467b5e9de63c"
 
 GEM_NAME = "aws-sdk-cloudwatchlogs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-codecommit_1.42.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-codecommit_1.42.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS CodeCommit (CodeCommit)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "bb34037129ac136eeb3674a7c7f4e883"
-SRC_URI[sha256sum] = "02cb9263874760d9664a915e88a530f3591286cdcbf740e95408cee1285e61b1"
+SRC_URI[md5sum] = "d6010fcaf3d9406073a8e507850e64d1"
+SRC_URI[sha256sum] = "d0fed017872442c244a5327d38bdc47627976e621048fc91e0296d2b9fc7e901"
 
 GEM_NAME = "aws-sdk-codecommit"
 

--- a/recipes-rubygems/rubygems-aws-sdk-codedeploy_1.39.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-codedeploy_1.39.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS CodeDeploy (CodeDeploy)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "01b0d8b33cc6c6896626932990d9082e"
-SRC_URI[sha256sum] = "448a1ea8369039e5ed1196afb858f7908eb95a5fd885fad3877e9ed321d8f984"
+SRC_URI[md5sum] = "ec71a15177f9ea4e40bf8b0213d74e50"
+SRC_URI[sha256sum] = "9b95889bb2a7152335db90df7e4776d0cf8a3d4fdcc724f4e1d4ea89f05849ac"
 
 GEM_NAME = "aws-sdk-codedeploy"
 

--- a/recipes-rubygems/rubygems-aws-sdk-codepipeline_1.44.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-codepipeline_1.44.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "2dc83016e3965e1cfa5bafa9de345fcd"
-SRC_URI[sha256sum] = "e50913b87e021661e23741a587b57bd1ade54500b796fea7dec360c885adaacc"
+SRC_URI[md5sum] = "e20143b2bb17cbcc237e53e0472abe15"
+SRC_URI[sha256sum] = "5093d594860a3257e54d9034e945cf7148e7e24bc7a47699774a531edd080f49"
 
 GEM_NAME = "aws-sdk-codepipeline"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cognitoidentity_1.31.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cognitoidentity_1.31.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Cognito Identity"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "59212388b84f4c8574a6d8bda3360454"
-SRC_URI[sha256sum] = "82c0df34eacba4353d66a4e983b3ffe8ce0ae6cf34fe38b4f0411b605c34d83f"
+SRC_URI[md5sum] = "71a405c550f889fe29812d2c7046b0a2"
+SRC_URI[sha256sum] = "02cf80f09e969eb1cc5c8cb3a4c7918910ab45b308da4149ec737e166326ed4c"
 
 GEM_NAME = "aws-sdk-cognitoidentity"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cognitoidentityprovider_1.50.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cognitoidentityprovider_1.50.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Cognito Identity Provider"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "64cdb40c79dfc1a2e857178ba88b40b5"
-SRC_URI[sha256sum] = "54f96be46b12a9d08becf577148d72eef0e9c9f351e9734e0d967b852da7579a"
+SRC_URI[md5sum] = "92e150281bdff63ac47ed9a8465a6c5b"
+SRC_URI[sha256sum] = "aa6ef890c60e825acc3d4a0e79c089ac2b8113a4fcf0c61f4a1fa6d28b6fa1dc"
 
 GEM_NAME = "aws-sdk-cognitoidentityprovider"
 

--- a/recipes-rubygems/rubygems-aws-sdk-configservice_1.59.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-configservice_1.59.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Config (Config Service)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "01c6d5029031863ec30b5e30ef0d8b6f"
-SRC_URI[sha256sum] = "23e716492dc414f1d0869f078fa597953b75d44d52d7d4087a908e389ce62e09"
+SRC_URI[md5sum] = "84d50e58d6213a90752ab9de0df5ca20"
+SRC_URI[sha256sum] = "696ebd5607dd751591aaa9b5afd5588c9b938c530f355afb21c4bf8dcb76a83a"
 
 GEM_NAME = "aws-sdk-configservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-costandusagereportservice_1.31.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-costandusagereportservice_1.31.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Cost and Usage Report Service"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "5bbd22300090903cf661b7cdb361d873"
-SRC_URI[sha256sum] = "f37ab812a8c993ddfdbffdff4fb1466d534d19cfb77295f9338648e43a82ebb7"
+SRC_URI[md5sum] = "51044be98195a0b3cfa5231dedba08e5"
+SRC_URI[sha256sum] = "237cf9ece5cc32cd819070b46505b6209a1b43263c9f69529682b43e070085ea"
 
 GEM_NAME = "aws-sdk-costandusagereportservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-databasemigrationservice_1.52.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-databasemigrationservice_1.52.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Database Migration Service"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "9762b1046a760147047d2929ebbbe7a3"
-SRC_URI[sha256sum] = "8144b97fc81ca474d7aa3c2212fbd79410578baff11eaa4f6ab3350116be5f53"
+SRC_URI[md5sum] = "589fffbf1a57a7ccaf71a863de83a9c6"
+SRC_URI[sha256sum] = "d61d7d6ff3c338c1c3118a553e972b9104762dae81429659b4e33e2e4787202b"
 
 GEM_NAME = "aws-sdk-databasemigrationservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-dynamodb_1.60.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-dynamodb_1.60.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon DynamoDB (DynamoDB)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "07d86dc59a980df868092bbb40caead8"
-SRC_URI[sha256sum] = "38103f97b1403f50aa4a301ad73ca228b1406aacbfc4921a7e9c5bfaec8f63a6"
+SRC_URI[md5sum] = "0bdedc1a816b8ca39736d84b6e741679"
+SRC_URI[sha256sum] = "23068906fc5945b30ec06ea8d9a7bf12b7553bbfe999c2fef4f1b3b4ffacdab5"
 
 GEM_NAME = "aws-sdk-dynamodb"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.227.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.227.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "1e465b09a99380dfe13b4331fcb5e455"
-SRC_URI[sha256sum] = "49627e0c61833e74f0d1ca3652749ef20eb26d0a7f899c2c8804374d454d4375"
+SRC_URI[md5sum] = "f819658c9d3bf8cd151a5e410c0f7c3e"
+SRC_URI[sha256sum] = "4d40a3d580a4ce821b8f69ec3b3da8becad2b109e15689d46085f9d154e71752"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecr_1.42.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecr_1.42.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon EC2 Container Registry (Amazon E
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "4d10e504a01c3321e5a23e9080d9a37e"
-SRC_URI[sha256sum] = "1bf27b4bfbef2ad727013495f3a781e2d4b9ac1c14f58b852d547d7f5bd22836"
+SRC_URI[md5sum] = "e53a38299343c7a7cd5820a71cbad154"
+SRC_URI[sha256sum] = "2a733de04c9b00d68f0941c334bd272f45c4c289300d3fa23cfda2d1eaf2be64"
 
 GEM_NAME = "aws-sdk-ecr"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.75.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.75.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon EC2 Container Service (Amazon EC
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "97062e411253b09d2b7e6e2d50ae32c6"
-SRC_URI[sha256sum] = "c07150ed83db01936792dcbb52896899d6f5214820fd0ded240c96da4e8d3462"
+SRC_URI[md5sum] = "23507aa2338548acefa0acb46d916d33"
+SRC_URI[sha256sum] = "e5164e0ca2b944e043e1d277a0b315345b9d17517f13dee291c0c696bb4913eb"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-efs_1.39.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-efs_1.39.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Elastic File System (EFS)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "0c9ac06888b3de56e3d6ed51f49b86d4"
-SRC_URI[sha256sum] = "7ed5952367e7fe075104cd456c12088e27e0eeb6868fdf4916e7f869c3036e0d"
+SRC_URI[md5sum] = "aca5adfb709faa2c40e63297a3238962"
+SRC_URI[sha256sum] = "cd5ea4e901bdc542b99ca16f8a3e4cc23b015231cd02e4d8b7a6ceae0dfab74e"
 
 GEM_NAME = "aws-sdk-efs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eks_1.51.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eks_1.51.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Elastic Kubernetes Service (Amaz
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "21467b56922ecebdb2c76621a3fb5631"
-SRC_URI[sha256sum] = "2100e10a6026cb4ef67d2bd23bfcc918f8d31e80067e5cd0da559942dda28344"
+SRC_URI[md5sum] = "763c52445e1e0221de9bcd10b6db157a"
+SRC_URI[sha256sum] = "d6ab1655541d3f3960882af8e773294420d8fbd1b2c813be0e31bdab0b8f6419"
 
 GEM_NAME = "aws-sdk-eks"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticache_1.54.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticache_1.54.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon ElastiCache"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "fd8d9d057250a6eac745d71efdfc10f3"
-SRC_URI[sha256sum] = "e5987bf67e273dc319ac2416be8c73de9d67764934f76f0b1e245d15acb0f7cd"
+SRC_URI[md5sum] = "4027fc27f63e8073e4642fe8abcdd3c8"
+SRC_URI[sha256sum] = "ea33c9b541ea83f5844b48de30fd935a653a452c3d303e6d72dae633c8147616"
 
 GEM_NAME = "aws-sdk-elasticache"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticbeanstalk_1.42.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticbeanstalk_1.42.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Elastic Beanstalk (Elastic Beanstal
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "8efe6d559c42513e1f885f58cfbe4e98"
-SRC_URI[sha256sum] = "5ff0a23d157e3bb617d498569de22331d718f7f6ff28cb1985b8e070b34e33a9"
+SRC_URI[md5sum] = "b9ae4d067598ce0e0c1b1c5b6553bc66"
+SRC_URI[sha256sum] = "e23f07446ec5b9e6e836b39805b38a7026d3c361e1c42775365aa5e9a4432e25"
 
 GEM_NAME = "aws-sdk-elasticbeanstalk"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticloadbalancing_1.31.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticloadbalancing_1.31.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Elastic Load Balancing"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "d879a0f7f0bb317618b00fb2696105a8"
-SRC_URI[sha256sum] = "b1191434ef76f24e6cdc1b51eb1fd2f914e2df3ac6bc58262aa6620c07d5dad8"
+SRC_URI[md5sum] = "113198cac9163b51676603aee25ed2ec"
+SRC_URI[sha256sum] = "630f8a47d4de0ce280f0b442a67a5bd40915149f6e82007cb5ba7b611bea7748"
 
 GEM_NAME = "aws-sdk-elasticloadbalancing"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticloadbalancingv2_1.61.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticloadbalancingv2_1.61.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Elastic Load Balancing (Elastic Load Ba
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "17d836d6f9e6ad88db8670dbc0537819"
-SRC_URI[sha256sum] = "f07eaefe156b43c5ef880f52adc6406de438ecc4b5aa1784abcc5db361c6d51c"
+SRC_URI[md5sum] = "c50ee8a63cfda5d63e86b8098fea3aea"
+SRC_URI[sha256sum] = "b5062682d3bb22c28581b1d538821107f474d86a3341d608a831e8b2f1b2139a"
 
 GEM_NAME = "aws-sdk-elasticloadbalancingv2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticsearchservice_1.51.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticsearchservice_1.51.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Elasticsearch Service"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "eb8b19bb7759e8d95efce4df76811fdd"
-SRC_URI[sha256sum] = "8ac5c931d493ff7212c4622c32e65f480c959f1af73b07dbb58a70e8770aa104"
+SRC_URI[md5sum] = "bcf364fa84b3407e7acdc2cd55ce725a"
+SRC_URI[sha256sum] = "1ba200d6986689fb445cc7eb60a200c6d5fa8f1262fa158d5ca24bf47abe8842"
 
 GEM_NAME = "aws-sdk-elasticsearchservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-firehose_1.37.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-firehose_1.37.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Kinesis Firehose (Firehose)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "1e49176375a9eb58c09f50b8b4302fac"
-SRC_URI[sha256sum] = "177409cd5e0e702d4fbfccd3034fe533356e22c369b667bc96d3e6ebf02e274a"
+SRC_URI[md5sum] = "4b32d3a4757988a95f583322d4f4376f"
+SRC_URI[sha256sum] = "2ff1d6ee3e08bedb0991721fd0967bbb438ddca2f242113016533116f69782fa"
 
 GEM_NAME = "aws-sdk-firehose"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.85.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.85.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Glue"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "77e93588186d18887d7766106dedf6e8"
-SRC_URI[sha256sum] = "d57f9897ec95098eb4b9cec300480045fdc9fee67ee2912a02ab3e500d5c79b6"
+SRC_URI[md5sum] = "e50b602f0ccbecdd1260fdc7108a4280"
+SRC_URI[sha256sum] = "f851f71cd9368ee1f6b70c99bf1418a8caa0b10a29ca9304e3c7e7d1fc6d4328"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-guardduty_1.45.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-guardduty_1.45.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon GuardDuty"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "aa8b3a47f07d6f545298fac940c4f056"
-SRC_URI[sha256sum] = "099f3411e94a2788b4241a16c9c77b4c2e2c8f730b74ab7a28d0a90c841f2659"
+SRC_URI[md5sum] = "6a1e558bde0439cc7445e010ebec999a"
+SRC_URI[sha256sum] = "7e0a438efd0b8c193625eb6d3ee0a74991a3bec83ac563fb4c21537f5cc27562"
 
 GEM_NAME = "aws-sdk-guardduty"
 

--- a/recipes-rubygems/rubygems-aws-sdk-iam_1.49.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-iam_1.49.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Identity and Access Management (IAM
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "a7f875939553eb26219418597fd62bfc"
-SRC_URI[sha256sum] = "12f842241a8bc2a09f292c94b673e3c7265ddabe30736b931a459d6cccc2ba0b"
+SRC_URI[md5sum] = "51cff6ae487f68a44518cd067e4281cd"
+SRC_URI[sha256sum] = "346d6dfef227df7091ac9b1073fdd735c6cec1f110f156efebf67c03f9b4fbb0"
 
 GEM_NAME = "aws-sdk-iam"
 

--- a/recipes-rubygems/rubygems-aws-sdk-kafka_1.35.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-kafka_1.35.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Managed Streaming for Kafka (Kafka)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "4700d866c3a6cfcb73f50cb64434cf11"
-SRC_URI[sha256sum] = "9e081ba0b8b22a5972fcac09baeb98281ba2cba2d849b03e48bcc345940f4fa0"
+SRC_URI[md5sum] = "4a92142517165a0e322f31c3fa4c5ee1"
+SRC_URI[sha256sum] = "2690ebf4a167eea960b688025b0cb3449e2e522f70544abbc3d25084624f2a66"
 
 GEM_NAME = "aws-sdk-kafka"
 

--- a/recipes-rubygems/rubygems-aws-sdk-kinesis_1.32.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-kinesis_1.32.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Kinesis (Kinesis)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "3706dba27179f9ddd1d88ff6e20c9cf4"
-SRC_URI[sha256sum] = "8b3cd047e2aa5eb4cab713f90e14a95fb11234caee81707b00e5e00106b156f3"
+SRC_URI[md5sum] = "9a618b8d2620bcc5b6ac34000a69cd73"
+SRC_URI[sha256sum] = "6bde717c3b95ca2fdc780f2564df61cd3b7e989ebf0479b64a3bd99d4ec35e5e"
 
 GEM_NAME = "aws-sdk-kinesis"
 

--- a/recipes-rubygems/rubygems-aws-sdk-kms_1.43.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-kms_1.43.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Key Management Service (KMS)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "264e07412ed19f720dfa39f55a946055"
-SRC_URI[sha256sum] = "31e0cb176db2bf7116faa0c37062a3deb518b1028d022fd639dff8c606728f03"
+SRC_URI[md5sum] = "8e1c586b68b6e0fee9737ee90329548b"
+SRC_URI[sha256sum] = "506f5131062df1f14e582ac1e4bdc8d917992e0980e04fe82f46e9ac8903ed06"
 
 GEM_NAME = "aws-sdk-kms"
 

--- a/recipes-rubygems/rubygems-aws-sdk-lambda_1.61.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-lambda_1.61.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Lambda"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "8a7c9d78b38429a8db3a6358386796be"
-SRC_URI[sha256sum] = "e3d81141d6b2d84456a3e5d1f92f82246cd4bc4eb0b8c39ee48797892e6edb95"
+SRC_URI[md5sum] = "f92a36c165964bd048921d01c07c2946"
+SRC_URI[sha256sum] = "f6b9a460dc6247c618dabb942df401dce7a5aa4a2b480c0b571eb39f32d2eee8"
 
 GEM_NAME = "aws-sdk-lambda"
 

--- a/recipes-rubygems/rubygems-aws-sdk-organizations_1.58.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-organizations_1.58.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Organizations (Organizations)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "5adc4b8079d883bf915e1226fe1c5a50"
-SRC_URI[sha256sum] = "c3ee90eba23580bfc781b10d52f3cbd829309572779a6df755fc232a3e06ac61"
+SRC_URI[md5sum] = "3fc12502ac791ad653a90531fbefd857"
+SRC_URI[sha256sum] = "cef670f0418bc59b45a5b2ac2fcf64e79485a1803aff629feefdc4646fc1124f"
 
 GEM_NAME = "aws-sdk-organizations"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ram_1.24.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ram_1.24.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Resource Access Manager (RAM)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "8e8bd80f468d6933da587e4febe9d09d"
-SRC_URI[sha256sum] = "7e4012ad6122a4fe34205fc9d27d742ef00295b0fe499cdbca0d02de3c00ad71"
+SRC_URI[md5sum] = "6683ebcba9eb852988d06e478b401f0b"
+SRC_URI[sha256sum] = "f240f654c805c349edee6d1e8ff42b36a1996d1651ef8561ea03b3645899f25f"
 
 GEM_NAME = "aws-sdk-ram"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.117.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.117.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Relational Database Service (Ama
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "40849bc69fff9baa5c66f7bff3a54a29"
-SRC_URI[sha256sum] = "99f81985a9da8b73f0a348af6ab5d9450af0a724262de817a72e8073cba1de93"
+SRC_URI[md5sum] = "ec9eb81d6fa613a9689442045bad9ab9"
+SRC_URI[sha256sum] = "caf43604847cca09f9bf9c0948b47a6bbd8eb6035a7f758b6dbf2ea3267b9d43"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-aws-sdk-redshift_1.55.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-redshift_1.55.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Redshift"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "ebb03a69531721ab56c5017159df20ec"
-SRC_URI[sha256sum] = "8fcc5ee6b77b526dba715e3de96b8a4199d68b15a695ad6fdc4c30bfcb8ba4b8"
+SRC_URI[md5sum] = "c5fc7c3d7557281fce95ff25bb2935a0"
+SRC_URI[sha256sum] = "eef479c2fb81d7587e82d02bbe1452bec958dcd6f1ca3a080d89e0dfc38ed2b5"
 
 GEM_NAME = "aws-sdk-redshift"
 

--- a/recipes-rubygems/rubygems-aws-sdk-route53_1.47.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-route53_1.47.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Route 53 (Route 53)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "76aea91090a4b4cf4267d62c8309b0b2"
-SRC_URI[sha256sum] = "e793d9d450b64641abe5bbfd4321238a7ea4db41818d64d5a8e5e6d4ed34b5cb"
+SRC_URI[md5sum] = "339333ba4a11542b745be8984f0e7599"
+SRC_URI[sha256sum] = "946f2fc7905ab050cfd948fa0d2dfff6578c3e47a385979bded1419b45cc057e"
 
 GEM_NAME = "aws-sdk-route53"
 

--- a/recipes-rubygems/rubygems-aws-sdk-route53domains_1.30.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-route53domains_1.30.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Route 53 Domains"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "669bd6f81fb36ebb9b40595081478ed1"
-SRC_URI[sha256sum] = "cf03598630b62cd7b6432f806df08e0279b3417f10c2f52b71d6c19af0196b4c"
+SRC_URI[md5sum] = "2810c4319c90524cb296ee139cb93a53"
+SRC_URI[sha256sum] = "2652e73281dc07da720c87b08a226cab696dac07137bb36116329bf14bbc7ed3"
 
 GEM_NAME = "aws-sdk-route53domains"
 

--- a/recipes-rubygems/rubygems-aws-sdk-route53resolver_1.24.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-route53resolver_1.24.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Route 53 Resolver (Route53Resolv
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "6adca51c8f58bcb276fa5fb1f1e80ac4"
-SRC_URI[sha256sum] = "7438d69c2d8f54cb6eff2b74faf5b9c007cacca24e318b650756940d8815cbe3"
+SRC_URI[md5sum] = "ab0a74417b93cadf5a6a5ecd4986c1b9"
+SRC_URI[sha256sum] = "860ecef66d3b6c3ff2b59b1c8800f9103c47a7fa13b963b4dfc32edee05ac678"
 
 GEM_NAME = "aws-sdk-route53resolver"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.91.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.91.0.bb
@@ -4,9 +4,7 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Simple Storage Service (Amazon S
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
@@ -14,8 +12,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "07a4ab1fa9ce346ded2991f0370a5c8e"
-SRC_URI[sha256sum] = "7b41b9f782556d967e714b4d4ff4dec4731dad9075766b567dc361a96fedf657"
+SRC_URI[md5sum] = "b3f256af360f6e5b9211fe102a70a1c7"
+SRC_URI[sha256sum] = "38c38fa9f97662aa1a58359397894e43bdcaaa301b13ed793ef1d3d1d2fb436f"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-aws-sdk-secretsmanager_1.46.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-secretsmanager_1.46.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Secrets Manager"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "bb8c98f0451ef5394d5d40d689f8db9b"
-SRC_URI[sha256sum] = "01af1973d83b34f31061f2e3e432437021185a406b67869ef6ff5a55c9ba36ec"
+SRC_URI[md5sum] = "4e948f7078635dbf43f7ab49f7da2f7a"
+SRC_URI[sha256sum] = "718438609e3353a92dc5aa45c36c2ac016f96d1ad03c4f07f49c56117d1a7d76"
 
 GEM_NAME = "aws-sdk-secretsmanager"
 

--- a/recipes-rubygems/rubygems-aws-sdk-securityhub_1.41.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-securityhub_1.41.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS SecurityHub"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "7b533aae1921a2266e94080c3939d6a4"
-SRC_URI[sha256sum] = "984a3e69d5e7545aab91b6eb37f879f15e555643d8c3eb421f30855b36a0dc48"
+SRC_URI[md5sum] = "5f6fa203b13dbe2e0debd2d219a17622"
+SRC_URI[sha256sum] = "5c326b5b82a9543fcc75f69389b65a059619a5e6dca4d7d72f75babbc2b85205"
 
 GEM_NAME = "aws-sdk-securityhub"
 

--- a/recipes-rubygems/rubygems-aws-sdk-servicecatalog_1.59.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-servicecatalog_1.59.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Service Catalog"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "8e9fc3e5e8994c82f1b439cf8dfe16e5"
-SRC_URI[sha256sum] = "93f2795b0e66d1e905feef0024d3353b1e27985f0da91cc8cd08781b00e6a638"
+SRC_URI[md5sum] = "806abfe2b7a916c6672e8919c8a7054a"
+SRC_URI[sha256sum] = "dc1e2974788fc9d52c457e21687812c55314dfe0d8f0823ad337d386ee8b8d8f"
 
 GEM_NAME = "aws-sdk-servicecatalog"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ses_1.38.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ses_1.38.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Simple Email Service (Amazon SES
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "5308ffc617e7c2563cd5c89f7ba090c4"
-SRC_URI[sha256sum] = "de1b708027d97bb673c090c24c2e8c7975b6eb1087dc158e47ba508aa79785c8"
+SRC_URI[md5sum] = "b1d326abab073f6ed4de885f17080e70"
+SRC_URI[sha256sum] = "d04322b6995f9270f54e75b49c225bbd3175f8c157f82fdc6be69ba0a12ed225"
 
 GEM_NAME = "aws-sdk-ses"
 

--- a/recipes-rubygems/rubygems-aws-sdk-shield_1.36.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-shield_1.36.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "c80b00fe019023caeacdb74ffdf60a36"
-SRC_URI[sha256sum] = "370116446b39b270e50e69e8d2e89bb4804e5f7b12d1a823a6f8c324db2bc6cd"
+SRC_URI[md5sum] = "4cddee61c9fa84d81bbd720f4c2aa81a"
+SRC_URI[sha256sum] = "89c24b335d9417bf67653f27539d0c626755777573f95ba172a25de601d42b9f"
 
 GEM_NAME = "aws-sdk-shield"
 

--- a/recipes-rubygems/rubygems-aws-sdk-sms_1.29.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-sms_1.29.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Server Migration Service (SMS)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "1b4859d0002d7f4af0d429d60bf3815d"
-SRC_URI[sha256sum] = "0330217e9b2f574d11fb56443151a0c6b715fdaf7a362e7a4a9faa974e5f4104"
+SRC_URI[md5sum] = "7516f88fec2950a5213e2ba0295a8e87"
+SRC_URI[sha256sum] = "f6c12c1a8c0805d09e40e4024e71813e21b8d94496ecec18f9e7cec2ecee0dcf"
 
 GEM_NAME = "aws-sdk-sms"
 

--- a/recipes-rubygems/rubygems-aws-sdk-sns_1.39.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-sns_1.39.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Simple Notification Service (Ama
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "d80f5f441816f8932c8243e9d9fd9e28"
-SRC_URI[sha256sum] = "cba925691dd51cfa42d9cb7fae9278ffa7e3ab05efa97515edacba1749881933"
+SRC_URI[md5sum] = "7a3edcbab8c875b08744a5e956521e4c"
+SRC_URI[sha256sum] = "04a79867cac6afccbc33c5db59a1c90d4da80af07a27e497a1d38a1c0e8abd5e"
 
 GEM_NAME = "aws-sdk-sns"
 

--- a/recipes-rubygems/rubygems-aws-sdk-sqs_1.37.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-sqs_1.37.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Simple Queue Service (Amazon SQS
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "5a0e751da4fb2ac0b5738fa7f0fa7bc9"
-SRC_URI[sha256sum] = "9840bb4e3024edae5fdd28b5560395dc39e6e44081147fb270bc5d3cb9420f1f"
+SRC_URI[md5sum] = "25e17d7d31ceabac12251ed7c236231f"
+SRC_URI[sha256sum] = "a3cf5277395ea80e188dc6219d5ae468f76bd8272f59d91a32f82f0497dcb9e7"
 
 GEM_NAME = "aws-sdk-sqs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ssm_1.106.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ssm_1.106.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for Amazon Simple Systems Manager (SSM) (Am
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "c771b119073cfddced3481a4dfb37e1a"
-SRC_URI[sha256sum] = "2f122303f9463c305eaa58dae530f923b4b45bd052edf241f09eed074ebd8eb4"
+SRC_URI[md5sum] = "9f58008745e3b177fcd96724c932b167"
+SRC_URI[sha256sum] = "3593867cbd9e172f6dfb42109bad84c4ebfbda4e733f360267b8bd5971870c55"
 
 GEM_NAME = "aws-sdk-ssm"
 

--- a/recipes-rubygems/rubygems-aws-sdk-states_1.39.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-states_1.39.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Step Functions (AWS SFN)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "378a9bf79320db6794b6e9736ffcb2c9"
-SRC_URI[sha256sum] = "f5852af34604054c9aff50920980bb70e3e298e87acd78696ffe2cad572601ee"
+SRC_URI[md5sum] = "2ff74191a02ec0dba192f5203c30cce2"
+SRC_URI[sha256sum] = "90296d8e5278e83aaef259e83eb4df0f8755ddaa1b51410468af65d2274c4a02"
 
 GEM_NAME = "aws-sdk-states"
 

--- a/recipes-rubygems/rubygems-aws-sdk-transfer_1.32.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-transfer_1.32.0.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "Official AWS Ruby gem for AWS Transfer Family (AWS Transfer)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "\
-    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
-"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "3d8a308e6b0716650e3923c0a9f9312d"
-SRC_URI[sha256sum] = "bc1194c410d74a3bc22f4ebe311cd03fca0c451f63d2f7eeccb3803456ef2e27"
+SRC_URI[md5sum] = "feb4035d8f5386b999acf1f7ed79b877"
+SRC_URI[sha256sum] = "83c6a5f1524443de8ab14db87126efbf85f535f76111dad59d44bd02214ffd44"
 
 GEM_NAME = "aws-sdk-transfer"
 

--- a/recipes-rubygems/rubygems-google-apis-core_0.3.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-core_0.3.0.bb
@@ -18,8 +18,8 @@ DEPENDS_class-native += "\
     rubygems-webrick-native \
 "
 
-SRC_URI[md5sum] = "ba38eed85bb6529bf621f745723d69bf"
-SRC_URI[sha256sum] = "4efc94daaf4b73f98a746d83823b28e6a3bbbb390ec957726015e9f30fc797a0"
+SRC_URI[md5sum] = "386faccbb3941397db176406edacd9bb"
+SRC_URI[sha256sum] = "4a04e1daa6397781e5ef289e9dcb9274fbb2d8018ea47869bfa875e97c94a4cb"
 
 GEM_NAME = "google-apis-core"
 

--- a/recipes-rubygems/rubygems-google-apis-discovery-v1_0.2.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-discovery-v1_0.2.0.bb
@@ -10,8 +10,8 @@ DEPENDS_class-native += "\
     rubygems-google-apis-core-native \
 "
 
-SRC_URI[md5sum] = "931278ce45f35237f8604ca24996e7dd"
-SRC_URI[sha256sum] = "0fa659e114f35c2e88ed847f5c129a83deb0cc310cdde687caee66844ea00007"
+SRC_URI[md5sum] = "8a61a47c66ecdf6ed8c395903edd9108"
+SRC_URI[sha256sum] = "054a5d8988e354f99559c5e419875c22985efb6cf24d0011ac0863bba64c995c"
 
 GEM_NAME = "google-apis-discovery_v1"
 

--- a/recipes-rubygems/rubygems-google-apis-generator_0.2.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-generator_0.2.0.bb
@@ -14,8 +14,8 @@ DEPENDS_class-native += "\
     rubygems-thor-native \
 "
 
-SRC_URI[md5sum] = "5ce33adfd39e5673fb328d6111b8045b"
-SRC_URI[sha256sum] = "9b581981caa3703086a52d4147145f49f2dc6d422b276ca40ef432b84ffab6cc"
+SRC_URI[md5sum] = "035ebb4d7f369197d6e625ebdd746d22"
+SRC_URI[sha256sum] = "8ea98f042e747f76837137f8b2bd1c927fc6009f873ff6e49cb5dd652b8a3499"
 
 GEM_NAME = "google-apis-generator"
 

--- a/recipes-rubygems/rubygems-strings_0.2.1.bb
+++ b/recipes-rubygems/rubygems-strings_0.2.1.bb
@@ -11,21 +11,20 @@ DEPENDS_class-native += "\
     rubygems-unicode-display-width-native \
     rubygems-unicode-utils-native \
 "
+
+SRC_URI[md5sum] = "d7ba6cdc31aff7b502f12faed2bd4738"
+SRC_URI[sha256sum] = "933293b3c95cf85b81eb44b3cf673e3087661ba739bbadfeadf442083158d6fb"
+
+GEM_NAME = "strings"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
 RDEPENDS_${PN}_class-target += "\
     rubygems-strings-ansi \
     rubygems-unicode-display-width \
     rubygems-unicode-utils \
 "
-
-SRC_URI[md5sum] = "30a4400d19f94ac6ce28b8e3953c67bd"
-SRC_URI[sha256sum] = "f578187c378dc304c8fd778923912f8ec8bcef40ed75dbd0ac5b5bc5eb07fc75"
-
-GEM_NAME = "strings"
-
-
-
-inherit rubygems
-inherit rubygentest
-inherit pkgconfig
 
 BBCLASSEXTEND = "native"


### PR DESCRIPTION
* aws-sdk-core: update to 3.113.0
* ffi: update to 1.15.0
* google-apis-core: update to 0.3.0
* strings: update to 0.2.1
* aws-sdk-kms: update to 1.43.0
* aws-sdk-secretsmanager: update to 1.46.0
* aws-sdk-budgets: update to 1.38.0
* aws-sdk-codepipeline: update to 1.44.0
* aws-sdk-iam: update to 1.49.0
* aws-sdk-shield: update to 1.36.0
* aws-sdk-organizations: update to 1.58.0
* aws-sdk-elasticache: update to 1.54.0
* aws-sdk-batch: update to 1.45.0
* aws-sdk-eks: update to 1.51.0
* aws-sdk-costandusagereportservice: update to 1.31.0
* aws-sdk-glue: update to 1.85.0
* aws-sdk-cloudwatch: update to 1.50.0
* aws-sdk-ses: update to 1.38.0
* aws-sdk-kinesis: update to 1.32.0
* aws-sdk-ecs: update to 1.75.0
* aws-sdk-elasticloadbalancing: update to 1.31.0
* aws-sdk-cloudfront: update to 1.49.0
* aws-sdk-sqs: update to 1.37.0
* aws-sdk-dynamodb: update to 1.60.0
* aws-sdk-s3: update to 1.91.0
* aws-sdk-route53: update to 1.47.0
* aws-sdk-codecommit: update to 1.42.0
* aws-sdk-lambda: update to 1.61.0
* aws-sdk-ec2: update to 1.227.0
* aws-sdk-guardduty: update to 1.45.0
* aws-sdk-apigatewayv2: update to 1.32.0
* aws-sdk-elasticbeanstalk: update to 1.42.0
* aws-sdk-securityhub: update to 1.41.0
* aws-sdk-ssm: update to 1.106.0
* aws-sdk-databasemigrationservice: update to 1.52.0
* aws-sdk-elasticloadbalancingv2: update to 1.61.0
* aws-sdk-codedeploy: update to 1.39.0
* aws-sdk-athena: update to 1.37.0
* aws-sdk-ram: update to 1.24.0
* aws-sdk-efs: update to 1.39.0
* aws-sdk-ecr: update to 1.42.0
* aws-sdk-firehose: update to 1.37.0
* aws-sdk-autoscaling: update to 1.58.0
* aws-sdk-route53resolver: update to 1.24.0
* aws-sdk-sms: update to 1.29.0
* aws-sdk-states: update to 1.39.0
* aws-sdk-cognitoidentity: update to 1.31.0
* aws-sdk-redshift: update to 1.55.0
* aws-sdk-route53domains: update to 1.30.0
* aws-sdk-rds: update to 1.117.0
* aws-sdk-cognitoidentityprovider: update to 1.50.0
* aws-sdk-kafka: update to 1.35.0
* aws-sdk-cloudwatchlogs: update to 1.40.0
* aws-sdk-servicecatalog: update to 1.59.0
* aws-sdk-sns: update to 1.39.0
* aws-sdk-cloudhsm: update to 1.29.0
* aws-sdk-cloudhsmv2: update to 1.33.0
* aws-sdk-configservice: update to 1.59.0
* aws-sdk-transfer: update to 1.32.0
* aws-sdk-elasticsearchservice: update to 1.51.0
* aws-sdk-cloudtrail: update to 1.34.0
* aws-sdk-apigateway: update to 1.61.0
* aws-sdk-cloudformation: update to 1.49.0
* aws-sdk-cloudwatchevents: update to 1.44.0
* google-apis-discovery_v1: update to 0.2.0
* google-apis-generator: update to 0.2.0
* aws-sdk-applicationautoscaling: update to 1.51.0