### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.441.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.441.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-SRC_URI[md5sum] = "af5f0ae6172b22f0d0f8df928cdfab4b"
-SRC_URI[sha256sum] = "8e4465a6c991fb3cd6e0a39f0a72019e522afbc8002939587bc68ae7144bc0be"
+SRC_URI[md5sum] = "3806ca4714f3937edc0c833ff673f144"
+SRC_URI[sha256sum] = "e9d1e11004c0d8f9711d1d3c5278cc97fdca56d85dd1d17811eda60017ae291e"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-batch_1.47.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-batch_1.47.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "fa96481cea52ebbede84216ccccf8cb1"
-SRC_URI[sha256sum] = "108e1bb22c8e873b4e1c99a15a6970fdbf9f53cbf26730c3bd6603e0cf5623bb"
+SRC_URI[md5sum] = "376a1114ba27cbfc41e167b4be074740"
+SRC_URI[sha256sum] = "80b99350e9977ad9958bd664c96f6241d0d16594382c0443490ad6d6f7f6a875"
 
 GEM_NAME = "aws-sdk-batch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudformation_1.50.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudformation_1.50.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "beb2ff03f7bcad53b43d6e512d3343ae"
-SRC_URI[sha256sum] = "e437f70a825a439c68d54d787c3bfb42773d7da049b711424ec1d53749389fda"
+SRC_URI[md5sum] = "978854a191a7eaaa1ecab155976216f3"
+SRC_URI[sha256sum] = "e7fa6bcaa568290bfaf51d06d9c54a250584383494d3a21ac7b0a35d2bf3a6e3"
 
 GEM_NAME = "aws-sdk-cloudformation"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudhsm_1.30.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudhsm_1.30.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "a22725345ed3316ba655a7b66c2fd723"
-SRC_URI[sha256sum] = "f406db5747bafaae0cd40124dec158735dd49355b650b01f30fc91ababa40571"
+SRC_URI[md5sum] = "56c5fb55cffeb0dba290b3848491086d"
+SRC_URI[sha256sum] = "9511eb23a55644bccbcd7928876fa4060be779235cd354d55d045d6c8aba9ade"
 
 GEM_NAME = "aws-sdk-cloudhsm"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatch_1.51.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatch_1.51.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "4762da6bcbde6b038826028318c0157b"
-SRC_URI[sha256sum] = "0ce46e9a34c294478fa054dfb470036046a5c838ee8b4bfe73b988641b00ea75"
+SRC_URI[md5sum] = "6a8e83d0eccbf71a06e3c7b0a6a8f7dc"
+SRC_URI[sha256sum] = "c8937d420ccd5d8c233d098bc18c8df3775a984c3de1313e6feaacd244b34d87"
 
 GEM_NAME = "aws-sdk-cloudwatch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-configservice_1.60.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-configservice_1.60.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "84d50e58d6213a90752ab9de0df5ca20"
-SRC_URI[sha256sum] = "696ebd5607dd751591aaa9b5afd5588c9b938c530f355afb21c4bf8dcb76a83a"
+SRC_URI[md5sum] = "35d1c2b9495344a83dddcde9540992c3"
+SRC_URI[sha256sum] = "9ab5cf374c07c03364162b64fd3a85b9953c322a9c25b6c18885dad22c629985"
 
 GEM_NAME = "aws-sdk-configservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.113.1.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.113.1.bb
@@ -13,8 +13,8 @@ DEPENDS_class-native += "\
     rubygems-jmespath-native \
 "
 
-SRC_URI[md5sum] = "f74f9df3859e61fbb7dbfee0c126aaa9"
-SRC_URI[sha256sum] = "3f49f4e8eec6c62e4936a7e0a654dcd92b4452006e5f5be0c6070c879defe49c"
+SRC_URI[md5sum] = "993d24b4f2d419d5c8fed220f15a190e"
+SRC_URI[sha256sum] = "e0fd125f6ace260217d3b98a6baa3fb0e66a142b7f36d6ce498955ffd2457d44"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.232.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.232.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "f4346594547093fed9bef3e148c4c94f"
-SRC_URI[sha256sum] = "e3efad633f1f39b101d98bab103a8d9b8cc56a9292f741cc588d24273cc5f8b0"
+SRC_URI[md5sum] = "fbb009b6897919892bb726cffd838e7b"
+SRC_URI[sha256sum] = "051f339369c20a5a680059df38134e606772133bfc89e19e7b15d5fb8d89f058"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.86.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.86.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "e50b602f0ccbecdd1260fdc7108a4280"
-SRC_URI[sha256sum] = "f851f71cd9368ee1f6b70c99bf1418a8caa0b10a29ca9304e3c7e7d1fc6d4328"
+SRC_URI[md5sum] = "58eee74cdfb05e95661d0ca74423ff96"
+SRC_URI[sha256sum] = "aa4fe6e1dd9786c9f2ed9ce5cabdf469d2749e16dd703c5d99b39149f3388cf4"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-iam_1.52.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-iam_1.52.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "1cd837ad482a648e0540ae3553c90f8f"
-SRC_URI[sha256sum] = "c9947f37bf1fc703e4aa9019bc46564b51774c134ec49b56bc14794d17324774"
+SRC_URI[md5sum] = "237401fd2945aad9ff6164e105e106ee"
+SRC_URI[sha256sum] = "91b1f1efd64a7dbd5a649235a16d0868feafb5c7890c3f48094fb8d17d01ac8e"
 
 GEM_NAME = "aws-sdk-iam"
 

