### PR TITLE
Cherry pick from origin/master

### DIFF
--- a/recipes-rubygems/rubygems-aws-sdk-autoscaling_1.63.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-autoscaling_1.63.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "548366d19de7daa5ec6ac8f4839eeff2"
-SRC_URI[sha256sum] = "b2846b90bc08042b4f0d2cbfb34b49f0fddd8f3661f4b971baa9970b2de330ff"
+SRC_URI[md5sum] = "71082ea3f50f5db55a6cd5060dce53a8"
+SRC_URI[sha256sum] = "8c4c703f7de0afa1455ddbb2ca46436a0c61eada358e136cd2864084dc6c2973"
 
 GEM_NAME = "aws-sdk-autoscaling"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.35.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.35.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "480adfc40cf69f3ad5c6ab18f08809ab"
-SRC_URI[sha256sum] = "abbf89e423219fafb3d7ae41e00151d7ee1ad988b3d3167cc507c62b94335d05"
+SRC_URI[md5sum] = "441c24f4dcf7122aa9cf24cab852baf0"
+SRC_URI[sha256sum] = "baf0c3f8583044b79b48af1a058fc7864f16c9228bf39a83fe85bf61ad7af644"
 
 GEM_NAME = "aws-sdk-cloudtrail"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.114.1.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.114.1.bb
@@ -13,8 +13,8 @@ DEPENDS_class-native += "\
     rubygems-jmespath-native \
 "
 
-SRC_URI[md5sum] = "a53e675090a4d274fd7f7db922e66db6"
-SRC_URI[sha256sum] = "4c8ebfa9078d9e4abe12a2e3004dc81c92a921d03343826731819af4585b5a25"
+SRC_URI[md5sum] = "6769e3bd1749592b9ce817ef13c0b8c9"
+SRC_URI[sha256sum] = "e28b117714089791c7d8515fe9d73ec7bf643fda065ae25d1a636179a4b67a26"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.240.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.240.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "1946632a9ef7383be6bd33a8be0cf755"
-SRC_URI[sha256sum] = "9e990ac436e619bb86dd67a880c119d818f3550475ddc9c5decd9d70a2c62525"
+SRC_URI[md5sum] = "9e2797eb4cac551c5c15fab8038a53d5"
+SRC_URI[sha256sum] = "b95d527985841e0c2157cafd7a39478db460980ae6cb4563b2227f9b88de1973"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.80.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.80.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "fac7841afeef8e73769b7125a6270c7b"
-SRC_URI[sha256sum] = "733b27c505b0fe0046ac8cc6de1dd386792ba25738f4049091e2498982e8f8a4"
+SRC_URI[md5sum] = "26e897e828bd952412f25f9759445b96"
+SRC_URI[sha256sum] = "fa029e1c80a936e8e7e10a1ee23c401775f679671ad2c268ecd7a260e87dd5e7"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-iam_1.55.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-iam_1.55.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "e36dd2ee218f7b6a9758feab4c7445e9"
-SRC_URI[sha256sum] = "753890069465854cebd226eecb94acae28ab758ce452fda6ee82d01af516da55"
+SRC_URI[md5sum] = "754e0a24f5020f6787f0cfbaf7dc248e"
+SRC_URI[sha256sum] = "35e9ed1918c1a6ba0c40ec5167f7429478881ac936db9dc0a0f262931c2f7a0f"
 
 GEM_NAME = "aws-sdk-iam"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.119.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.119.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "4afccb76439c4e2851b9de6fb0a42a24"
-SRC_URI[sha256sum] = "f56f210d9c34c515f889eaafe3f22e16f1378eb3fd749ebb818efdd553f7592a"
+SRC_URI[md5sum] = "ee05b8df5ddc1fd98ce72c8e01c9b2a3"
+SRC_URI[sha256sum] = "0ca620b35029552943f531006153b147719e576fef11b19a1b089c73ad1d7865"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-aws-sdk-route53resolver_1.26.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-route53resolver_1.26.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "6588931aca6f0b27dd35a2ae2045b680"
-SRC_URI[sha256sum] = "c71d3f134077ba477cf0f8479bb7716134d1058618f68635428396cf4cf175af"
+SRC_URI[md5sum] = "b36dda742d1f0f552e81f019f31953bd"
+SRC_URI[sha256sum] = "46271c494cd34efef0824bcb2a129c4332dc5259e3440568cdd786770eaeed82"
 
 GEM_NAME = "aws-sdk-route53resolver"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.96.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.96.0.bb
