### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.434.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.434.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-SRC_URI[md5sum] = "131e9dd31c300f708cefe662e6a8b4fe"
-SRC_URI[sha256sum] = "ef7dba4202f68bd181be92d338ff216d63a1da45b682fe158ac3c3f760111f78"
+SRC_URI[md5sum] = "464328cb5bc70913cf5e727c0f624c18"
+SRC_URI[sha256sum] = "814a96b7135e86a28eab0b8e148191fb1cf7e7c3d92e68c8ffdcd235025849c5"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-apigateway_1.62.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-apigateway_1.62.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "17f5f2cf083a9291c2349ea85ac2da5e"
-SRC_URI[sha256sum] = "dcae182787d971479fa5380efd84ec5054939be5d78b4d9952092dee71d3be7a"
+SRC_URI[md5sum] = "ff852b992b85f21a532eb270bb314331"
+SRC_URI[sha256sum] = "0f24c2a008e1f57750299cc8c396af69b8f858bf4796810e0b6c93d75b5e388d"
 
 GEM_NAME = "aws-sdk-apigateway"
 

--- a/recipes-rubygems/rubygems-aws-sdk-autoscaling_1.59.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-autoscaling_1.59.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "0295336e10c04378c57ac0228430e88f"
-SRC_URI[sha256sum] = "e52b1fc527ce847a2c6799f465a1ca759727534da0c5f2df2deb8370b0d96aaa"
+SRC_URI[md5sum] = "18e00870f198ac0599c171aec7d6e1c8"
+SRC_URI[sha256sum] = "7993fe5ddb5a95aa8fd1e8567c89d080980b40b77556b5238a399728a283262f"
 
 GEM_NAME = "aws-sdk-autoscaling"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.76.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.76.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "23507aa2338548acefa0acb46d916d33"
-SRC_URI[sha256sum] = "e5164e0ca2b944e043e1d277a0b315345b9d17517f13dee291c0c696bb4913eb"
+SRC_URI[md5sum] = "215039e72439d91e76647fcb5243a9d8"
+SRC_URI[sha256sum] = "4c782561fd49ae8d2abc20d96d85fd607308c6c4a0e0cf2ca82c7dcae46f9c13"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-chef-config_16.11.7.bb
+++ b/recipes-rubygems/rubygems-chef-config_16.11.7.bb
@@ -15,8 +15,8 @@ DEPENDS_class-native += "\
     rubygems-tomlrb-native \
 "
 
-SRC_URI[md5sum] = "01bd324808ae3b50e9121ccba0c61be2"
-SRC_URI[sha256sum] = "1f4961e4d6aa4df374f739c6f62ae1d2be03dcff1bd93e56d9c963b8a156747c"
+SRC_URI[md5sum] = "1a3599b78aa79355117a880cb570a6ea"
+SRC_URI[sha256sum] = "647b22204327d8275e33a1a72b8a7e07c5c8abbd51eb10e7491b6a67d86ddfcf"
 
 GEM_NAME = "chef-config"
 

--- a/recipes-rubygems/rubygems-chef-utils_16.11.7.bb
+++ b/recipes-rubygems/rubygems-chef-utils_16.11.7.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/chef/chef/tree/master/chef-utils"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=8f7bb094c7232b058c7e9f2e431f389c"
 
-SRC_URI[md5sum] = "8e185c6a525ec9ec76f0318a99606839"
-SRC_URI[sha256sum] = "a74253da6aab8ff92c955549536bdecbc4d1ce8032c8201576f2a8ef4e8ed7b3"
+SRC_URI[md5sum] = "b4082dbeeb5a430722be23726670231d"
+SRC_URI[sha256sum] = "ff943c8988115745b300acf01860b5f1627e99dbd1f42e5cd1fa364347a1b1f8"
 
 GEM_NAME = "chef-utils"
 

--- a/recipes-rubygems/rubygems-chef_16.11.7.bb
+++ b/recipes-rubygems/rubygems-chef_16.11.7.bb
@@ -45,8 +45,8 @@ DEPENDS_class-native += "\
     rubygems-uuidtools-native \
 "
 
-SRC_URI[md5sum] = "755bb008c1cec862337b4579601ec520"
-SRC_URI[sha256sum] = "f9eb4f49cddb8d6f94067411b425f306cab6605e63cce51fd727d62dc996c17a"
+SRC_URI[md5sum] = "bda3cd0b6c1169892a5af543b6185dd4"
+SRC_URI[sha256sum] = "125d1f4cdfebdabc9836364862c87ff68019388c6c6ef263f69011d27efd29f8"
 
 GEM_NAME = "chef"
 

--- a/recipes-rubygems/rubygems-facter_4.0.52.bb
+++ b/recipes-rubygems/rubygems-facter_4.0.52.bb
@@ -13,8 +13,8 @@ DEPENDS_class-native += "\
     rubygems-thor-native \
 "
 
