### PR TITLE
Package update

### DIFF
--- a/lib/oeqa/runtime/cases/rubygems_rubygems_chef.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_chef.py
@@ -2,9 +2,6 @@ from rubygems_utils import RubyGemsTestUtils
 
 class RubyGemsTestrubygems_chef(RubyGemsTestUtils):
 
-    def test_exec_knife(self):
-        self.gem_exec_wrapper("knife")
-
     def test_gem_list_rubygems_chef(self):
         self.gem_is_installed("chef")
 

--- a/recipes-rubygems/rubygems-aws-partitions_1.449.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.449.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-SRC_URI[md5sum] = "5f79bd97f319761f41ff0c15ba566f55"
-SRC_URI[sha256sum] = "07d4e20bba3729483c53255737ea50d8a8edeeabf5733c960eb9b269709fddbd"
+SRC_URI[md5sum] = "a2655dd05a461611ac0141da67c43524"
+SRC_URI[sha256sum] = "c4fd36fcf865ff6ba4b2a5a76c21d4c71a3f2871c1baa982444ee59a2848a9a1"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudformation_1.52.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudformation_1.52.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "d95370b6e3a802a12dd8d24c7cd29a95"
-SRC_URI[sha256sum] = "997e5676729b4631d7ad27496944fa3745a1fc26c1a56ab92e4e5ed88fa92793"
+SRC_URI[md5sum] = "dd47cfe6a58d1d3a4da6c3dbc2e4a253"
+SRC_URI[sha256sum] = "47e1d3c949b56714fcf6588dd8214ba9b392a7758741074904cd77cde0483b01"
 
 GEM_NAME = "aws-sdk-cloudformation"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.50.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.50.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "3f8bef7db92b73b116106aa0ea4b3638"
-SRC_URI[sha256sum] = "ee5bb2bf72c71376988ae7b1467a3e65721c8318a3b884ef80d0711257c9a242"
+SRC_URI[md5sum] = "8bb7bee4fe60ab9cf30612bb56c056d1"
+SRC_URI[sha256sum] = "3a0deb350974e731ab648e0423152a9b24a0b02afbe483c3411ee6c888ab83b2"
 
 GEM_NAME = "aws-sdk-cloudfront"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.235.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.235.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "fa68fc79e48537866cc2199f149c7b2a"
-SRC_URI[sha256sum] = "e42f0a4a31b3fcaeae6bb6d4aa0170b611893f137223aec226e257e6e24698e6"
+SRC_URI[md5sum] = "d8e184a04c93ae7c49fed74ad36e2fd1"
+SRC_URI[sha256sum] = "64885afb7da2ca773a1130ebe365633daf8da3950585cba1210d209e4b7696cd"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.77.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.77.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "215039e72439d91e76647fcb5243a9d8"
-SRC_URI[sha256sum] = "4c782561fd49ae8d2abc20d96d85fd607308c6c4a0e0cf2ca82c7dcae46f9c13"
+SRC_URI[md5sum] = "c235d4d95f93d6f803148d7fcbb2d07f"
+SRC_URI[sha256sum] = "95137a6c3ee53162ad7acce5c9bc445d61b427e9f377879a490a815dfe1cc01d"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eks_1.52.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eks_1.52.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "763c52445e1e0221de9bcd10b6db157a"
-SRC_URI[sha256sum] = "d6ab1655541d3f3960882af8e773294420d8fbd1b2c813be0e31bdab0b8f6419"
+SRC_URI[md5sum] = "f4335d7a5225eea624bda0dea866d450"
+SRC_URI[sha256sum] = "8c84093a9150863df3f5d99767252ab9d31fa960ef728bd02eea79f3f108abdc"
 
 GEM_NAME = "aws-sdk-eks"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.87.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.87.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "58eee74cdfb05e95661d0ca74423ff96"