@@ -12,8 +12,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "e45e52e9e7198c4a805861e49232b77e"
-SRC_URI[sha256sum] = "fb9f61a0af7c730eb2231db3e93dd866c028cbb6ac2a3eaba7251400e932a956"
+SRC_URI[md5sum] = "b2b019223be81dd7cf9a51c548f2c1a0"
+SRC_URI[sha256sum] = "8431733e33b1fe31321637ac29db1c02a3c07ef20246773a30aa5f6353d886bc"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-aws-sdk-sns_1.41.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-sns_1.41.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "c9c488318e49281e0328c2885fb5011f"
-SRC_URI[sha256sum] = "aecf6008ce3aea9db5e9125b3807000a4de57755754ba23aad899be2053270e4"
+SRC_URI[md5sum] = "d524a3b181bbaae8ead7a1e75fb23c57"
+SRC_URI[sha256sum] = "b2a399febc55c6e37d37c44a11938cee1ec73130c38d1ccd71be0828e118f76d"
 
 GEM_NAME = "aws-sdk-sns"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ssm_1.111.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ssm_1.111.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "a420b57486ef1d9345c558ce5dd45d59"
-SRC_URI[sha256sum] = "5b2d91baeaa43279a50938848a159b87eb06b031d6ee6ffa0cc24d4dcee66420"
+SRC_URI[md5sum] = "27bbf97bc33e2556275ff0a4c1013a69"
+SRC_URI[sha256sum] = "f38fafe5b71a1b11ab50751c3dc78eb6e9683732c289eb787f26881202dd4456"
 
 GEM_NAME = "aws-sdk-ssm"
 

--- a/recipes-rubygems/rubygems-google-apis-generator_0.3.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-generator_0.3.0.bb
@@ -14,8 +14,8 @@ DEPENDS_class-native += "\
     rubygems-thor-native \
 "
 
-SRC_URI[md5sum] = "035ebb4d7f369197d6e625ebdd746d22"
-SRC_URI[sha256sum] = "8ea98f042e747f76837137f8b2bd1c927fc6009f873ff6e49cb5dd652b8a3499"
+SRC_URI[md5sum] = "12bd10f3f70b71bb0d2c500e74c3e5c4"
+SRC_URI[sha256sum] = "f7078384e265caffbd1e9f295951c74fd5f022d5f9fd5158c775db2e59c74f6e"
 
 GEM_NAME = "google-apis-generator"
 

--- a/recipes-rubygems/rubygems-inspec-bin_4.37.23.bb
+++ b/recipes-rubygems/rubygems-inspec-bin_4.37.23.bb
@@ -10,8 +10,8 @@ DEPENDS_class-native += "\
     rubygems-inspec-native \
 "
 
-SRC_URI[md5sum] = "af69c540fcd066675b9e208b2a91df56"
-SRC_URI[sha256sum] = "e0cd0e3df1cd330a0e856770496d7391f01a769a80dbff124bb8762268dfe209"
+SRC_URI[md5sum] = "8d44e9a1cda2e8b88bd7c77cba358322"
+SRC_URI[sha256sum] = "206a2490877901b3b9f111fb30847efd380765191b9df06ef46b31af55bf3181"
 
 GEM_NAME = "inspec-bin"
 

--- a/recipes-rubygems/rubygems-inspec-core_4.37.23.bb
+++ b/recipes-rubygems/rubygems-inspec-core_4.37.23.bb
@@ -31,8 +31,8 @@ DEPENDS_class-native += "\
     rubygems-tty-table-native \
 "
 
