### PR TITLE
Cherry pick from origin/master

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.467.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.467.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-SRC_URI[md5sum] = "09f616bb878976ebe5333c4899a4edf0"
-SRC_URI[sha256sum] = "b1561f8f24eaeb996f901dc70de40da8dfe246183413663e80bf72328d77433b"
+SRC_URI[md5sum] = "ce01aa655cc5c8d79556f864de45fa50"
+SRC_URI[sha256sum] = "0ce35261854ee35582f760886ac921b2d0b73d65739415f9ee367e7022a942a2"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cognitoidentityprovider_1.53.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cognitoidentityprovider_1.53.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "fe8e4662635bd80ce0c5ceab9d2d6bfe"
-SRC_URI[sha256sum] = "779ea1263954f624f3cb8d7b0dd21f6a062ece50b18f8a100875d4a39019a963"
+SRC_URI[md5sum] = "0df8287fd549ac261e31c736d5ae056f"
+SRC_URI[sha256sum] = "456c432bc3551b0431fd9cf6549142e633f22708ee7594aa35e5b4d2401d5b48"
 
 GEM_NAME = "aws-sdk-cognitoidentityprovider"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.114.2.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.114.2.bb
@@ -13,8 +13,8 @@ DEPENDS_class-native += "\
     rubygems-jmespath-native \
 "
 
-SRC_URI[md5sum] = "6769e3bd1749592b9ce817ef13c0b8c9"
-SRC_URI[sha256sum] = "e28b117714089791c7d8515fe9d73ec7bf643fda065ae25d1a636179a4b67a26"
+SRC_URI[md5sum] = "264ded83b366e7cc146f605621e115b8"
+SRC_URI[sha256sum] = "0180c936ecfb714061491e5370bd0f3a4709b22d2c252ffd9380b35edbc6cb27"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.242.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.242.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "9e2797eb4cac551c5c15fab8038a53d5"
-SRC_URI[sha256sum] = "b95d527985841e0c2157cafd7a39478db460980ae6cb4563b2227f9b88de1973"
+SRC_URI[md5sum] = "8857328e37b9c530ae43afde73bd76d3"
+SRC_URI[sha256sum] = "d115a5857b56561e09821ff34efd5ea965132dd1a4d5d8a59a119c4e9a7b707d"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eks_1.55.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eks_1.55.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "c69163dd7c99aabf482f435b7a78170d"
-SRC_URI[sha256sum] = "18d3c92851fd830f579fb5c6774af59903a5e9ffc1787155fd44af5560a85e2d"
+SRC_URI[md5sum] = "7a0a50aff844fab3045e407011380a23"
+SRC_URI[sha256sum] = "8452ea1a1b198819b23723be2d5ef249383978cfc3f82b18c4a39874d9762469"
 
 GEM_NAME = "aws-sdk-eks"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.88.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.88.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "66f2bd1b0784360180bafbe9eaea1d78"
-SRC_URI[sha256sum] = "15f4b3eac6631fa685f9a52b085f65ea45e025d9d9712288c6961d0e1f041c3d"
+SRC_URI[md5sum] = "4d1b298fcf65717aedb803fca110ca02"
+SRC_URI[sha256sum] = "6e343f5fce6f4aac18e2e8f906442df811944a572c5fda3a93e6c7b155540898"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ram_1.26.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ram_1.26.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "769a5e9f82d5e5ff04fa4ae2e4f84058"
-SRC_URI[sha256sum] = "a2a09fa4ba03d41c4da0baf317f7ba9e64cc897640fc930175dba848007802b6"
+SRC_URI[md5sum] = "96a2e75c39247cb52d29fb35fc23e5d4"
+SRC_URI[sha256sum] = "4c09b74c1117e2d8dd54ae50c32e1b1251440c400c80277bc0c9b73d4bd6a666"
 
 GEM_NAME = "aws-sdk-ram"
 

--- a/recipes-rubygems/rubygems-aws-sdk-redshift_1.63.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-redshift_1.63.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "151f31a3741a3cb9f4e363265ed89b6e"
-SRC_URI[sha256sum] = "e0e5a4e85adbe3797c9b4ce2e15798aa2c467ccff0299e5d4f0c089e21910630"
+SRC_URI[md5sum] = "cc4744e31314945bbad3c4477de41249"
+SRC_URI[sha256sum] = "98eb819ac4b8ebcf2b6aadc5888d8866859a25150c7c08c93848e55dc4f80239"
 
 GEM_NAME = "aws-sdk-redshift"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.96.1.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.96.1.bb
