### PR TITLE
template-conf: remove image-mklibs

### DIFF
--- a/conf/variant/rubygems/common.inc
+++ b/conf/variant/rubygems/common.inc
@@ -3,7 +3,7 @@ EXTRA_IMAGE_FEATURES = "debug-tweaks"
 PACKAGECONFIG_append_pn-qemu-system-native = " sdl"
 PACKAGE_CLASSES = "package_rpm"
 PATCHRESOLVE = "noop"
-USER_CLASSES = "image-mklibs image-prelink"
+USER_CLASSES = "image-prelink"
 
 DISTRO_FEATURES_DEFAULT = "acl argp ext2 ipv4 ipv6 largefile xattr nfs vfat"
 


### PR DESCRIPTION
support was removed upstream so it needs to be removed here as well,
otherwise we parsing errors like
ERROR: ParseError in configuration INHERITs: image-mklibs.bbclass

Closes #134

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>