-SRC_URI[sha256sum] = "aa4fe6e1dd9786c9f2ed9ce5cabdf469d2749e16dd703c5d99b39149f3388cf4"
+SRC_URI[md5sum] = "66f2bd1b0784360180bafbe9eaea1d78"
+SRC_URI[sha256sum] = "15f4b3eac6631fa685f9a52b085f65ea45e025d9d9712288c6961d0e1f041c3d"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-organizations_1.59.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-organizations_1.59.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "3fc12502ac791ad653a90531fbefd857"
-SRC_URI[sha256sum] = "cef670f0418bc59b45a5b2ac2fcf64e79485a1803aff629feefdc4646fc1124f"
+SRC_URI[md5sum] = "c4630d65ddc1631a63689c191e444c4a"
+SRC_URI[sha256sum] = "549df22a9573d85d14c114731de60b4689d0a62e17a46d6bbd651ec3e0f1bfac"
 
 GEM_NAME = "aws-sdk-organizations"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.94.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.94.0.bb
@@ -12,8 +12,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "09b3f57a23a20795904353a6b5bcd68b"
-SRC_URI[sha256sum] = "07dbbb62d0398b4d53a4ba87dc9ee020a11f3f1716c31584effc46312c2482f4"
+SRC_URI[md5sum] = "56acac04c70778d6555602ea58c3f895"
+SRC_URI[sha256sum] = "69472bc01e8e783321448782a666734b1d14d13bf52901cfeb67062c9c0d2e85"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-chef-config_17.0.242.bb
+++ b/recipes-rubygems/rubygems-chef-config_17.0.242.bb
@@ -15,8 +15,8 @@ DEPENDS_class-native += "\
     rubygems-tomlrb-native \
 "
 
-SRC_URI[md5sum] = "fc2c8a7c5a3433f81f7e8c61071a1cdb"
-SRC_URI[sha256sum] = "cc1ddad739818ee9ae4df8c0590fb1155f7224a0118cfbbc7078128ab1768c2f"
+SRC_URI[md5sum] = "57719f2b0ddf7dd8cb9f6b06bec44708"
+SRC_URI[sha256sum] = "b4e0bf818d582295fa51b4e45eb717e60cfb0b912d57d8b62a893217c3642a4a"
 
 GEM_NAME = "chef-config"
 

--- a/recipes-rubygems/rubygems-chef-utils_17.0.242.bb
+++ b/recipes-rubygems/rubygems-chef-utils_17.0.242.bb
@@ -6,13 +6,21 @@ HOMEPAGE = "https://github.com/chef/chef/tree/master/chef-utils"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=8f7bb094c7232b058c7e9f2e431f389c"
 
-SRC_URI[md5sum] = "c45ac30eabd87e3c03cd7493d5a86490"
-SRC_URI[sha256sum] = "5e9229007c77f0064f675c74286feffc639c0d1b96f90899fdd03894dab09300"
+DEPENDS_class-native += "\
+    rubygems-concurrent-ruby-native \
+"
+
+SRC_URI[md5sum] = "66cb37aa745139e70d52c903b2180034"
+SRC_URI[sha256sum] = "bb7970dc43199ce891ed3472935881626fc676c5fbc1a7348aee50d478cc3a49"
 
 GEM_NAME = "chef-utils"
 
 inherit rubygems
 inherit rubygentest
 inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-concurrent-ruby \
+"
 
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-chef_17.0.242.bb
+++ b/recipes-rubygems/rubygems-chef_17.0.242.bb
@@ -9,7 +9,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=8f7bb094c7232b058c7e9f2e431f389c"
 DEPENDS_class-native += "\
     rubygems-addressable-native \
     rubygems-bcrypt-pbkdf-native \
-    rubygems-bundler-native \
     rubygems-chef-config-native \
     rubygems-chef-utils-native \
     rubygems-chef-vault-native \
@@ -45,8 +44,8 @@ DEPENDS_class-native += "\
     rubygems-uuidtools-native \
 "
 
-SRC_URI[md5sum] = "b7d63cb50c302f7628765ac191754e50"
-SRC_URI[sha256sum] = "cc38c2f8b64fc7f37cf5e8ee18bb20a084f8fe0507d3c443f2c7c2cfd86919ab"
+SRC_URI[md5sum] = "114636a477643f69a6d0e5fdc9066038"
+SRC_URI[sha256sum] = "958f9a6bd73a1ecb34187368ca0d72735e2f1c2b4b43e6ca69920ca54a6d565f"
 
 GEM_NAME = "chef"
 