@@ -12,8 +12,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "b2b019223be81dd7cf9a51c548f2c1a0"
-SRC_URI[sha256sum] = "8431733e33b1fe31321637ac29db1c02a3c07ef20246773a30aa5f6353d886bc"
+SRC_URI[md5sum] = "0378cbef612bc262b09f0b535745ba61"
+SRC_URI[sha256sum] = "d004844475c3d06514e78696e8dab7e2a2653b861f00c8137782897a6b5b4860"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-aws-sdk-servicecatalog_1.60.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-servicecatalog_1.60.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "806abfe2b7a916c6672e8919c8a7054a"
-SRC_URI[sha256sum] = "dc1e2974788fc9d52c457e21687812c55314dfe0d8f0823ad337d386ee8b8d8f"
+SRC_URI[md5sum] = "d4f57bfbd715059d4f986b20d6dae65e"
+SRC_URI[sha256sum] = "47238975e6ec0dc406dddf1a62fc750b33acec97ec2beb75b67f4859f25d5dfe"
 
 GEM_NAME = "aws-sdk-servicecatalog"
 

--- a/recipes-rubygems/rubygems-aws-sdk-transfer_1.34.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-transfer_1.34.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "f39c54e6d1e59bb8c73216c40432888e"
-SRC_URI[sha256sum] = "7db685ce9fe0323991378543c9f5e7d203cfbf3a9d00f95c933aae2691f3151d"
+SRC_URI[md5sum] = "2ce127f9c0e384805b8528139267c8e4"
+SRC_URI[sha256sum] = "f62121bf12994d62ac494988673497022f6dd9be987f6c8f47236cad31bbff04"
 
 GEM_NAME = "aws-sdk-transfer"
 

--- a/recipes-rubygems/rubygems-chef-config_17.2.29.bb
+++ b/recipes-rubygems/rubygems-chef-config_17.2.29.bb
@@ -15,8 +15,8 @@ DEPENDS_class-native += "\
     rubygems-tomlrb-native \
 "
 
-SRC_URI[md5sum] = "e322a98e092274a9c8711e68c49d4f8b"
-SRC_URI[sha256sum] = "826f3cf5feaba38164d6947aea8599375cc22f06f01ad405ad0572f6eb6c3537"
+SRC_URI[md5sum] = "32c16ef50c45ed8364f73e75c4e23159"
+SRC_URI[sha256sum] = "4d03dd2ae76b25646547bea8797bd0912315101c7c68837d195cb703b00aaca1"
 
 GEM_NAME = "chef-config"
 

--- a/recipes-rubygems/rubygems-chef-utils_17.2.29.bb
+++ b/recipes-rubygems/rubygems-chef-utils_17.2.29.bb
@@ -10,8 +10,8 @@ DEPENDS_class-native += "\
     rubygems-concurrent-ruby-native \
 "
 
-SRC_URI[md5sum] = "6d93872cc0140290adec05a083d14d1c"
-SRC_URI[sha256sum] = "3e1768ebb0498e48cd36200ec61b7570b6c6ff7494731d2a93a287d7ec7b6adb"
+SRC_URI[md5sum] = "3c8711330c7f6c6697740cfac7a0c7a8"
+SRC_URI[sha256sum] = "a264bdbd5df46253eaf7f3f5812857a76b81d5b96f51d102efdffe44ac66c6cc"
 
 GEM_NAME = "chef-utils"
 

--- a/recipes-rubygems/rubygems-chef_17.2.29.bb
+++ b/recipes-rubygems/rubygems-chef_17.2.29.bb
@@ -35,8 +35,8 @@ DEPENDS_class-native += "\
     rubygems-uuidtools-native \
 "
 
-SRC_URI[md5sum] = "044041ebdf6443a86f501aca7381a4c3"
-SRC_URI[sha256sum] = "55589012ef8e01dc6bb7fc77b662c45a8339aba24b68c6448d13fae2c65b863d"
+SRC_URI[md5sum] = "e436da7f78fa680648cda071551a7ec6"
+SRC_URI[sha256sum] = "eaa653e081b5f677a6f8f86f6e0ae311628e5c79a247909160592ca19412b067"
 
 GEM_NAME = "chef"
 

