### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.456.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.456.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-SRC_URI[md5sum] = "9cac9a7bd6dd5922509d1d5249cfd58f"
-SRC_URI[sha256sum] = "a5447aed6cbd4810e7306e59176688e1bec09cba68c2487406658d90a6ae5537"
+SRC_URI[md5sum] = "24816915487a2206df74b06f3c1dd822"
+SRC_URI[sha256sum] = "02a60f14390425f8464c774f23d55e32fc3f5fe48edd6e16ad8f8728ea9fa6bc"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatchevents_1.46.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatchevents_1.46.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "0d729ed4162e216feba1e9b44ae0dc0e"
-SRC_URI[sha256sum] = "2101c6c9522a7aadd18e26532ad0190af3f80194f4ab26ca2a1578246e382eec"
+SRC_URI[md5sum] = "82e47b50896879f65e42e62bbdb764f2"
+SRC_URI[sha256sum] = "6218116e13fe2d2d41a2f6567b2ff389c567503fe50dda29b18652de5adcdef5"
 
 GEM_NAME = "aws-sdk-cloudwatchevents"
 

--- a/recipes-rubygems/rubygems-aws-sdk-configservice_1.62.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-configservice_1.62.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "cee0c6f57959d267e8337e6599e32324"
-SRC_URI[sha256sum] = "8b3481cfc6130cd5b25b6bd15c678576f5fb88a0e1851c2b640749f28694cced"
+SRC_URI[md5sum] = "eba9af60e0acb75ce364eead06cb8f54"
+SRC_URI[sha256sum] = "b38cc03b1d51740dd64270c0a97ffe6b7c066560d057e088c2c99700ae84d16f"
 
 GEM_NAME = "aws-sdk-configservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.236.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.236.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "d8e184a04c93ae7c49fed74ad36e2fd1"
-SRC_URI[sha256sum] = "64885afb7da2ca773a1130ebe365633daf8da3950585cba1210d209e4b7696cd"
+SRC_URI[md5sum] = "d7b203f791081d3d354aa7e0c4dfc9a5"
+SRC_URI[sha256sum] = "820d7f7b975fd322c30782e57863b0714b5421c3a1be72852503a55634c18ff4"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.78.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.78.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "c235d4d95f93d6f803148d7fcbb2d07f"
-SRC_URI[sha256sum] = "95137a6c3ee53162ad7acce5c9bc445d61b427e9f377879a490a815dfe1cc01d"
+SRC_URI[md5sum] = "01ac221b2740a9583e2a65ee33f2988a"
+SRC_URI[sha256sum] = "2b8ab524fdb852d917e4d253977387e8ecd7f9b1487115be6bb4a9788558f034"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eks_1.53.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eks_1.53.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "f4335d7a5225eea624bda0dea866d450"
-SRC_URI[sha256sum] = "8c84093a9150863df3f5d99767252ab9d31fa960ef728bd02eea79f3f108abdc"
+SRC_URI[md5sum] = "4fbffc682635afa4f6da1df077d21f71"
+SRC_URI[sha256sum] = "5f565db760b998bbc8d558480bc0c557788d0579b31ec6bd8b5bbc42131d9668"
 
 GEM_NAME = "aws-sdk-eks"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticsearchservice_1.52.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticsearchservice_1.52.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "bcf364fa84b3407e7acdc2cd55ce725a"
-SRC_URI[sha256sum] = "1ba200d6986689fb445cc7eb60a200c6d5fa8f1262fa158d5ca24bf47abe8842"
+SRC_URI[md5sum] = "b2e8463f3a9a44bc1b653701a023d447"
+SRC_URI[sha256sum] = "d8219d19bc57d411e1d63348c2c7f36c272232b06b258d43276294745e25b817"
 
 GEM_NAME = "aws-sdk-elasticsearchservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-securityhub_1.46.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-securityhub_1.46.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "7a9a53f80d05c61ee7b1db45c0a2647e"
