### PR TITLE
ruby-gen: fix EXTRA_ mapping

### DIFF
--- a/scripts/ruby-gen
+++ b/scripts/ruby-gen
@@ -292,8 +292,8 @@ def create_tpl(args, pkgname, version):
             "__rdeps": _rdepends,
             "__tdeps": prettify_list(save_variables("DEPENDS", ["class-target"], _oldrecipes)),
             "__version": _bestversion,
-            "__xtradep": prettify_list(save_variables("EXTRA_RDEPENDS", None, _oldrecipes)),
-            "__xtrardep": prettify_list(save_variables("EXTRA_DEPENDS", None, _oldrecipes)),
+            "__xtradep": prettify_list(save_variables("EXTRA_DEPENDS", None, _oldrecipes)),
+            "__xtrardep": prettify_list(save_variables("EXTRA_RDEPENDS", None, _oldrecipes)),
         }
         __calculated["__class"] = "\n".join(
             ["inherit {}".format(x) for x in __calculated["__class"]])


### PR DESCRIPTION
map EXTRA_DEPENDS and EXTRA_RDEPENDS to
the correct keys in an updated recipe

Closes #94

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>