--- a/recipes-rubygems/rubygems-concurrent-ruby_1.1.9.bb
+++ b/recipes-rubygems/rubygems-concurrent-ruby_1.1.9.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "http://www.concurrent-ruby.com"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=e319104fe1435b64fc0a67032db44f02"
 
-SRC_URI[md5sum] = "68c226f3ee1bf39313dd4ebc0cf52d43"
-SRC_URI[sha256sum] = "e35169e8e01c33cddc9d322e4e793a9bc8c3c00c967d206d17457e0d301f2257"
+SRC_URI[md5sum] = "417a23cac840f6ea8bdd0841429c3c19"
+SRC_URI[sha256sum] = "0ec0846d991c38f355b4228ad8ea77aa69c3fdaa320cd574dafedc10c4688a5b"
 
 GEM_NAME = "concurrent-ruby"
 

--- a/recipes-rubygems/rubygems-http-cookie_1.0.4.bb
+++ b/recipes-rubygems/rubygems-http-cookie_1.0.4.bb
@@ -10,8 +10,8 @@ DEPENDS_class-native += "\
     rubygems-domain-name-native \
 "
 
-SRC_URI[md5sum] = "6a5ebc9f1b1f3628794c71b30ce7e5ec"
-SRC_URI[sha256sum] = "2f11269d817bc52ab2af2721e89a377660a961078de2a3a55fc696d7897e8c00"
+SRC_URI[md5sum] = "72925abeaa57cf214e93fee5ec101bbd"
+SRC_URI[sha256sum] = "89a64e1b9e3ed823b559b2030e0b62ad850d0d11325a0589145ebf93d80267a4"
 
 GEM_NAME = "http-cookie"
 

--- a/recipes-rubygems/rubygems-inspec-bin_4.37.25.bb
+++ b/recipes-rubygems/rubygems-inspec-bin_4.37.25.bb
@@ -10,8 +10,8 @@ DEPENDS_class-native += "\
     rubygems-inspec-native \
 "
 
-SRC_URI[md5sum] = "8d44e9a1cda2e8b88bd7c77cba358322"
-SRC_URI[sha256sum] = "206a2490877901b3b9f111fb30847efd380765191b9df06ef46b31af55bf3181"
+SRC_URI[md5sum] = "56e014ab147e5218100388af0ed513e9"
+SRC_URI[sha256sum] = "47498f6137e8734c26fed8d5c749f54888547737c4ea44529b9b4fd0fcf438dc"
 
 GEM_NAME = "inspec-bin"
 

--- a/recipes-rubygems/rubygems-inspec-core_4.37.25.bb
+++ b/recipes-rubygems/rubygems-inspec-core_4.37.25.bb
@@ -31,8 +31,8 @@ DEPENDS_class-native += "\
     rubygems-tty-table-native \
 "
 
-SRC_URI[md5sum] = "86b1a291a550f809a638a2e814cbe092"
-SRC_URI[sha256sum] = "0212fa9dc9901e058d04287932998122de746f93fafcd0cc45bb040ca2826f26"
+SRC_URI[md5sum] = "85f8103faf3d27bbd89bdec72fb2db17"
+SRC_URI[sha256sum] = "20c173248f8a4524906529e53fb6fcadc6bea37beec92cd0dba6ee411320d36b"
 
 GEM_NAME = "inspec-core"
 

--- a/recipes-rubygems/rubygems-inspec_4.37.25.bb
+++ b/recipes-rubygems/rubygems-inspec_4.37.25.bb
@@ -15,8 +15,8 @@ DEPENDS_class-native += "\
     rubygems-train-winrm-native \
 "
 
-SRC_URI[md5sum] = "e9980973d8845703f9cb2ea48a44f453"
-SRC_URI[sha256sum] = "a86413fb9d0ff072acada0bf185407392bd9d119ce58f01e011bff16b6e06f7f"
+SRC_URI[md5sum] = "c30843d149da9441aa2aa211ca94d988"
+SRC_URI[sha256sum] = "e22c1a19993f40820a28a3b40136ed49ca428f072640cbb997b3fc3bc2cb8039"
 
 GEM_NAME = "inspec"
 