@@ -66,7 +65,6 @@ do_install_append() {
 RDEPENDS_${PN}_class-target += "\
     rubygems-addressable \
     rubygems-bcrypt-pbkdf \
-    rubygems-bundler \
     rubygems-chef-config \
     rubygems-chef-utils \
     rubygems-chef-vault \

--- a/recipes-rubygems/rubygems-excon_0.81.0.bb
+++ b/recipes-rubygems/rubygems-excon_0.81.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/excon/excon"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=8b04a0291ec55b31563a50b191b72cb1"
 
-SRC_URI[md5sum] = "7091d6257fb4aa46cbf2c99dec9ecbf3"
-SRC_URI[sha256sum] = "05b579499c852f6880b0be1d231aba8f893558ce593ab17bdd00ea6ec9d1c84a"
+SRC_URI[md5sum] = "cec0507827e05f04e7d53cf865e4f729"
+SRC_URI[sha256sum] = "e7c78b2114c42e06024fb9812fc5a6b9a984ed973f585c09c67f5ae6e7b6e5a5"
 
 GEM_NAME = "excon"
 

--- a/recipes-rubygems/rubygems-googleauth_0.16.2.bb
+++ b/recipes-rubygems/rubygems-googleauth_0.16.2.bb
@@ -15,8 +15,8 @@ DEPENDS_class-native += "\
     rubygems-signet-native \
 "
 
-SRC_URI[md5sum] = "f5e3322c8b83d594506b3e92895ce43b"
-SRC_URI[sha256sum] = "566a17835f4c412f21bc57a79f32451e84152446d11e6cdc6b9958d221556890"
+SRC_URI[md5sum] = "aa1c2f1c3bf0905782308e9b4f51f4a7"
+SRC_URI[sha256sum] = "057c72865a94a5c55d51fb8702635dfb0fe02085f67a417542285cb61022c75f"
 
 GEM_NAME = "googleauth"
 

--- a/recipes-rubygems/rubygems-inspec-bin_4.36.4.bb
+++ b/recipes-rubygems/rubygems-inspec-bin_4.36.4.bb
@@ -10,8 +10,8 @@ DEPENDS_class-native += "\
     rubygems-inspec-native \
 "
 
-SRC_URI[md5sum] = "cb76c47d5b7fe88cc12adc3ad1e6dd79"
-SRC_URI[sha256sum] = "02e492ff7bd334b05c37343e9f2c606e25675e6bb4314fdf4516b948834bb1a9"
+SRC_URI[md5sum] = "8977704da9bc0b2d17be3b8d17d4cf35"
+SRC_URI[sha256sum] = "df1e116c9a4fdd24fbd0681893e51f1d3d2328d6b279fc5b485add41af2d02c4"
 
 GEM_NAME = "inspec-bin"
 

--- a/recipes-rubygems/rubygems-inspec-core_4.36.4.bb
+++ b/recipes-rubygems/rubygems-inspec-core_4.36.4.bb
@@ -31,8 +31,8 @@ DEPENDS_class-native += "\
     rubygems-tty-table-native \
 "
 
-SRC_URI[md5sum] = "d80b9c307e916781286f48ee71bc2b93"
-SRC_URI[sha256sum] = "f1eb380b00f251563ece4dd91da58e8ecc7a3ff133aa1e2cb90ca509dc18e042"
+SRC_URI[md5sum] = "4d81a3aca0be893c58e801060cdea29b"
+SRC_URI[sha256sum] = "f1f595361da8062931bfb544bc059f79a16799f14f79c2b5c88af87380d9d9f0"
 
 GEM_NAME = "inspec-core"
 

--- a/recipes-rubygems/rubygems-inspec_4.36.4.bb
+++ b/recipes-rubygems/rubygems-inspec_4.36.4.bb
@@ -17,8 +17,8 @@ DEPENDS_class-native += "\
     rubygems-train-winrm-native \
 "
 
-SRC_URI[md5sum] = "f039c2ec702f64f6263898221f2431fb"
-SRC_URI[sha256sum] = "dcfbea32346b9cc9feb3f5ddae88efb6a0270ef4b208f0a10d7e1cc8adbcedb2"
+SRC_URI[md5sum] = "7df3f5ec7268b7e2c58be85a39584b31"
+SRC_URI[sha256sum] = "bd69349c9ddd6cae9aeaa1149ff8d185c53e81c9ee4e235872245a4d42780376"
 
 GEM_NAME = "inspec"
 

--- a/recipes-rubygems/rubygems-mini-portile2_2.5.1.bb
+++ b/recipes-rubygems/rubygems-mini-portile2_2.5.1.bb
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: MIT
 SUMMARY = "RubyGem: mini_portile2"
 DESCRIPTION = "Simplistic port-like solution for developers"
-HOMEPAGE = "http://github.com/flavorjones/mini_portile"
+HOMEPAGE = "https://github.com/flavorjones/mini_portile"
 
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=ca91f53befc541b9880a8502e7d2699d"
 
-SRC_URI[md5sum] = "996b17722d57f7ce20c6cafc64a2e60a"
-SRC_URI[sha256sum] = "a7a7a09d646619d8efb0898169806266bf2982c70cc131fd285aa25e55bdabc1"
+SRC_URI[md5sum] = "cb5fe30fc3a76f8a17e034d13f8385f5"
+SRC_URI[sha256sum] = "a2677195305dc31b9c7890292967dabefdef266a426334b9b09728040ee9e175"
 
 GEM_NAME = "mini_portile2"
 

--- a/recipes-rubygems/rubygems-ohai_17.0.42.bb
+++ b/recipes-rubygems/rubygems-ohai_17.0.42.bb
@@ -21,8 +21,8 @@ DEPENDS_class-native += "\
     rubygems-wmi-lite-native \
 "
 
-SRC_URI[md5sum] = "0926d3e5f48d7bd9a1d380dbc914f50e"
-SRC_URI[sha256sum] = "037646ef22c126dcd1a485cf84a783ebcd52bb5d76a5149ccbf0f1842cbf7beb"
+SRC_URI[md5sum] = "072153464c8a2c944b6c52a4e7b98938"
+SRC_URI[sha256sum] = "f4d5c2d2a95f43cbae0fc3afe18a1efef51658343d67b2215c2ecedd076e4d49"
 
 GEM_NAME = "ohai"
 

--- a/recipes-rubygems/rubygems-puppet_7.6.1.bb
+++ b/recipes-rubygems/rubygems-puppet_7.6.1.bb
@@ -23,8 +23,8 @@ DEPENDS_class-native += "\
     rubygems-semantic-puppet-native \
 "
 
-SRC_URI[md5sum] = "c1f5978661034b7e718e8866c372cc09"
-SRC_URI[sha256sum] = "a8f029a794f47412e362f5cb04cdf6c4a50e60fe02c87abd3ee47a7ee92c9e0d"
+SRC_URI[md5sum] = "f0b9a3f44dd7d1fce1e147693e971908"
+SRC_URI[sha256sum] = "48febcb3edfe9cc97ec929876f8e552cc33982cd5f8116b34a9581d1bfe6d35a"
 
 GEM_NAME = "puppet"
 

--- a/recipes-rubygems/rubygems-reek_6.0.4.bb
+++ b/recipes-rubygems/rubygems-reek_6.0.4.bb
@@ -6,7 +6,9 @@ HOMEPAGE = "https://github.com/troessner/reek"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://License.txt;md5=59252b93b9ae85dab91487d72990f77c"
 
-EXTRA_RDEPENDS += "rubygems-codeclimate-engine-rb"
+EXTRA_RDEPENDS += "\
+    rubygems-codeclimate-engine-rb \
+"
 
 DEPENDS_class-native += "\
     rubygems-kwalify-native \
@@ -15,8 +17,8 @@ DEPENDS_class-native += "\
     rubygems-rainbow-native \
 "
 
-SRC_URI[md5sum] = "946ff94aaf22808e07117f0dd912251e"
-SRC_URI[sha256sum] = "e262cc8ce4cce4ea259bcdcc50f9c4a90d39f3e0e93b9d42f0c400d882dc8efe"
+SRC_URI[md5sum] = "275f3a29a87228a4f6b2de3940dbf532"
+SRC_URI[sha256sum] = "b70bc41d2f2a34eba744060337752c4575e0b5ac4cf10a86b3afaaf78fc3054a"
 
 GEM_NAME = "reek"
 

--- a/recipes-rubygems/rubygems-specinfra_2.82.25.bb
+++ b/recipes-rubygems/rubygems-specinfra_2.82.25.bb
@@ -13,8 +13,8 @@ DEPENDS_class-native += "\
     rubygems-sfl-native \
 "
 
-SRC_URI[md5sum] = "7434f8ba5124ff928097fdfb487312b2"
-SRC_URI[sha256sum] = "68463aa378d5b5fd48ae149b4b9d7747e40d4890e313c04a0b781ce1c76f3f5b"
+SRC_URI[md5sum] = "67be1709d9af6159b9090f9784ce1f5f"
+SRC_URI[sha256sum] = "bfeb5bf4cd4f75b5d2d075c4e62e8e25b1b2519fc7e7eac428a45cc9f490667d"
 
 GEM_NAME = "specinfra"
 

--- a/recipes-rubygems/rubygems-train-core_3.7.0.bb
+++ b/recipes-rubygems/rubygems-train-core_3.7.0.bb
@@ -15,8 +15,8 @@ DEPENDS_class-native += "\
     rubygems-net-ssh-native \
 "
 
-SRC_URI[md5sum] = "324d5f9930fdd598ce272951829cd982"
-SRC_URI[sha256sum] = "ec1543c32d981e77b8a9f2643efee949add22c7dc2f556a7df0a1b50be8c68f4"
+SRC_URI[md5sum] = "28c6851d8103b0d06fb579eba3595927"
+SRC_URI[sha256sum] = "486735a075655af63a2f226abf0532d27603078a99473213e1addb66f3017abf"
 
 GEM_NAME = "train-core"
 

--- a/recipes-rubygems/rubygems-train_3.7.0.bb
+++ b/recipes-rubygems/rubygems-train_3.7.0.bb
@@ -21,8 +21,8 @@ DEPENDS_class-native += "\
     rubygems-train-winrm-native \
 "
 
-SRC_URI[md5sum] = "1193a3a249e65d32cb769d528fdcc8f1"
-SRC_URI[sha256sum] = "2fb8aa1aaa3e747dcf2fe9c78ad86cb9ec5091ecfdeee585aa3ad845f911822e"
+SRC_URI[md5sum] = "951c9b337ee10df22c7a7a5e0a32a1dc"
+SRC_URI[sha256sum] = "fdbe7774028bbe11e9b48d8973893c43b9801b27d7e4a15054e01d24504cc34f"
 
 GEM_NAME = "train"
 


### PR DESCRIPTION
* chef-utils: update to 17.0.242
* train-core: update to 3.7.0
* chef-config: update to 17.0.242
* googleauth: update to 0.16.2
* inspec-core: update to 4.36.4
* aws-sdk-cloudformation: update to 1.52.0
* mini_portile2: update to 2.5.1
* ohai: update to 17.0.42
* excon: update to 0.81.0
* aws-sdk-organizations: update to 1.59.0
* train: update to 3.7.0
* aws-sdk-s3: update to 1.94.0
* specinfra: update to 2.82.25
* aws-sdk-ecs: update to 1.77.0
* aws-partitions: update to 1.449.0
* puppet: update to 7.6.1
* aws-sdk-ec2: update to 1.235.0
* aws-sdk-eks: update to 1.52.0
* reek: update to 6.0.4
* aws-sdk-cloudfront: update to 1.50.0
* inspec: update to 4.36.4
* aws-sdk-glue: update to 1.87.0
* chef: update to 17.0.242
* inspec-bin: update to 4.36.4