--- a/recipes-rubygems/rubygems-aws-sdk-redshift_1.59.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-redshift_1.59.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "190f973a71b9ad743db3ead86f074004"
-SRC_URI[sha256sum] = "6d1929e0cacf15e8d75c3b9d9cbe9d38237891b03a1b15e109455200b641e1ea"
+SRC_URI[md5sum] = "a8d1d9a256c13eed72e86323962f03de"
+SRC_URI[sha256sum] = "3c14da2096211f2277b245bfbe91ddbdeaadc8d89c64cb6b1f989aa931753d39"
 
 GEM_NAME = "aws-sdk-redshift"
 

--- a/recipes-rubygems/rubygems-aws-sdk-route53resolver_1.25.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-route53resolver_1.25.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "ab0a74417b93cadf5a6a5ecd4986c1b9"
-SRC_URI[sha256sum] = "860ecef66d3b6c3ff2b59b1c8800f9103c47a7fa13b963b4dfc32edee05ac678"
+SRC_URI[md5sum] = "6588931aca6f0b27dd35a2ae2045b680"
+SRC_URI[sha256sum] = "c71d3f134077ba477cf0f8479bb7716134d1058618f68635428396cf4cf175af"
 
 GEM_NAME = "aws-sdk-route53resolver"
 

--- a/recipes-rubygems/rubygems-googleauth_0.16.1.bb
+++ b/recipes-rubygems/rubygems-googleauth_0.16.1.bb
@@ -15,8 +15,8 @@ DEPENDS_class-native += "\
     rubygems-signet-native \
 "
 
-SRC_URI[md5sum] = "499c7579d140e2b7677d6af20e923c70"
-SRC_URI[sha256sum] = "89fb8010f81426c1c83183792c2d6f6cf65e3955af2a83115ffe409ca2817581"
+SRC_URI[md5sum] = "f5e3322c8b83d594506b3e92895ce43b"
+SRC_URI[sha256sum] = "566a17835f4c412f21bc57a79f32451e84152446d11e6cdc6b9958d221556890"
 
 GEM_NAME = "googleauth"
 

--- a/recipes-rubygems/rubygems-i18n_1.8.10.bb
+++ b/recipes-rubygems/rubygems-i18n_1.8.10.bb
@@ -10,8 +10,8 @@ DEPENDS_class-native += "\
     rubygems-concurrent-ruby-native \
 "
 
-SRC_URI[md5sum] = "eb6d2f8a637b693c687ecf5846bf1866"
-SRC_URI[sha256sum] = "62a877ff6b5fdb4c20ca614c6bfcd6abd7b426d883069e59ce41a6744758e622"
+SRC_URI[md5sum] = "2694f6336817961b18e82b40a94e8054"
+SRC_URI[sha256sum] = "ca24e52fdd6ad7af419241eef8c41e65ef4e3499c6b252df13f697919eb24e3c"
 
 GEM_NAME = "i18n"
 

--- a/recipes-rubygems/rubygems-ohai_16.12.3.bb
+++ b/recipes-rubygems/rubygems-ohai_16.12.3.bb
@@ -21,8 +21,8 @@ DEPENDS_class-native += "\
     rubygems-wmi-lite-native \
 "
 
-SRC_URI[md5sum] = "73e6d3752dbedf3620ae9dc6b0d3e7d2"
-SRC_URI[sha256sum] = "0483139fe0bf54b66f3cd6fae99f9313ac42f1a7e850a8319681d328adf9e4dc"
+SRC_URI[md5sum] = "1e9218172bc9e067ed0a47b22ea69960"
+SRC_URI[sha256sum] = "3046eeba9a8564088538def336575cc76d480d8f516f8ba55a8891bd13a3b632"
 
 GEM_NAME = "ohai"
 

--- a/recipes-rubygems/rubygems-rubycritic_4.6.1.bb
+++ b/recipes-rubygems/rubygems-rubycritic_4.6.1.bb
@@ -19,8 +19,8 @@ DEPENDS_class-native += "\
     rubygems-virtus-native \
 "
 
-SRC_URI[md5sum] = "39350f134adc043928b94a1b296cce3f"
-SRC_URI[sha256sum] = "c1e362d4552fab9aca3133417a31e55924df1848ff5541c0cef11249f9b1c1c0"
+SRC_URI[md5sum] = "2b98ea1abcc1ae9dc8507e144bc0d29a"
+SRC_URI[sha256sum] = "1530cbd82a48e75909bc74efc89e0d0901359aa86d2806ce385d68d703b19095"
 
 GEM_NAME = "rubycritic"
 


### PR DESCRIPTION
* aws-sdk-core: update to 3.113.1
* googleauth: update to 0.16.1
* aws-sdk-cloudformation: update to 1.50.0
* i18n: update to 1.8.10
* aws-sdk-ec2: update to 1.232.0
* aws-sdk-cloudhsm: update to 1.30.0
* aws-sdk-batch: update to 1.47.0
* aws-sdk-cloudwatch: update to 1.51.0
* ohai: update to 16.12.3
* aws-sdk-redshift: update to 1.59.0
* aws-sdk-route53resolver: update to 1.25.0
* aws-sdk-glue: update to 1.86.0
* aws-sdk-configservice: update to 1.60.0
* aws-sdk-iam: update to 1.52.0
* rubycritic: update to 4.6.1