--- a/recipes-rubygems/rubygems-puppet-resource-api_1.8.14.bb
+++ b/recipes-rubygems/rubygems-puppet-resource-api_1.8.14.bb
@@ -9,17 +9,18 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
 DEPENDS_class-native += "\
     rubygems-hocon-native \
 "
-RDEPENDS_${PN}_class-target += "\
-    rubygems-hocon \
-"
 
-SRC_URI[md5sum] = "3f6edad4f7a03713ff20d8ae0378e895"
-SRC_URI[sha256sum] = "db296a0046dac6bd14f56b39f1ac22c6503ba1c80ca2468f6c058cebd5c1a33d"
+SRC_URI[md5sum] = "aee660a8398fc1c4dff2154eeb8b5975"
+SRC_URI[sha256sum] = "920e4fe74983cdfd20ce6b38f302bafbad653956aaf89cd9058d839eb3b590b5"
 
 GEM_NAME = "puppet-resource_api"
 
 inherit rubygems
 inherit rubygentest
 inherit pkgconfig
+
+RDEPENDS_${PN}_class-target += "\
+    rubygems-hocon \
+"
 
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-semantic-puppet_1.0.4.bb
+++ b/recipes-rubygems/rubygems-semantic-puppet_1.0.4.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/puppetlabs/semantic_puppet"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=8737b067d16e724769a2968ed8d6373f"
 
-SRC_URI[md5sum] = "36e4e7d0f0fb4d8f93e005ba6e330528"
-SRC_URI[sha256sum] = "3b83bff3bed1188d603947184c0e3ee4443543e3e832edccc7127b6209bb292b"
+SRC_URI[md5sum] = "bf36de9dffe6bc035a862bf0c3dc034b"
+SRC_URI[sha256sum] = "5d8380bf733c1552ef77e06a7c44a6d5b48def7d390ecf3bd71cad477f5ce13d"
 
 GEM_NAME = "semantic_puppet"
 

--- a/recipes-rubygems/rubygems-virtus_2.0.0.bb
+++ b/recipes-rubygems/rubygems-virtus_2.0.0.bb
@@ -10,11 +10,10 @@ DEPENDS_class-native += "\
     rubygems-axiom-types-native \
     rubygems-coercible-native \
     rubygems-descendants-tracker-native \
-    rubygems-equalizer-native \
 "
 
-SRC_URI[md5sum] = "83051103a3439993d685a0c023b5f9f2"
-SRC_URI[sha256sum] = "d3053b9ff62d3f8b7b233f7e1aa9530b73ed7e541bee2c62f2c711362287371a"
+SRC_URI[md5sum] = "9a3cd6a019c80c3465ce783ea9091cf5"
+SRC_URI[sha256sum] = "8841dae4eb7fcc097320ba5ea516bf1839e5d056c61ee27138aa4bddd6e3d1c2"
 
 GEM_NAME = "virtus"
 
@@ -26,7 +25,6 @@ RDEPENDS_${PN}_class-target += "\
     rubygems-axiom-types \
     rubygems-coercible \
     rubygems-descendants-tracker \
-    rubygems-equalizer \
 "
 
 BBCLASSEXTEND = "native"


### PR DESCRIPTION
* aws-sdk-core: update to 3.114.2
* concurrent-ruby: update to 1.1.9
* chef-utils: update to 17.2.29
* chef-config: update to 17.2.29
* inspec-core: update to 4.37.25
* virtus: update to 2.0.0
* aws-sdk-redshift: update to 1.63.0
* aws-sdk-transfer: update to 1.34.0
* aws-sdk-eks: update to 1.55.0
* http-cookie: update to 1.0.4
* aws-sdk-ec2: update to 1.242.0
* aws-sdk-ram: update to 1.26.0
* aws-sdk-glue: update to 1.88.0
* aws-sdk-s3: update to 1.96.1
* aws-sdk-servicecatalog: update to 1.60.0
* aws-sdk-cognitoidentityprovider: update to 1.53.0
* puppet-resource_api: update to 1.8.14
* inspec: update to 4.37.25
* semantic_puppet: update to 1.0.4
* inspec-bin: update to 4.37.25
* chef: update to 17.2.29