### PR TITLE
Add recipes / tests to get a running jekyll

### DIFF
--- a/lib/oeqa/runtime/cases/rubygems_exceptions.py
+++ b/lib/oeqa/runtime/cases/rubygems_exceptions.py
@@ -15,6 +15,7 @@ class RubyGemsTestExceptions():
         "gauntlet_flay": "causes a SIGKILL",
         "gauntlet_flog": "causes a SIGKILL",
         "gauntlet_grep": "causes a SIGKILL",
+        "jekyll-sass-converter": "module:Jekyll: uninitialized constant Jekyll::Page (NameError)",
         "gauntlet_parser": "causes a SIGKILL",
         "ruby20_parser": "not the parser you are looking for",
         "ruby21_parser": "not the parser you are looking for",

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_colorator.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_colorator.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_colorator(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_colorator(self):
+        self.gem_is_installed("colorator")
+
+    def test_load_colorator(self):
+        self.gem_is_loadable("colorator")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_em_websocket.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_em_websocket.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_em_websocket(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_em_websocket(self):
+        self.gem_is_installed("em-websocket")
+
+    def test_load_em_websocket(self):
+        self.gem_is_loadable("em-websocket")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_eventmachine.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_eventmachine.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_eventmachine(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_eventmachine(self):
+        self.gem_is_installed("eventmachine")
+
+    def test_load_eventmachine(self):
+        self.gem_is_loadable("eventmachine")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_forwardable_extended.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_forwardable_extended.py
@@ -1,0 +1,7 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_forwardable_extended(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_forwardable_extended(self):
+        self.gem_is_installed("forwardable-extended")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_http_parser.rb.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_http_parser.rb.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_http_parser.rb(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_http_parser.rb(self):
+        self.gem_is_installed("http_parser.rb")
+
+    def test_load_http_parser(self):
+        self.gem_is_loadable("http_parser")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_jekyll.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_jekyll.py
@@ -1,0 +1,13 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_jekyll(RubyGemsTestUtils):
+
+    def test_exec_jekyll(self):
+        self.gem_exec_wrapper("jekyll")
+
+    def test_gem_list_rubygems_jekyll(self):
+        self.gem_is_installed("jekyll")
+
+    def test_load_jekyll(self):
+        self.gem_is_loadable("jekyll")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_jekyll_sass_converter.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_jekyll_sass_converter.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_jekyll_sass_converter(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_jekyll_sass_converter(self):
+        self.gem_is_installed("jekyll-sass-converter")
+
+    def test_load_jekyll_sass_converter(self):
+        self.gem_is_loadable("jekyll-sass-converter")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_jekyll_watch.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_jekyll_watch.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_jekyll_watch(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_jekyll_watch(self):
+        self.gem_is_installed("jekyll-watch")
+
+    def test_load_jekyll_watch(self):
+        self.gem_is_loadable("jekyll-watch")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_kramdown.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_kramdown.py
@@ -1,0 +1,13 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_kramdown(RubyGemsTestUtils):
+
+    def test_exec_kramdown(self):
+        self.gem_exec_wrapper("kramdown")
+
+    def test_gem_list_rubygems_kramdown(self):
+        self.gem_is_installed("kramdown")
+
+    def test_load_kramdown(self):
+        self.gem_is_loadable("kramdown")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_kramdown_parser_gfm.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_kramdown_parser_gfm.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_kramdown_parser_gfm(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_kramdown_parser_gfm(self):
+        self.gem_is_installed("kramdown-parser-gfm")
+
+    def test_load_kramdown_parser_gfm(self):
+        self.gem_is_loadable("kramdown-parser-gfm")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_liquid.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_liquid.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_liquid(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_liquid(self):
+        self.gem_is_installed("liquid")
+
+    def test_load_liquid(self):
+        self.gem_is_loadable("liquid")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_listen.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_listen.py
@@ -1,0 +1,13 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_listen(RubyGemsTestUtils):
+
+    def test_exec_listen(self):
+        self.gem_exec_wrapper("listen")
+
+    def test_gem_list_rubygems_listen(self):
+        self.gem_is_installed("listen")
+
+    def test_load_listen(self):
+        self.gem_is_loadable("listen")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_mercenary.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_mercenary.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_mercenary(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_mercenary(self):
+        self.gem_is_installed("mercenary")
+
+    def test_load_mercenary(self):
+        self.gem_is_loadable("mercenary")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_pathutil.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_pathutil.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_pathutil(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_pathutil(self):
+        self.gem_is_installed("pathutil")
+
+    def test_load_pathutil(self):
+        self.gem_is_loadable("pathutil")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_rb_fsevent.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_rb_fsevent.py
@@ -1,0 +1,13 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_rb_fsevent(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_rb_fsevent(self):
+        self.gem_is_installed("rb-fsevent")
+
+    def test_load_otnetstring(self):
+        self.gem_is_loadable("otnetstring")
+
+    def test_load_rb_fsevent(self):
+        self.gem_is_loadable("rb-fsevent")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_rb_inotify.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_rb_inotify.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_rb_inotify(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_rb_inotify(self):
+        self.gem_is_installed("rb-inotify")
+
+    def test_load_rb_inotify(self):
+        self.gem_is_loadable("rb-inotify")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_rouge.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_rouge.py
@@ -1,0 +1,13 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_rouge(RubyGemsTestUtils):
+
+    def test_exec_rougify(self):
+        self.gem_exec_wrapper("rougify")
+
+    def test_gem_list_rubygems_rouge(self):
+        self.gem_is_installed("rouge")
+
+    def test_load_rouge(self):
+        self.gem_is_loadable("rouge")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_safe_yaml.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_safe_yaml.py
@@ -1,0 +1,13 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_safe_yaml(RubyGemsTestUtils):
+
+    def test_exec_safe_yaml(self):
+        self.gem_exec_wrapper("safe_yaml")
+
+    def test_gem_list_rubygems_safe_yaml(self):
+        self.gem_is_installed("safe_yaml")
+
+    def test_load_safe_yaml(self):
+        self.gem_is_loadable("safe_yaml")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_sassc.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_sassc.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_sassc(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_sassc(self):
+        self.gem_is_installed("sassc")
+
+    def test_load_sassc(self):
+        self.gem_is_loadable("sassc")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_terminal_table.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_terminal_table.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_terminal_table(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_terminal_table(self):
+        self.gem_is_installed("terminal-table")
+
+    def test_load_terminal_table(self):
+        self.gem_is_loadable("terminal-table")
+

--- a/packagegroups-rubygems/packagegroup-rubygems.bb
+++ b/packagegroups-rubygems/packagegroup-rubygems.bb
@@ -90,6 +90,7 @@ RDEPENDS_${PN} += "\
     rubygems-codeclimate-engine-rb \
     rubygems-coderay \
     rubygems-coercible \
+    rubygems-colorator \
     rubygems-concurrent-ruby \
     rubygems-connection-pool \
     rubygems-declarative \
@@ -101,9 +102,11 @@ RDEPENDS_${PN} += "\
     rubygems-docker-api \
     rubygems-domain-name \
     rubygems-ed25519 \
+    rubygems-em-websocket \
     rubygems-equalizer \
     rubygems-erubi \
     rubygems-erubis \
+    rubygems-eventmachine \
     rubygems-excon \
     rubygems-facter \
     rubygems-faraday \
@@ -118,6 +121,7 @@ RDEPENDS_${PN} += "\
     rubygems-ffi-yajl \
     rubygems-flay \
     rubygems-flog \
+    rubygems-forwardable-extended \
     rubygems-fuzzyurl \
     rubygems-gauntlet \
     rubygems-gems \
@@ -133,6 +137,7 @@ RDEPENDS_${PN} += "\
     rubygems-highline \
     rubygems-hocon \
     rubygems-http-cookie \
+    rubygems-http-parser.rb \
     rubygems-httpclient \
     rubygems-i18n \
     rubygems-ice-nine \
@@ -142,17 +147,25 @@ RDEPENDS_${PN} += "\
     rubygems-inspec-bin \
     rubygems-inspec-core \
     rubygems-ipaddress \
+    rubygems-jekyll \
+    rubygems-jekyll-sass-converter \
+    rubygems-jekyll-watch \
     rubygems-jmespath \
     rubygems-json \
     rubygems-jwt \
+    rubygems-kramdown \
+    rubygems-kramdown-parser-gfm \
     rubygems-kwalify \
     rubygems-launchy \
     rubygems-libyajl2 \
     rubygems-license-acceptance \
+    rubygems-liquid \
+    rubygems-listen \
     rubygems-little-plugger \
     rubygems-locale \
     rubygems-logging \
     rubygems-memoist \
+    rubygems-mercenary \
     rubygems-method-source \
     rubygems-mime-types \
     rubygems-mime-types-data \
@@ -186,6 +199,7 @@ RDEPENDS_${PN} += "\
     rubygems-parslet \
     rubygems-pastel \
     rubygems-path-expander \
+    rubygems-pathutil \
     rubygems-plist \
     rubygems-proxifier \
     rubygems-pry \
@@ -195,9 +209,12 @@ RDEPENDS_${PN} += "\
     rubygems-puppetmodule-netdev-stdlib \
     rubygems-rack \
     rubygems-rainbow \
+    rubygems-rb-fsevent \
+    rubygems-rb-inotify \
     rubygems-reek \
     rubygems-representable \
     rubygems-retriable \
+    rubygems-rouge \
     rubygems-rspec \
     rubygems-rspec-core \
     rubygems-rspec-expectations \
@@ -210,6 +227,8 @@ RDEPENDS_${PN} += "\
     rubygems-rubycritic \
     rubygems-rubyntlm \
     rubygems-rubyzip \
+    rubygems-safe-yaml \
+    rubygems-sassc \
     rubygems-scanf \
     rubygems-semantic-puppet \
     rubygems-semverse \
@@ -227,6 +246,7 @@ RDEPENDS_${PN} += "\
     rubygems-strings-ansi \
     rubygems-syslog-logger \
     rubygems-systemu \
+    rubygems-terminal-table \
     rubygems-thor \
     rubygems-thread-safe \
     rubygems-tilt \

--- a/recipes-rubygems/rubygems-colorator_1.1.0.bb
+++ b/recipes-rubygems/rubygems-colorator_1.1.0.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: colorator"
+DESCRIPTION = "Colorize your text in the terminal."
+HOMEPAGE = "https://github.com/octopress/colorator"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=7142c47e8abbc7d3d61d8755d76dc42e"
+
+SRC_URI[md5sum] = "1c8e8ee6c0cf7ef7d531343056f94ad5"
+SRC_URI[sha256sum] = "e2f85daf57af47d740db2a32191d1bdfb0f6503a0dfbc8327d0c9154d5ddfc38"
+
+GEM_NAME = "colorator"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-em-websocket_0.5.2.bb
+++ b/recipes-rubygems/rubygems-em-websocket_0.5.2.bb
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: em-websocket"
+DESCRIPTION = "EventMachine based WebSocket server"
+HOMEPAGE = "http://github.com/igrigorik/em-websocket"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENCE;md5=4380eb54de8fb059e00993d1f4a8537f"
+
+DEPENDS_class-native += "\
+    rubygems-eventmachine-native \
+    rubygems-http-parser.rb-native \
+"
+
+SRC_URI[md5sum] = "a730813935b12faf8d6780d4f7e5e19e"
+SRC_URI[sha256sum] = "6bae6d8dd9c05c0d1619aef91903c82542de7a15fa92e0110d13a8324eafe1d5"
+
+GEM_NAME = "em-websocket"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-eventmachine \
+    rubygems-http-parser.rb \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-eventmachine_1.2.7.bb
+++ b/recipes-rubygems/rubygems-eventmachine_1.2.7.bb
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: eventmachine"
+DESCRIPTION = "EventMachine implements a fast, single-threaded engine for arbitrary networkcommunications"
+HOMEPAGE = "http://rubyeventmachine.com"
+
+LICENSE = "Ruby & GPL-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=270149a18e664d261350cfe727055898"
+
+SRC_URI[md5sum] = "c9c775bac51d47404fa1cb27a704117b"
+SRC_URI[sha256sum] = "994016e42aa041477ba9cff45cbe50de2047f25dd418eba003e84f0d16560972"
+
+GEM_NAME = "eventmachine"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+do_install_append() {
+    # avoid unwanted dependencies: we do not support java
+    rm -f ${D}/${libdir}/ruby/gems/3.0.0/gems/eventmachine-${PV}/lib/jeventmachine.rb
+}
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-forwardable-extended_2.6.0.bb
+++ b/recipes-rubygems/rubygems-forwardable-extended_2.6.0.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: forwardable-extended"
+DESCRIPTION = "Forwardable with hash, and instance variable extensions."
+HOMEPAGE = "http://github.com/envygeeks/forwardable-extended"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=923993a758a91936eb181a9eadb12dd3"
+
+SRC_URI[md5sum] = "37cb8b939ad6d29b6b51b7e8c93de0b2"
+SRC_URI[sha256sum] = "1bec948c469bbddfadeb3bd90eb8c85f6e627a412a3e852acfd7eaedbac3ec97"
+
+GEM_NAME = "forwardable-extended"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-http-parser.rb_0.6.0.bb
+++ b/recipes-rubygems/rubygems-http-parser.rb_0.6.0.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: http_parser.rb"
+DESCRIPTION = "Ruby bindings to http://github.com/ry/http-parser and http://github.com/a2800276/http-parser.java"
+HOMEPAGE = "http://github.com/tmm1/http_parser.rb"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE-MIT;md5=157efc3766c6d07d3d857ebbab43351a"
+
+SRC_URI[md5sum] = "1c9d471b7fd78d5857d6d12fe016278e"
+SRC_URI[sha256sum] = "f11d0aec50ef26a7d1f991e627ac88acdb5979282aeba7a5c3be6ce0636ed196"
+
+GEM_NAME = "http_parser.rb"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-jekyll-sass-converter_2.1.0.bb
+++ b/recipes-rubygems/rubygems-jekyll-sass-converter_2.1.0.bb
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: jekyll-sass-converter"
+DESCRIPTION = "A basic Sass converter for Jekyll."
+HOMEPAGE = "https://github.com/jekyll/jekyll-sass-converter"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+DEPENDS_class-native += "\
+    rubygems-sassc-native \
+"
+
+SRC_URI[md5sum] = "8a55ea7e8984f861d9bcdf38b8f43ff8"
+SRC_URI[sha256sum] = "bb25965bfdec2c61220192f45d9358d34a9fce388f72ec95119fc6cc09c9cc12"
+
+GEM_NAME = "jekyll-sass-converter"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-sassc \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-jekyll-watch_2.2.1.bb
+++ b/recipes-rubygems/rubygems-jekyll-watch_2.2.1.bb
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: jekyll-watch"
+DESCRIPTION = "Rebuild your Jekyll site when a file changes with the `--watch` switch."
+HOMEPAGE = "https://github.com/jekyll/jekyll-watch"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+DEPENDS_class-native += "\
+    rubygems-listen-native \
+"
+
+SRC_URI[md5sum] = "db6ffa7da229622f10fdc17bae627515"
+SRC_URI[sha256sum] = "bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1"
+
+GEM_NAME = "jekyll-watch"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-listen \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-jekyll_4.2.0.bb
+++ b/recipes-rubygems/rubygems-jekyll_4.2.0.bb
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: jekyll"
+DESCRIPTION = "Jekyll is a simple, blog aware, static site generator."
+HOMEPAGE = "https://jekyllrb.com"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=bf9972594da0ef277f46d8d9e5902582"
+
+DEPENDS_class-native += "\
+    rubygems-addressable-native \
+    rubygems-colorator-native \
+    rubygems-em-websocket-native \
+    rubygems-i18n-native \
+    rubygems-jekyll-sass-converter-native \
+    rubygems-jekyll-watch-native \
+    rubygems-kramdown-native \
+    rubygems-kramdown-parser-gfm-native \
+    rubygems-liquid-native \
+    rubygems-mercenary-native \
+    rubygems-pathutil-native \
+    rubygems-rouge-native \
+    rubygems-safe-yaml-native \
+    rubygems-terminal-table-native \
+    rubygems-webrick-native \
+"
+
+SRC_URI[md5sum] = "719a878cc0c771db7f39dbc361355020"
+SRC_URI[sha256sum] = "d86ae4bfaa09337af7666d0e8ab1b8dba5ca3750d496eea5ca4c232ed1811333"
+
+GEM_NAME = "jekyll"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-addressable \
+    rubygems-colorator \
+    rubygems-em-websocket \
+    rubygems-i18n \
+    rubygems-jekyll-sass-converter \
+    rubygems-jekyll-watch \
+    rubygems-kramdown \
+    rubygems-kramdown-parser-gfm \
+    rubygems-liquid \
+    rubygems-mercenary \
+    rubygems-pathutil \
+    rubygems-rouge \
+    rubygems-safe-yaml \
+    rubygems-terminal-table \
+    rubygems-webrick \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-kramdown-parser-gfm_1.1.0.bb
+++ b/recipes-rubygems/rubygems-kramdown-parser-gfm_1.1.0.bb
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: kramdown-parser-gfm"
+DESCRIPTION = "kramdown-parser-gfm provides a kramdown parser for the GFM dialect of Markdown"
+HOMEPAGE = "https://github.com/kramdown/parser-gfm"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=22e426aa1c3c4ebfeb7201e70fcefa60"
+
+DEPENDS_class-native += "\
+    rubygems-kramdown-native \
+"
+
+SRC_URI[md5sum] = "1bc966d087bbb0eeb99fb877773173f5"
+SRC_URI[sha256sum] = "fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729"
+
+GEM_NAME = "kramdown-parser-gfm"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-kramdown \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-kramdown_2.3.1.bb
+++ b/recipes-rubygems/rubygems-kramdown_2.3.1.bb
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: kramdown"
+DESCRIPTION = "kramdown is yet-another-markdown-parser but fast, pure Ruby,using a strict syntax definition and supporting several common extensions."
+HOMEPAGE = "http://kramdown.gettalong.org"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=efa42ef946dcb15e4ee38ea3aeedf2b0"
+
+DEPENDS_class-native += "\
+    rubygems-rexml-native \
+"
+
+SRC_URI[md5sum] = "1324f4af5b0b15d96066d2654fbe7d15"
+SRC_URI[sha256sum] = "59e938cfa42a3d6169b295727fe09c4c91d742336c8fbd1042529f4db664ab49"
+
+GEM_NAME = "kramdown"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-rexml \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-liquid_5.0.1.bb
+++ b/recipes-rubygems/rubygems-liquid_5.0.1.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: liquid"
+DESCRIPTION = "A secure, non-evaling end user template engine with aesthetic markup."
+HOMEPAGE = "http://www.liquidmarkup.org"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=f2a65a7b0b338ce2e5c688284735d982"
+
+SRC_URI[md5sum] = "c6e491e43afa7962ee8421d4a3e25f4e"
+SRC_URI[sha256sum] = "745771f725b8f6541c4ed942755cb43b7b8d7bb4d4ab9437ba074cebd95772d8"
+
+GEM_NAME = "liquid"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-listen_3.5.1.bb
+++ b/recipes-rubygems/rubygems-listen_3.5.1.bb
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: listen"
+DESCRIPTION = "The Listen gem listens to file modifications and notifies you about the changes"
+HOMEPAGE = "https://github.com/guard/listen"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=5cce4e14a2b69c74e9c91d66a93c7b65"
+
+DEPENDS_class-native += "\
+    rubygems-rb-fsevent-native \
+    rubygems-rb-inotify-native \
+"
+
+SRC_URI[md5sum] = "13acebd3800bdea503c24808f61a3847"
+SRC_URI[sha256sum] = "d2f6425068347454936c75bf3b9fc0f925b40d17ba7df752031c8c083b195b40"
+
+GEM_NAME = "listen"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-rb-fsevent \
+    rubygems-rb-inotify \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-mercenary_0.4.0.bb
+++ b/recipes-rubygems/rubygems-mercenary_0.4.0.bb
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: mercenary"
+DESCRIPTION = "Lightweight and flexible library for writing command-line apps in Ruby."
+HOMEPAGE = "https://github.com/jekyll/mercenary"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=a8f56631a8cc9c1d0b0ef11290556bf9"
+
+SRC_URI[md5sum] = "8bc01b5577bc5738bd5130aa51929236"
+SRC_URI[sha256sum] = "b25a1e4a59adca88665e08e24acf0af30da5b5d859f7d8f38fba52c28f405138"
+
+GEM_NAME = "mercenary"
+
+EXTRA_RDEPENDS += "bash"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-pathutil_0.16.2.bb
+++ b/recipes-rubygems/rubygems-pathutil_0.16.2.bb
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: pathutil"
+DESCRIPTION = "Like Pathname but a little less insane."
+HOMEPAGE = "http://github.com/envygeeks/pathutil"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=f940cffeb4fe06731c38f620cdcd7767"
+
+DEPENDS_class-native += "\
+    rubygems-forwardable-extended-native \
+"
+
+SRC_URI[md5sum] = "733b5e1d35c08b25b031c6bf2f31b273"
+SRC_URI[sha256sum] = "e43b74365631cab4f6d5e4228f812927efc9cb2c71e62976edcb252ee948d589"
+
+GEM_NAME = "pathutil"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-forwardable-extended \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-rb-fsevent_0.11.0.bb
+++ b/recipes-rubygems/rubygems-rb-fsevent_0.11.0.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: rb-fsevent"
+DESCRIPTION = "FSEvents API with Signals catching (without RubyCocoa)"
+HOMEPAGE = "http://rubygems.org/gems/rb-fsevent"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=0f54ca712fa5d09964ad633d7ab46d36"
+
+SRC_URI[md5sum] = "4917afbf78a17a3804cb0c8f64b245d8"
+SRC_URI[sha256sum] = "3a02b6360c856cc16e7f62382573b238f5cfb61a48169dd4c83b842c094b5de3"
+
+GEM_NAME = "rb-fsevent"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-rb-inotify_0.10.1.bb
+++ b/recipes-rubygems/rubygems-rb-inotify_0.10.1.bb
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: rb-inotify"
+DESCRIPTION = "A Ruby wrapper for Linux inotify, using FFI"
+HOMEPAGE = "https://github.com/guard/rb-inotify"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=98201cb3e99717097b99fa767e46ffbb"
+
+DEPENDS_class-native += "\
+    rubygems-ffi-native \
+"
+
+SRC_URI[md5sum] = "ade741fff16c0fd7b8c3117219170543"
+SRC_URI[sha256sum] = "050062d4f31d307cca52c3f6a7f4b946df8de25fc4bd373e1a5142e41034a7ca"
+
+GEM_NAME = "rb-inotify"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-ffi \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-rouge_3.26.0.bb
+++ b/recipes-rubygems/rubygems-rouge_3.26.0.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: rouge"
+DESCRIPTION = "Rouge aims to a be a simple, easy-to-extend drop-in replacement for pygments."
+HOMEPAGE = "http://rouge.jneen.net/"
+
+LICENSE = "MIT & BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=548cf784d6d431718abbb22a2eb5cdbe"
+
+SRC_URI[md5sum] = "945771e0d76c0e4731d231187b3f4f8f"
+SRC_URI[sha256sum] = "a3deb40ae6a07daf67ace188b32c63df04cffbe3c9067ef82495d41101188b2c"
+
+GEM_NAME = "rouge"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-safe-yaml_1.0.5.bb
+++ b/recipes-rubygems/rubygems-safe-yaml_1.0.5.bb
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: safe_yaml"
+DESCRIPTION = "Parse YAML safely"
+HOMEPAGE = "https://github.com/dtao/safe_yaml"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=87342e90f6d5e1c4c246b64ec59c982b"
+
+SRC_URI[md5sum] = "23b7ec89ee8b27f77164ae7867177eb8"
+SRC_URI[sha256sum] = "a6ac2d64b7eb027bdeeca1851fe7e7af0d668e133e8a88066a0c6f7087d9f848"
+
+GEM_NAME = "safe_yaml"
+
+EXTRA_RDEPENDS += "bash"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-sassc_2.4.0.bb
+++ b/recipes-rubygems/rubygems-sassc_2.4.0.bb
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: sassc"
+DESCRIPTION = "Use libsass with Ruby!"
+HOMEPAGE = "https://github.com/sass/sassc-ruby"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=c4af8b2031d4dad9d1923cb8311870fc"
+
+EXTRA_DEPENDS = "libsass"
+
+DEPENDS_class-native += "\
+    rubygems-ffi-native \
+"
+
+SRC_URI[md5sum] = "2f68401685a8be2a7ebb779620ec2a4d"
+SRC_URI[sha256sum] = "4c60a2b0a3b36685c83b80d5789401c2f678c1652e3288315a1551d811d9f83e"
+
+GEM_NAME = "sassc"
+
+GEM_INSTALL_FLAGS += "\
+    --disable-strip \
+"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-ffi \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-terminal-table_3.0.1.bb
+++ b/recipes-rubygems/rubygems-terminal-table_3.0.1.bb
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: terminal-table"
+DESCRIPTION = "Simple, feature rich ascii table generation library"
+HOMEPAGE = "https://github.com/tj/terminal-table"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=1be7620aed40ef7f9125c19d23513d14"
+
+DEPENDS_class-native += "\
+    rubygems-unicode-display-width-native \
+"
+
+SRC_URI[md5sum] = "b56c424f919daf3474dc5f57f31f7bef"
+SRC_URI[sha256sum] = "9273aff0bfab536c05fdf2e301b760326d3b8c4575ada987843a82828eaecb7c"
+
+GEM_NAME = "terminal-table"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-unicode-display-width \
+"
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
Am interested in jekyll. Most recipes could remain as auto-created - some required further tweaks (unshipped licenses / extra(-r)depends)
Unfortunately testimage fails all tests in my environment because dropbear's configuration files do not make it into rootfs. That causes passoword-less / root ssh accesses to fail for insufficient permission. Have to investigate further...
As an alternative test I simply use jekyll on target without issues for a while now - yeah good old manual testing....
So I hope this is acceptable for you (and your CI machinery).