-SRC_URI[sha256sum] = "fec483669f43079713c32c44b9b9f5c3f2ae7504c8598f50bebdf4a4a04c75f3"
+SRC_URI[md5sum] = "7459d71f8e39ddf09f5c6645dfba31d6"
+SRC_URI[sha256sum] = "b17fd76fb78785cbe839d7f965e9c9837d4deb8cb10dbc755f745809a230dcc2"
 
 GEM_NAME = "aws-sdk-securityhub"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ssm_1.110.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ssm_1.110.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "c8f218763a2857d77910c5286b5791fb"
-SRC_URI[sha256sum] = "210413b6a9752ab60c735e987ee4521ece00d224561dce05215d43214a4a62be"
+SRC_URI[md5sum] = "a420b57486ef1d9345c558ce5dd45d59"
+SRC_URI[sha256sum] = "5b2d91baeaa43279a50938848a159b87eb06b031d6ee6ffa0cc24d4dcee66420"
 
 GEM_NAME = "aws-sdk-ssm"
 

--- a/recipes-rubygems/rubygems-chef-config_17.1.35.bb
+++ b/recipes-rubygems/rubygems-chef-config_17.1.35.bb
@@ -15,8 +15,8 @@ DEPENDS_class-native += "\
     rubygems-tomlrb-native \
 "
 
-SRC_URI[md5sum] = "57719f2b0ddf7dd8cb9f6b06bec44708"
-SRC_URI[sha256sum] = "b4e0bf818d582295fa51b4e45eb717e60cfb0b912d57d8b62a893217c3642a4a"
+SRC_URI[md5sum] = "e322a98e092274a9c8711e68c49d4f8b"
+SRC_URI[sha256sum] = "826f3cf5feaba38164d6947aea8599375cc22f06f01ad405ad0572f6eb6c3537"
 
 GEM_NAME = "chef-config"
 

--- a/recipes-rubygems/rubygems-chef-utils_17.1.35.bb
+++ b/recipes-rubygems/rubygems-chef-utils_17.1.35.bb
@@ -10,8 +10,8 @@ DEPENDS_class-native += "\
     rubygems-concurrent-ruby-native \
 "
 
-SRC_URI[md5sum] = "66cb37aa745139e70d52c903b2180034"
-SRC_URI[sha256sum] = "bb7970dc43199ce891ed3472935881626fc676c5fbc1a7348aee50d478cc3a49"
+SRC_URI[md5sum] = "6d93872cc0140290adec05a083d14d1c"
+SRC_URI[sha256sum] = "3e1768ebb0498e48cd36200ec61b7570b6c6ff7494731d2a93a287d7ec7b6adb"
 
 GEM_NAME = "chef-utils"
 

--- a/recipes-rubygems/rubygems-chef_17.1.35.bb
+++ b/recipes-rubygems/rubygems-chef_17.1.35.bb
@@ -8,18 +8,15 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=8f7bb094c7232b058c7e9f2e431f389c"
 
 DEPENDS_class-native += "\
     rubygems-addressable-native \
-    rubygems-bcrypt-pbkdf-native \
     rubygems-chef-config-native \
     rubygems-chef-utils-native \
     rubygems-chef-vault-native \
     rubygems-chef-zero-native \
     rubygems-diff-lcs-native \
-    rubygems-ed25519-native \
     rubygems-erubis-native \
     rubygems-ffi-libarchive-native \
     rubygems-ffi-native \
     rubygems-ffi-yajl-native \
-    rubygems-highline-native \
     rubygems-iniparse-native \
     rubygems-inspec-core-native \
     rubygems-license-acceptance-native \
@@ -29,23 +26,17 @@ DEPENDS_class-native += "\
     rubygems-mixlib-log-native \
     rubygems-mixlib-shellout-native \
     rubygems-net-sftp-native \
-    rubygems-net-ssh-multi-native \
-    rubygems-net-ssh-native \
     rubygems-ohai-native \
-    rubygems-pastel-native \
     rubygems-plist-native \
     rubygems-proxifier-native \
     rubygems-syslog-logger-native \
     rubygems-train-core-native \
     rubygems-train-winrm-native \
-    rubygems-tty-prompt-native \
-    rubygems-tty-screen-native \
-    rubygems-tty-table-native \
     rubygems-uuidtools-native \
 "
 