-SRC_URI[md5sum] = "ca3d7c2f194d9d8125981172f887e35a"
-SRC_URI[sha256sum] = "cb19f8154fae391886658e33e1f0e675568b2ca58374f150cf9213d7e3751e7f"
+SRC_URI[md5sum] = "86b1a291a550f809a638a2e814cbe092"
+SRC_URI[sha256sum] = "0212fa9dc9901e058d04287932998122de746f93fafcd0cc45bb040ca2826f26"
 
 GEM_NAME = "inspec-core"
 

--- a/recipes-rubygems/rubygems-inspec_4.37.23.bb
+++ b/recipes-rubygems/rubygems-inspec_4.37.23.bb
@@ -15,8 +15,8 @@ DEPENDS_class-native += "\
     rubygems-train-winrm-native \
 "
 
-SRC_URI[md5sum] = "1980f9f461f27e66a618ffcc852d3689"
-SRC_URI[sha256sum] = "796c6ae042a0cfcc2df981db91f030bb3e13fa7a8601577bdd0449062da3a9cf"
+SRC_URI[md5sum] = "e9980973d8845703f9cb2ea48a44f453"
+SRC_URI[sha256sum] = "a86413fb9d0ff072acada0bf185407392bd9d119ce58f01e011bff16b6e06f7f"
 
 GEM_NAME = "inspec"
 

--- a/recipes-rubygems/rubygems-mini-portile2_2.6.1.bb
+++ b/recipes-rubygems/rubygems-mini-portile2_2.6.1.bb
@@ -6,21 +6,13 @@ HOMEPAGE = "https://github.com/flavorjones/mini_portile"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=ca91f53befc541b9880a8502e7d2699d"
 
-DEPENDS_class-native += "\
-    rubygems-net-ftp-native \
-"
-
-SRC_URI[md5sum] = "4a8698f0afe695c9a1b7050513710b3f"
-SRC_URI[sha256sum] = "7ac4d87aeab13575ac09813e1f87f03f330f2c9e357a11e6f291a95127015e28"
+SRC_URI[md5sum] = "9271663118e11fbeec96c40b0c78d182"
+SRC_URI[sha256sum] = "385fd7a2f3cda0ea5a0cb85551a936da941d7580fc9037a75dea820843aa7dd3"
 
 GEM_NAME = "mini_portile2"
 
 inherit rubygems
 inherit rubygentest
 inherit pkgconfig
-
-RDEPENDS_${PN}_class-target += "\
-    rubygems-net-ftp \
-"
 
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-nokogiri_1.11.7.bb
+++ b/recipes-rubygems/rubygems-nokogiri_1.11.7.bb
@@ -23,8 +23,8 @@ GEM_INSTALL_FLAGS += "\
     --use-system-libraries \
 "
 
-SRC_URI[md5sum] = "217b9583ea9341ad72eccd8047a95cfc"
-SRC_URI[sha256sum] = "9f182a07755dde5e1cda3777dce1d693723f4bef1b947947e0892e168d199dfc"
+SRC_URI[md5sum] = "c49903a564d6f71765a04afc9c7ff974"
+SRC_URI[sha256sum] = "4976a9c9e796527d51dc6c311b9bd93a0233f6a7962a0f569aa5c782461836ef"
 
 GEM_NAME = "nokogiri"
 


### PR DESCRIPTION
* aws-sdk-core: update to 3.114.1
* inspec-core: update to 4.37.23
* aws-sdk-ec2: update to 1.240.0
* google-apis-generator: update to 0.3.0
* aws-sdk-cloudtrail: update to 1.35.0
* aws-sdk-s3: update to 1.96.0
* aws-sdk-sns: update to 1.41.0
* aws-sdk-iam: update to 1.55.0
* aws-sdk-ssm: update to 1.111.0
* aws-sdk-autoscaling: update to 1.63.0
* aws-sdk-ecs: update to 1.80.0
* mini_portile2: update to 2.6.1
* inspec: update to 4.37.23
* aws-sdk-route53resolver: update to 1.26.0
* aws-sdk-rds: update to 1.119.0
* nokogiri: update to 1.11.7
* inspec-bin: update to 4.37.23