### PR TITLE
ci: fall back on next best matching cache

### DIFF
--- a/.github/workflows/cron-master-qemu86-64-pkgupdate.yml
+++ b/.github/workflows/cron-master-qemu86-64-pkgupdate.yml
@@ -45,6 +45,8 @@ jobs:
         with:
           path: /opt/build/sstate-cache
           key: rubygems-x86-64-glibc-${{ github.sha }}
+          restore-keys: |
+            rubygems-x86-64-glibc-
       - name: checkout (poky)
         uses: priv-kweihmann/meta-sca-ci-utils/addlayer@latest
         with:

--- a/.github/workflows/push-master-qemu86-64-glibc.yml
+++ b/.github/workflows/push-master-qemu86-64-glibc.yml
@@ -43,6 +43,8 @@ jobs:
         with:
           path: /opt/build/sstate-cache
           key: rubygems-x86-64-glibc-${{ github.sha }}
+          restore-keys: |
+            rubygems-x86-64-glibc-
       - name: checkout (poky)
         uses: priv-kweihmann/meta-sca-ci-utils/addlayer@latest
         with:

--- a/.github/workflows/push-master-qemu86-64-musl.yml
+++ b/.github/workflows/push-master-qemu86-64-musl.yml
@@ -43,6 +43,8 @@ jobs:
         with:
           path: /opt/build/sstate-cache
           key: rubygems-x86-64-musl-${{ github.sha }}
+          restore-keys: |
+            rubygems-x86-64-musl-
       - name: checkout (poky)
         uses: priv-kweihmann/meta-sca-ci-utils/addlayer@latest
         with:


### PR DESCRIPTION
by using restore-keys features of the caches action, which
gives back the most recent cache starting with the given
prefix

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>