-SRC_URI[md5sum] = "114636a477643f69a6d0e5fdc9066038"
-SRC_URI[sha256sum] = "958f9a6bd73a1ecb34187368ca0d72735e2f1c2b4b43e6ca69920ca54a6d565f"
+SRC_URI[md5sum] = "044041ebdf6443a86f501aca7381a4c3"
+SRC_URI[sha256sum] = "55589012ef8e01dc6bb7fc77b662c45a8339aba24b68c6448d13fae2c65b863d"
 
 GEM_NAME = "chef"
 
@@ -64,18 +55,15 @@ do_install_append() {
 
 RDEPENDS_${PN}_class-target += "\
     rubygems-addressable \
-    rubygems-bcrypt-pbkdf \
     rubygems-chef-config \
     rubygems-chef-utils \
     rubygems-chef-vault \
     rubygems-chef-zero \
     rubygems-diff-lcs \
-    rubygems-ed25519 \
     rubygems-erubis \
     rubygems-ffi \
     rubygems-ffi-libarchive \
     rubygems-ffi-yajl \
-    rubygems-highline \
     rubygems-iniparse \
     rubygems-inspec-core \
     rubygems-license-acceptance \
@@ -85,18 +73,12 @@ RDEPENDS_${PN}_class-target += "\
     rubygems-mixlib-log \
     rubygems-mixlib-shellout \
     rubygems-net-sftp \
-    rubygems-net-ssh \
-    rubygems-net-ssh-multi \
     rubygems-ohai \
-    rubygems-pastel \
     rubygems-plist \
     rubygems-proxifier \
     rubygems-syslog-logger \
     rubygems-train-core \
     rubygems-train-winrm \
-    rubygems-tty-prompt \
-    rubygems-tty-screen \
-    rubygems-tty-table \
     rubygems-uuidtools \
 "
 

--- a/recipes-rubygems/rubygems-docile_1.4.0.bb
+++ b/recipes-rubygems/rubygems-docile_1.4.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://ms-ati.github.io/docile/"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e74ce31842082484e7525142a0cae01f"
 
-SRC_URI[md5sum] = "b07475d7f767d0b3f260223721369986"
-SRC_URI[sha256sum] = "7f980b18ea99e95aed225efdd1694d9d8e10e3fdbd133718c6006d8e9bceedae"
+SRC_URI[md5sum] = "346d8ca3988c5e5dab44d50545e9b239"
+SRC_URI[sha256sum] = "5f1734bde23721245c20c3d723e76c104208e1aa01277a69901ce770f0ebb8d3"
 
 GEM_NAME = "docile"
 

--- a/recipes-rubygems/rubygems-inspec-bin_4.37.8.bb
+++ b/recipes-rubygems/rubygems-inspec-bin_4.37.8.bb
@@ -10,8 +10,8 @@ DEPENDS_class-native += "\
     rubygems-inspec-native \
 "
 
-SRC_URI[md5sum] = "76735fbe20f8041e55b72db69e71fcc2"
-SRC_URI[sha256sum] = "1883a67b5f425d99cfe4c411db501f1b7a48f9d34eb53285ccd53271e632790a"
+SRC_URI[md5sum] = "46be8bdf098f5deabb31216f51c8d3df"
+SRC_URI[sha256sum] = "05cb2aa58f748a9039cca54cd48c09df35c01f70a184eb1f8bba7fe35266ec5f"
 
 GEM_NAME = "inspec-bin"
 

--- a/recipes-rubygems/rubygems-inspec-core_4.37.8.bb
+++ b/recipes-rubygems/rubygems-inspec-core_4.37.8.bb
@@ -31,8 +31,8 @@ DEPENDS_class-native += "\
     rubygems-tty-table-native \
 "
 
-SRC_URI[md5sum] = "1ea7b25d74009214fe5483025a7704e0"
-SRC_URI[sha256sum] = "28bce098274e06b44c2ecdf05bcf099ccb7f3e31e7b3d1d2d0689ef1f05cb45f"
+SRC_URI[md5sum] = "58d9bb382ae56d3ef5de9a12a7e4002f"
+SRC_URI[sha256sum] = "1377d7fbda2fa8a55d3ed8e302c5f16539a285e22bb9e4c751284a87dcaa202a"
 
 GEM_NAME = "inspec-core"
 

--- a/recipes-rubygems/rubygems-inspec_4.37.8.bb
+++ b/recipes-rubygems/rubygems-inspec_4.37.8.bb
@@ -17,8 +17,8 @@ DEPENDS_class-native += "\
     rubygems-train-winrm-native \
 "
 
-SRC_URI[md5sum] = "7c6e5f768a8d84d1089925776f190e26"
-SRC_URI[sha256sum] = "24fd03365fc58a165f4f9b94f8287a20dce8a5877e04ff2c778ad18f5271bd09"
+SRC_URI[md5sum] = "092d9705cc0c65353767e42634b7896a"
+SRC_URI[sha256sum] = "770e5d68ab9e06f8460cab5db7057b4d7aebd4bb8bebbb1ffa81dd4c7651f287"
 
 GEM_NAME = "inspec"
 

--- a/recipes-rubygems/rubygems-nokogiri_1.11.4.bb
+++ b/recipes-rubygems/rubygems-nokogiri_1.11.4.bb
@@ -23,8 +23,8 @@ GEM_INSTALL_FLAGS += "\
     --use-system-libraries \
 "
 
-SRC_URI[md5sum] = "5daafd86dd2c292005170da77a9708e6"
-SRC_URI[sha256sum] = "a09beb5c1fa55da31ee494da8c6ad34b2636d099d6c04b964c7f51f15a45a7a5"
+SRC_URI[md5sum] = "26e4e5edaa30354c5468be7416051412"
+SRC_URI[sha256sum] = "2bdd84d3bb168ab21a0e8d65f43194593f3b77b0016fa5de2dfaeac951fc2e17"
 
 GEM_NAME = "nokogiri"
 

--- a/recipes-rubygems/rubygems-ohai_17.1.0.bb
+++ b/recipes-rubygems/rubygems-ohai_17.1.0.bb
@@ -21,8 +21,8 @@ DEPENDS_class-native += "\
     rubygems-wmi-lite-native \
 "
 
-SRC_URI[md5sum] = "072153464c8a2c944b6c52a4e7b98938"
-SRC_URI[sha256sum] = "f4d5c2d2a95f43cbae0fc3afe18a1efef51658343d67b2215c2ecedd076e4d49"
+SRC_URI[md5sum] = "6fb471f3ed24be521945114e7a2e8920"
+SRC_URI[sha256sum] = "064261cfc51f2c2a841d0081a2b94705491382871dfc64c3e916ab57f736b511"
 
 GEM_NAME = "ohai"
 

--- a/recipes-rubygems/rubygems-slop_4.9.0.bb
+++ b/recipes-rubygems/rubygems-slop_4.9.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "http://github.com/leejarvis/slop"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=40575ded674b04c083ce6818c01f0282"
 
-SRC_URI[md5sum] = "f6d6720a1fef617e77ae2feab9e71456"
-SRC_URI[sha256sum] = "a3d5be3ad304b9dbd00b7c18a0a067b09ff6fd28485d4c6b05adb294d1eea115"
+SRC_URI[md5sum] = "a5b97ab00624c4d1272293d50af1f734"
+SRC_URI[sha256sum] = "32a396ad5e092f6a7b36122976570ac778fbe04f19be2a0dc683ac7189d4c626"
 
 GEM_NAME = "slop"
 


### PR DESCRIPTION
* chef-utils: update to 17.1.35
* chef-config: update to 17.1.35
* inspec-core: update to 4.37.8
* docile: update to 1.4.0
* aws-sdk-elasticsearchservice: update to 1.52.0
* nokogiri: update to 1.11.4
* aws-partitions: update to 1.456.0
* aws-sdk-securityhub: update to 1.46.0
* aws-sdk-configservice: update to 1.62.0
* aws-sdk-eks: update to 1.53.0
* aws-sdk-ecs: update to 1.78.0
* aws-sdk-cloudwatchevents: update to 1.46.0
* aws-sdk-ec2: update to 1.236.0
* ohai: update to 17.1.0
* inspec: update to 4.37.8
* aws-sdk-ssm: update to 1.110.0
* inspec-bin: update to 4.37.8
* chef: update to 17.1.35
* slop: update to 4.9.0