### PR TITLE
ci: switch back to firstcommon in cherry-picking

### DIFF
--- a/.github/workflows/cron-master-qemu86-64-cherrypick.yml
+++ b/.github/workflows/cron-master-qemu86-64-cherrypick.yml
@@ -72,6 +72,7 @@ jobs:
           GITHUB_REPO_USER=priv-kweihmann \
           GITHUB_REPO=meta-rubygems \
           ${WORKSPACE}/sources/meta-rubygems/scripts/cherry-pick-bot \
+          --cpmode=firstcommon \
           origin/master \
           origin/dunfell \
           ${WORKSPACE}/sources/meta-rubygems/.nocherry


### PR DESCRIPTION
switch back to just cherry picking since the first common commit
in source and target branches.
This should prevent picking changes without a change set or even
outdated commits

Closes #159

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>