### PR TITLE
ci: fix branch name in cherry-pick PL

### DIFF
--- a/.github/workflows/cron-master-qemu86-64-cherrypick.yml
+++ b/.github/workflows/cron-master-qemu86-64-cherrypick.yml
@@ -72,8 +72,8 @@ jobs:
           GITHUB_REPO_USER=priv-kweihmann \
           GITHUB_REPO=meta-rubygems \
           ${WORKSPACE}/sources/meta-rubygems/scripts/cherry-pick-bot \
-          origin/master \
-          origin/dunfell \
+          master \
+          dunfell \
           ${WORKSPACE}/sources/meta-rubygems/.nocherry \
           ${WORKSPACE}/sources/poky \
           ${WORKSPACE}/sources/meta-openembedded \


### PR DESCRIPTION
as we don't need to prefix the branches with origin/ - 
this is done already internally