-SRC_URI[md5sum] = "d8088a901f508ffd8652508500a94924"
-SRC_URI[sha256sum] = "89b782fddd6ae98e400858a50e9f5f2adf6ad8607eb06a7b1ee4759b70ca6b82"
+SRC_URI[md5sum] = "506d3387aab8140ae5c4b297a392c27f"
+SRC_URI[sha256sum] = "7be62cc1c5a057f149164c1045fccbbf40b85747b188393ccf685c0d17e93469"
 
 GEM_NAME = "facter"
 

--- a/recipes-rubygems/rubygems-hiera_3.7.0.bb
+++ b/recipes-rubygems/rubygems-hiera_3.7.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/puppetlabs/hiera"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://COPYING;md5=67c01e92d4ae704f266de057db62d718"
 
-SRC_URI[md5sum] = "c1975a0cad3df4ba6cf64d07be219f75"
-SRC_URI[sha256sum] = "a77b182673a04955b444001dc80c15fe549dfc707254790be572a76dfcecf954"
+SRC_URI[md5sum] = "24fd0b1e4f449d09a81bf7688e0dcbde"
+SRC_URI[sha256sum] = "0a5dd57f260a7fb86d1326c060a7c0061e9dd9a6dee3fbc8187a53b2d6532bbc"
 
 GEM_NAME = "hiera"
 

--- a/recipes-rubygems/rubygems-mixlib-authentication_3.0.10.bb
+++ b/recipes-rubygems/rubygems-mixlib-authentication_3.0.10.bb
@@ -6,12 +6,10 @@ HOMEPAGE = "https://github.com/chef/mixlib-authentication"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=8f7bb094c7232b058c7e9f2e431f389c"
 
-SRC_URI[md5sum] = "7bb0a9909c8f6aa68efd02551a3fcc39"
-SRC_URI[sha256sum] = "43e49f3d8b16c99d04ec1b273d3f9aa6eceac30903693f684e67595e88b1def1"
+SRC_URI[md5sum] = "2b6d753a64e6c13d75fc6e87727d27c9"
+SRC_URI[sha256sum] = "c5be44490cebf8481171f09cc25e646663aee3ae58ea2de6d9f94bc922c2a61e"
 
 GEM_NAME = "mixlib-authentication"
-
-
 
 inherit rubygems
 inherit rubygentest

--- a/recipes-rubygems/rubygems-ohai_16.10.7.bb
+++ b/recipes-rubygems/rubygems-ohai_16.10.7.bb
@@ -20,6 +20,16 @@ DEPENDS_class-native += "\
     rubygems-train-core-native \
     rubygems-wmi-lite-native \
 "
+
+SRC_URI[md5sum] = "73e6d3752dbedf3620ae9dc6b0d3e7d2"
+SRC_URI[sha256sum] = "0483139fe0bf54b66f3cd6fae99f9313ac42f1a7e850a8319681d328adf9e4dc"
+
+GEM_NAME = "ohai"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
 RDEPENDS_${PN}_class-target += "\
     rubygems-chef-config \
     rubygems-chef-utils \
@@ -34,16 +44,5 @@ RDEPENDS_${PN}_class-target += "\
     rubygems-train-core \
     rubygems-wmi-lite \
 "
-
-SRC_URI[md5sum] = "e4dabebe107a05061bec6c7cf0fba4aa"
-SRC_URI[sha256sum] = "b835806e585faea4ac8346b68c722fb5fc29a29f73fd7e3a022f9073132dec22"
-
-GEM_NAME = "ohai"
-
-
-
-inherit rubygems
-inherit rubygentest
-inherit pkgconfig
 
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-puppet_7.5.0.bb
+++ b/recipes-rubygems/rubygems-puppet_7.5.0.bb
@@ -23,8 +23,8 @@ DEPENDS_class-native += "\
     rubygems-semantic-puppet-native \
 "
 
-SRC_URI[md5sum] = "eb18488e61f43bf3cf7ee94128c469e6"
-SRC_URI[sha256sum] = "6f84c473ed35fea22efcd83aca9548bd50a379b83c67a258f2d5021c6df58edd"
+SRC_URI[md5sum] = "c1f5978661034b7e718e8866c372cc09"
+SRC_URI[sha256sum] = "a8f029a794f47412e362f5cb04cdf6c4a50e60fe02c87abd3ee47a7ee92c9e0d"
 
 GEM_NAME = "puppet"
 


### PR DESCRIPTION
* train-core: update to 3.5.4
* chef-utils: update to 16.11.7
* chef-config: update to 16.11.7
* ~inspec-core: update to 4.28.0~
* aws-sdk-apigateway: update to 1.62.0
* ~train: update to 3.5.4~
* aws-sdk-autoscaling: update to 1.59.0
* aws-sdk-ecs: update to 1.76.0
* puppet: update to 7.5.0
* ohai: update to 16.10.7
* ~train-aws: update to 0.1.60~
* aws-partitions: update to 1.434.0
* mixlib-authentication: update to 3.0.10
* ~inspec: update to 4.28.0~
* chef: update to 16.11.7
* ~inspec-bin: update to 4.28.0~