### PR TITLE
Package update

### DIFF
--- a/lib/oeqa/runtime/cases/rubygems_rubygems_aws_sdk_eventbridge.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_aws_sdk_eventbridge.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_aws_sdk_eventbridge(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_aws_sdk_eventbridge(self):
+        self.gem_is_installed("aws-sdk-eventbridge")
+
+    def test_load_aws_sdk_eventbridge(self):
+        self.gem_is_loadable("aws-sdk-eventbridge")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_faraday_em_http.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_faraday_em_http.py
@@ -1,0 +1,7 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_faraday_em_http(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_faraday_em_http(self):
+        self.gem_is_installed("faraday-em_http")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_faraday_em_synchrony.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_faraday_em_synchrony.py
@@ -1,0 +1,7 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_faraday_em_synchrony(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_faraday_em_synchrony(self):
+        self.gem_is_installed("faraday-em_synchrony")
+

--- a/packagegroups-rubygems/packagegroup-rubygems.bb
+++ b/packagegroups-rubygems/packagegroup-rubygems.bb
@@ -45,6 +45,7 @@ RDEPENDS_${PN} += "\
     rubygems-aws-sdk-elasticloadbalancing \
     rubygems-aws-sdk-elasticloadbalancingv2 \
     rubygems-aws-sdk-elasticsearchservice \
+    rubygems-aws-sdk-eventbridge \
     rubygems-aws-sdk-firehose \
     rubygems-aws-sdk-glue \
     rubygems-aws-sdk-guardduty \

--- a/packagegroups-rubygems/packagegroup-rubygems.bb
+++ b/packagegroups-rubygems/packagegroup-rubygems.bb
@@ -111,6 +111,8 @@ RDEPENDS_${PN} += "\
     rubygems-facter \
     rubygems-faraday \
     rubygems-faraday-cookie-jar \
+    rubygems-faraday-em-http \
+    rubygems-faraday-em-synchrony \
     rubygems-faraday-excon \
     rubygems-faraday-middleware \
     rubygems-faraday-net-http \

--- a/recipes-rubygems/rubygems-aws-partitions_1.465.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.465.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-SRC_URI[md5sum] = "233bfda61339b8ba3d3f4d506722626a"
-SRC_URI[sha256sum] = "abb61e42ae184c54552132b81ac550da82544b191f5cc8a43601cd06f52f9d3f"
+SRC_URI[md5sum] = "09f616bb878976ebe5333c4899a4edf0"
+SRC_URI[sha256sum] = "b1561f8f24eaeb996f901dc70de40da8dfe246183413663e80bf72328d77433b"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.51.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.51.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "8bb7bee4fe60ab9cf30612bb56c056d1"
-SRC_URI[sha256sum] = "3a0deb350974e731ab648e0423152a9b24a0b02afbe483c3411ee6c888ab83b2"
+SRC_URI[md5sum] = "18158206a8e2d90f84d4f6aa6f02bad6"
+SRC_URI[sha256sum] = "14f0aea310971b29ff78013033bdca51147e8fc4c91828fa91df1330b8947461"
 
 GEM_NAME = "aws-sdk-cloudfront"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.41.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.41.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "3b990d82fbaa3ede466a33736f1ede53"
-SRC_URI[sha256sum] = "5ad557789318977a91193618e8d37c2ab964b02515b8059bb518467b5e9de63c"
+SRC_URI[md5sum] = "07c469d0b0e1296a49ffe0b9b8bbb6d2"
+SRC_URI[sha256sum] = "10dbaaed14661b0149b852166ea656ab5b3a05ab86b746b174d7157162a46d17"
 
 GEM_NAME = "aws-sdk-cloudwatchlogs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.239.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.239.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "d7b203f791081d3d354aa7e0c4dfc9a5"
-SRC_URI[sha256sum] = "820d7f7b975fd322c30782e57863b0714b5421c3a1be72852503a55634c18ff4"
+SRC_URI[md5sum] = "1946632a9ef7383be6bd33a8be0cf755"
+SRC_URI[sha256sum] = "9e990ac436e619bb86dd67a880c119d818f3550475ddc9c5decd9d70a2c62525"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.79.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.79.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "01ac221b2740a9583e2a65ee33f2988a"
-SRC_URI[sha256sum] = "2b8ab524fdb852d917e4d253977387e8ecd7f9b1487115be6bb4a9788558f034"
+SRC_URI[md5sum] = "fac7841afeef8e73769b7125a6270c7b"
+SRC_URI[sha256sum] = "733b27c505b0fe0046ac8cc6de1dd386792ba25738f4049091e2498982e8f8a4"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eventbridge_1.24.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eventbridge_1.24.0.bb
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
-SUMMARY = "RubyGem: aws-sdk-s3"
-DESCRIPTION = "Official AWS Ruby gem for Amazon Simple Storage Service (Amazon S3)"
+SUMMARY = "RubyGem: aws-sdk-eventbridge"
+DESCRIPTION = "Official AWS Ruby gem for Amazon EventBridge"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
@@ -8,14 +8,13 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
-    rubygems-aws-sdk-kms-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "44219cef58fe048785109bf322596ec8"
-SRC_URI[sha256sum] = "846a0ce96e9461e482b6b2318553d660900ebcc3ca6884178a9ac609d314176c"
+SRC_URI[md5sum] = "9fecd6d8789076d0b371a3db3a00ae35"
+SRC_URI[sha256sum] = "42ae41cd789de9fac80bf2d4ba8259f54ca5211524f2a8eac6812a0e37bf41b2"
 
-GEM_NAME = "aws-sdk-s3"
+GEM_NAME = "aws-sdk-eventbridge"
 
 inherit rubygems
 inherit rubygentest
@@ -23,7 +22,6 @@ inherit pkgconfig
 
 RDEPENDS_${PN}_class-target += "\
     rubygems-aws-sdk-core \
-    rubygems-aws-sdk-kms \
     rubygems-aws-sigv4 \
 "
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.95.1.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.95.1.bb
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
-SUMMARY = "RubyGem: aws-sdk-transfer"
-DESCRIPTION = "Official AWS Ruby gem for AWS Transfer Family (AWS Transfer)"
+SUMMARY = "RubyGem: aws-sdk-s3"
+DESCRIPTION = "Official AWS Ruby gem for Amazon Simple Storage Service (Amazon S3)"
 HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 
 LICENSE = "Apache-2.0"
@@ -8,13 +8,14 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS_class-native += "\
     rubygems-aws-sdk-core-native \
+    rubygems-aws-sdk-kms-native \
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "feb4035d8f5386b999acf1f7ed79b877"
-SRC_URI[sha256sum] = "83c6a5f1524443de8ab14db87126efbf85f535f76111dad59d44bd02214ffd44"
+SRC_URI[md5sum] = "e45e52e9e7198c4a805861e49232b77e"
+SRC_URI[sha256sum] = "fb9f61a0af7c730eb2231db3e93dd866c028cbb6ac2a3eaba7251400e932a956"
 
-GEM_NAME = "aws-sdk-transfer"
+GEM_NAME = "aws-sdk-s3"
 
 inherit rubygems
 inherit rubygentest
@@ -22,6 +23,7 @@ inherit pkgconfig
 
 RDEPENDS_${PN}_class-target += "\
     rubygems-aws-sdk-core \
+    rubygems-aws-sdk-kms \
     rubygems-aws-sigv4 \
 "
 

--- a/recipes-rubygems/rubygems-aws-sdk-sqs_1.39.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-sqs_1.39.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "245814e123abf05157aad7d59440d2e5"
-SRC_URI[sha256sum] = "2e42127c10908dc6e59c49d73c8917bd5618435c858343b7ecd1114c3ca2a206"
+SRC_URI[md5sum] = "176864f5b546887e489654d876bcfb6b"
+SRC_URI[sha256sum] = "d2196751eced53b2c7561970f716aa68dc062c3cd3f15cba3c4a6fc048dd701e"
 
 GEM_NAME = "aws-sdk-sqs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-transfer_1.33.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-transfer_1.33.0.bb
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: aws-sdk-transfer"
+DESCRIPTION = "Official AWS Ruby gem for AWS Transfer Family (AWS Transfer)"
+HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+DEPENDS_class-native += "\
+    rubygems-aws-sdk-core-native \
+    rubygems-aws-sigv4-native \
+"
+
+SRC_URI[md5sum] = "f39c54e6d1e59bb8c73216c40432888e"
+SRC_URI[sha256sum] = "7db685ce9fe0323991378543c9f5e7d203cfbf3a9d00f95c933aae2691f3151d"
+
+GEM_NAME = "aws-sdk-transfer"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-aws-sdk-core \
+    rubygems-aws-sigv4 \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-excon_0.82.0.bb
+++ b/recipes-rubygems/rubygems-excon_0.82.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/excon/excon"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=8b04a0291ec55b31563a50b191b72cb1"
 
-SRC_URI[md5sum] = "cec0507827e05f04e7d53cf865e4f729"
-SRC_URI[sha256sum] = "e7c78b2114c42e06024fb9812fc5a6b9a984ed973f585c09c67f5ae6e7b6e5a5"
+SRC_URI[md5sum] = "751bef9cb67f86c4e6b73a12b6bd5aac"
+SRC_URI[sha256sum] = "6a1641e9b5725ee9a973869458a7d740ae72e3f60d976eb0e7a2341dabf6a984"
 
 GEM_NAME = "excon"
 

--- a/recipes-rubygems/rubygems-faraday-em-http_1.0.0.bb
+++ b/recipes-rubygems/rubygems-faraday-em-http_1.0.0.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: faraday-em_http"
+DESCRIPTION = "Faraday adapter for Em::Http"
+HOMEPAGE = "https://github.com/lostisland/faraday-em_http"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=20830660ee48a0c845a62aad77c18f4a"
+
+SRC_URI[md5sum] = "4b14f4a6132802f235f79e8ab987e3c2"
+SRC_URI[sha256sum] = "7a3d4c7079789121054f57e08cd4ef7e40ad1549b63101f38c7093a9d6c59689"
+
+GEM_NAME = "faraday-em_http"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-faraday-em-synchrony_1.0.0.bb
+++ b/recipes-rubygems/rubygems-faraday-em-synchrony_1.0.0.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: faraday-em_synchrony"
+DESCRIPTION = "Faraday adapter for EM::Synchrony"
+HOMEPAGE = "https://github.com/lostisland/faraday-em_synchrony"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=20830660ee48a0c845a62aad77c18f4a"
+
+SRC_URI[md5sum] = "95c919f72c9c13de42cdd19c4caebcc5"
+SRC_URI[sha256sum] = "460dad1c30cc692d6e77d4c391ccadb4eca4854b315632cd7e560f74275cf9ed"
+
+GEM_NAME = "faraday-em_synchrony"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-faraday_1.4.2.bb
+++ b/recipes-rubygems/rubygems-faraday_1.4.2.bb
@@ -7,6 +7,8 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=eeb478a3bdc6cd7919e354aeb42b94e4"
 
 DEPENDS_class-native += "\
+    rubygems-faraday-em-http-native \
+    rubygems-faraday-em-synchrony-native \
     rubygems-faraday-excon-native \
     rubygems-faraday-net-http-native \
     rubygems-faraday-net-http-persistent-native \
@@ -14,8 +16,8 @@ DEPENDS_class-native += "\
     rubygems-ruby2-keywords-native \
 "
 
-SRC_URI[md5sum] = "cba4ba88c95fc453d8d9e04dea41a0e9"
-SRC_URI[sha256sum] = "71c3864e7c2325821c6023bc498d748f6502803c073759fa5450397a4035c460"
+SRC_URI[md5sum] = "77cdd35f32618ae19e7fc2a13dfba443"
+SRC_URI[sha256sum] = "fbac4fc71c941a7030bdf65edc6e84de4e080e3164b48ac6bba390fdc099b01e"
 
 GEM_NAME = "faraday"
 
@@ -24,6 +26,8 @@ inherit rubygentest
 inherit pkgconfig
 
 RDEPENDS_${PN}_class-target += "\
+    rubygems-faraday-em-http \
+    rubygems-faraday-em-synchrony \
     rubygems-faraday-excon \
     rubygems-faraday-net-http \
     rubygems-faraday-net-http-persistent \

--- a/recipes-rubygems/rubygems-ffi_1.15.1.bb
+++ b/recipes-rubygems/rubygems-ffi_1.15.1.bb
@@ -15,8 +15,8 @@ GEM_INSTALL_FLAGS += "\
     --with-opt-dir=${RECIPE_SYSROOT} \
 "
 
-SRC_URI[md5sum] = "d5d910a1a5b079caf88d73bd2c956a3c"
-SRC_URI[sha256sum] = "621057e9bd2bd5771a072015ed57b71f9be43b5d9f18b53863d4bbb5c772015b"
+SRC_URI[md5sum] = "63f782c2c7dc4db127da72b5bcec53c6"
+SRC_URI[sha256sum] = "d125ee6a8b88405926f8af9b3d25a75ae93e1c782cd50bd62e81e20cce16d696"
 
 GEM_NAME = "ffi"
 

--- a/recipes-rubygems/rubygems-google-apis-discovery-v1_0.4.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-discovery-v1_0.4.0.bb
@@ -10,8 +10,8 @@ DEPENDS_class-native += "\
     rubygems-google-apis-core-native \
 "
 
-SRC_URI[md5sum] = "20a9649b3bc2a3d9d2526d83ff01ee48"
-SRC_URI[sha256sum] = "ad8bf88b9ad12e6b10ca6f31a50b1cf71614e4048ce147c4c650046eb75b14e5"
+SRC_URI[md5sum] = "9ba7ed271b98c34a1ca557243d6a4536"
+SRC_URI[sha256sum] = "50b418352b7170fbfbfc249e8309065fb28d426ea10dc248bcfe2696646e5f1d"
 
 GEM_NAME = "google-apis-discovery_v1"
 

--- a/recipes-rubygems/rubygems-inspec-bin_4.37.20.bb
+++ b/recipes-rubygems/rubygems-inspec-bin_4.37.20.bb
@@ -10,8 +10,8 @@ DEPENDS_class-native += "\
     rubygems-inspec-native \
 "
 
-SRC_URI[md5sum] = "a9610c72a21d59e0d00acfb3a3a762c8"
-SRC_URI[sha256sum] = "a037fc3b60371e12af985ce00d3503dcdfbcf019b743da81281bee04402d1f12"
+SRC_URI[md5sum] = "af69c540fcd066675b9e208b2a91df56"
+SRC_URI[sha256sum] = "e0cd0e3df1cd330a0e856770496d7391f01a769a80dbff124bb8762268dfe209"
 
 GEM_NAME = "inspec-bin"
 

--- a/recipes-rubygems/rubygems-inspec-core_4.37.20.bb
+++ b/recipes-rubygems/rubygems-inspec-core_4.37.20.bb
@@ -31,8 +31,8 @@ DEPENDS_class-native += "\
     rubygems-tty-table-native \
 "
 
-SRC_URI[md5sum] = "5c1c254baadf692d101b3b198c9d6907"
-SRC_URI[sha256sum] = "6a3fa9b3fd4c612facd994b80714e72721cfb69aeac2bac0524c437ec015554a"
+SRC_URI[md5sum] = "ca3d7c2f194d9d8125981172f887e35a"
+SRC_URI[sha256sum] = "cb19f8154fae391886658e33e1f0e675568b2ca58374f150cf9213d7e3751e7f"
 
 GEM_NAME = "inspec-core"
 

--- a/recipes-rubygems/rubygems-inspec_4.37.20.bb
+++ b/recipes-rubygems/rubygems-inspec_4.37.20.bb
@@ -17,8 +17,8 @@ DEPENDS_class-native += "\
     rubygems-train-winrm-native \
 "
 
-SRC_URI[md5sum] = "790fa6ea4b48cefa86e8c75fc3a558e0"
-SRC_URI[sha256sum] = "33f61a753af36786ca9e6d8e6e58401bfd58161742db83ea1290500e753395b2"
+SRC_URI[md5sum] = "1980f9f461f27e66a618ffcc852d3689"
+SRC_URI[sha256sum] = "796c6ae042a0cfcc2df981db91f030bb3e13fa7a8601577bdd0449062da3a9cf"
 
 GEM_NAME = "inspec"
 

--- a/recipes-rubygems/rubygems-mini-portile2_2.5.2.bb
+++ b/recipes-rubygems/rubygems-mini-portile2_2.5.2.bb
@@ -6,13 +6,21 @@ HOMEPAGE = "https://github.com/flavorjones/mini_portile"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=ca91f53befc541b9880a8502e7d2699d"
 
-SRC_URI[md5sum] = "cb5fe30fc3a76f8a17e034d13f8385f5"
-SRC_URI[sha256sum] = "a2677195305dc31b9c7890292967dabefdef266a426334b9b09728040ee9e175"
+DEPENDS_class-native += "\
+    rubygems-net-ftp-native \
+"
+
+SRC_URI[md5sum] = "4a8698f0afe695c9a1b7050513710b3f"
+SRC_URI[sha256sum] = "7ac4d87aeab13575ac09813e1f87f03f330f2c9e357a11e6f291a95127015e28"
 
 GEM_NAME = "mini_portile2"
 
 inherit rubygems
 inherit rubygentest
 inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-net-ftp \
+"
 
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-nokogiri_1.11.6.bb
+++ b/recipes-rubygems/rubygems-nokogiri_1.11.6.bb
@@ -23,8 +23,8 @@ GEM_INSTALL_FLAGS += "\
     --use-system-libraries \
 "
 
-SRC_URI[md5sum] = "c0b5af6e1a97086fd92203359a32e140"
-SRC_URI[sha256sum] = "15f0f270afbf9e3d4db0b0661d9742b2c02ae3bc8f17ec42c61fab1a8cb700c5"
+SRC_URI[md5sum] = "217b9583ea9341ad72eccd8047a95cfc"
+SRC_URI[sha256sum] = "9f182a07755dde5e1cda3777dce1d693723f4bef1b947947e0892e168d199dfc"
 
 GEM_NAME = "nokogiri"
 

--- a/recipes-rubygems/rubygems-slop_4.9.1.bb
+++ b/recipes-rubygems/rubygems-slop_4.9.1.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "http://github.com/leejarvis/slop"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=40575ded674b04c083ce6818c01f0282"
 
-SRC_URI[md5sum] = "a5b97ab00624c4d1272293d50af1f734"
-SRC_URI[sha256sum] = "32a396ad5e092f6a7b36122976570ac778fbe04f19be2a0dc683ac7189d4c626"
+SRC_URI[md5sum] = "56c164acf52d683b3176f84af0743fc7"
+SRC_URI[sha256sum] = "498de9c170ab15573a69aca92cc6199122be319e108de0f74a41cb26abdceb18"
 
 GEM_NAME = "slop"
 

--- a/recipes-rubygems/rubygems-train-aws_0.2.8.bb
+++ b/recipes-rubygems/rubygems-train-aws_0.2.8.bb
@@ -43,6 +43,7 @@ DEPENDS_class-native += "\
     rubygems-aws-sdk-elasticloadbalancing-native \
     rubygems-aws-sdk-elasticloadbalancingv2-native \
     rubygems-aws-sdk-elasticsearchservice-native \
+    rubygems-aws-sdk-eventbridge-native \
     rubygems-aws-sdk-firehose-native \
     rubygems-aws-sdk-glue-native \
     rubygems-aws-sdk-guardduty-native \
@@ -72,8 +73,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sdk-transfer-native \
 "
 
-SRC_URI[md5sum] = "58c0e65acc54427760af2b2005353bfb"
-SRC_URI[sha256sum] = "96eaa07c453ed871edc04dfa583972ee6f0c7c29bb1c0de24118b3cd124261ed"
+SRC_URI[md5sum] = "926844e704452e5d55bb825606a06686"
+SRC_URI[sha256sum] = "ceb60c4fffd7b5be7e53ed1970d4bcd3d05e998efe8c44097588ccc5742eff14"
 
 GEM_NAME = "train-aws"
 
@@ -118,6 +119,7 @@ RDEPENDS_${PN}_class-target += "\
     rubygems-aws-sdk-elasticloadbalancing \
     rubygems-aws-sdk-elasticloadbalancingv2 \
     rubygems-aws-sdk-elasticsearchservice \
+    rubygems-aws-sdk-eventbridge \
     rubygems-aws-sdk-firehose \
     rubygems-aws-sdk-glue \
     rubygems-aws-sdk-guardduty \

--- a/recipes-rubygems/rubygems-train-core_3.7.2.bb
+++ b/recipes-rubygems/rubygems-train-core_3.7.2.bb
@@ -15,8 +15,8 @@ DEPENDS_class-native += "\
     rubygems-net-ssh-native \
 "
 
-SRC_URI[md5sum] = "28c6851d8103b0d06fb579eba3595927"
-SRC_URI[sha256sum] = "486735a075655af63a2f226abf0532d27603078a99473213e1addb66f3017abf"
+SRC_URI[md5sum] = "b7bfbf61ff38756ec9b6f4ca86bf9ffc"
+SRC_URI[sha256sum] = "477f8fc8c5725d4a45b77d0df6680dcd064820c7171a5d05b3a05e4f906703eb"
 
 GEM_NAME = "train-core"
 

--- a/recipes-rubygems/rubygems-train_3.7.2.bb
+++ b/recipes-rubygems/rubygems-train_3.7.2.bb
@@ -21,8 +21,8 @@ DEPENDS_class-native += "\
     rubygems-train-winrm-native \
 "
 
-SRC_URI[md5sum] = "951c9b337ee10df22c7a7a5e0a32a1dc"
-SRC_URI[sha256sum] = "fdbe7774028bbe11e9b48d8973893c43b9801b27d7e4a15054e01d24504cc34f"
+SRC_URI[md5sum] = "0a1cba7fff82a4499199244c1746b3e3"
+SRC_URI[sha256sum] = "f9d72d312a3a913ebc0d0bf56a8ef3d33128ffc28cc2766f3be46aa8a0da1eb2"
 
 GEM_NAME = "train"
 


### PR DESCRIPTION
* faraday: update to 1.4.2
* ffi: update to 1.15.1
* train-core: update to 3.7.2
* inspec-core: update to 4.37.20
* aws-sdk-ecs: update to 1.79.0
* aws-sdk-cloudfront: update to 1.51.0
* google-apis-discovery_v1: update to 0.4.0
* aws-sdk-cloudwatchlogs: update to 1.41.0
* train: update to 3.7.2
* nokogiri: update to 1.11.6
* aws-partitions: update to 1.465.0
* aws-sdk-ec2: update to 1.239.0
* aws-sdk-sqs: update to 1.39.0
* train-aws: update to 0.2.8
* inspec: update to 4.37.20
* excon: update to 0.82.0
* inspec-bin: update to 4.37.20
* slop: update to 4.9.1