### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-activemodel_6.1.4.bb
+++ b/recipes-rubygems/rubygems-activemodel_6.1.4.bb
@@ -10,8 +10,8 @@ DEPENDS_class-native += "\
     rubygems-activesupport-native \
 "
 
-SRC_URI[md5sum] = "663ad8020b8549e16437a9dec9b32213"
-SRC_URI[sha256sum] = "5459410a49855d18b89ecf2d509cb74924e37559a01a991b41d9fb4c201cedbe"
+SRC_URI[md5sum] = "7cc71c8aa1ad204ca96529c4a077cd87"
+SRC_URI[sha256sum] = "27f3223172e81b8e60e7da7f3b812bba046472716def6793d89c177b9e435e76"
 
 GEM_NAME = "activemodel"
 

--- a/recipes-rubygems/rubygems-activesupport_6.1.4.bb
+++ b/recipes-rubygems/rubygems-activesupport_6.1.4.bb
@@ -14,8 +14,8 @@ DEPENDS_class-native += "\
     rubygems-zeitwerk-native \
 "
 
-SRC_URI[md5sum] = "1863d3975e3f2f631abc802791d43159"
-SRC_URI[sha256sum] = "d9074834deca6676aabd432f16c392e991eca1f675cbcefc38671a0a7d6b5db3"
+SRC_URI[md5sum] = "765f79e5e623c45cef6decfc965cab80"
+SRC_URI[sha256sum] = "b37564f4fc3bc66f3f98d3032b8bb8cbdbd23ba0f7c02648287048463cf70f4f"
 
 GEM_NAME = "activesupport"
 

--- a/recipes-rubygems/rubygems-aws-partitions_1.472.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.472.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-SRC_URI[md5sum] = "cb5da46072525640a4bcf5c16684a0e8"
-SRC_URI[sha256sum] = "79b5cd7c023cd6f7ab4ab8994ff06edfa2615a4212c878a29b22e8f1ab2c0676"
+SRC_URI[md5sum] = "e3fd6f478433929626c60ccb0845c2f8"
+SRC_URI[sha256sum] = "7381d8233ac203e247734c3e32cc4ca507ed2be9135c09234644ad7a76bffed8"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudformation_1.53.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudformation_1.53.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "dd47cfe6a58d1d3a4da6c3dbc2e4a253"
-SRC_URI[sha256sum] = "47e1d3c949b56714fcf6588dd8214ba9b392a7758741074904cd77cde0483b01"
+SRC_URI[md5sum] = "0eaa43628b3a45039d576d2816c6992a"
+SRC_URI[sha256sum] = "c333f09d492d7fced12e71ce11a4b2d1866ae6da64f036a4d0910492f918fd96"
 
 GEM_NAME = "aws-sdk-cloudformation"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.52.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.52.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "18158206a8e2d90f84d4f6aa6f02bad6"
-SRC_URI[sha256sum] = "14f0aea310971b29ff78013033bdca51147e8fc4c91828fa91df1330b8947461"
+SRC_URI[md5sum] = "c5f10e3cb407b8333e40543a4f2b95bb"
+SRC_URI[sha256sum] = "d4edeab774a8b4fd725f809582be6fb46ee60a133c6f5d345cb7e012e640ba62"
 
 GEM_NAME = "aws-sdk-cloudfront"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatchevents_1.47.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatchevents_1.47.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "82e47b50896879f65e42e62bbdb764f2"
-SRC_URI[sha256sum] = "6218116e13fe2d2d41a2f6567b2ff389c567503fe50dda29b18652de5adcdef5"
+SRC_URI[md5sum] = "842ab516196c74a577d5d97cebe6f598"
+SRC_URI[sha256sum] = "f656112028bba844731e213ca5a3e19dfede606409152f4d61094fe91f41ccbb"
 
 GEM_NAME = "aws-sdk-cloudwatchevents"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.115.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.115.0.bb
@@ -13,8 +13,8 @@ DEPENDS_class-native += "\
     rubygems-jmespath-native \
 "
 
-SRC_URI[md5sum] = "088b216e725a533ba6aee2725a4da803"
-SRC_URI[sha256sum] = "ccb1c219f9b79a4269ed8534810af9f518a9537e8e552608630430ea882f9383"
+SRC_URI[md5sum] = "7a95ddd58115f245452dd2b11e5aea2f"
+SRC_URI[sha256sum] = "b88401fb9cee40e4699f808da48e792206fff269651bb0e18e62494b242f9a19"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.245.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.245.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "f06272f18715128cf585f6391339cf0b"
-SRC_URI[sha256sum] = "e6fedc7f6b723c1f197e56e31956f3fc6e7ddec46353ae51d2b83255d9ebd776"
+SRC_URI[md5sum] = "55d03fecb2bbd058f40b931828227f43"
+SRC_URI[sha256sum] = "9a6fd764f6f987a37df3023137db480d90f8333a1156a3453dc4ea9d897d95e3"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eventbridge_1.25.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eventbridge_1.25.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "9fecd6d8789076d0b371a3db3a00ae35"
-SRC_URI[sha256sum] = "42ae41cd789de9fac80bf2d4ba8259f54ca5211524f2a8eac6812a0e37bf41b2"
+SRC_URI[md5sum] = "004fcd40e89f3923f2387d22fd0add6d"
+SRC_URI[sha256sum] = "8bc6244a5f05ae5ab8f0a291370be1a5309bbc3f8b5bfbe5d503297ba50b93b1"
 
 GEM_NAME = "aws-sdk-eventbridge"
 

--- a/recipes-rubygems/rubygems-aws-sdk-securityhub_1.47.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-securityhub_1.47.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "7459d71f8e39ddf09f5c6645dfba31d6"
-SRC_URI[sha256sum] = "b17fd76fb78785cbe839d7f965e9c9837d4deb8cb10dbc755f745809a230dcc2"
+SRC_URI[md5sum] = "2897103dc4b4e0b944f7112e0253c24a"
+SRC_URI[sha256sum] = "406b01c357c73cf368d37936d9667e83025e9c4fd2ee58c6df103ab8ddedc550"
 
 GEM_NAME = "aws-sdk-securityhub"
 

--- a/recipes-rubygems/rubygems-aws-sdk-transfer_1.35.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-transfer_1.35.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "2ce127f9c0e384805b8528139267c8e4"
-SRC_URI[sha256sum] = "f62121bf12994d62ac494988673497022f6dd9be987f6c8f47236cad31bbff04"
+SRC_URI[md5sum] = "13ff979362e9d46b07fe510c9726b28b"
+SRC_URI[sha256sum] = "a3446473628075d0e9677a774b4e0002990302ed9f86e3be2689f70a6ab22245"
 
 GEM_NAME = "aws-sdk-transfer"
 

--- a/recipes-rubygems/rubygems-chef-zero_15.0.7.bb
+++ b/recipes-rubygems/rubygems-chef-zero_15.0.7.bb
@@ -14,6 +14,16 @@ DEPENDS_class-native += "\
     rubygems-uuidtools-native \
     rubygems-webrick-native \
 "
+
+SRC_URI[md5sum] = "fd2ec3b3ee341f8c5192271a1d136581"
+SRC_URI[sha256sum] = "20c37db613c66dda47d4d032a7838904bbec53b67f0c6727fd2ab5008ae1b83d"
+
+GEM_NAME = "chef-zero"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
 RDEPENDS_${PN}_class-target += "\
     rubygems-ffi-yajl \
     rubygems-hashie \
@@ -22,16 +32,5 @@ RDEPENDS_${PN}_class-target += "\
     rubygems-uuidtools \
     rubygems-webrick \
 "
-
-SRC_URI[md5sum] = "a00156fa94546e3dac6d3182c97f37c2"
-SRC_URI[sha256sum] = "8d776ea3b4e0a5c3acf429ca2343643e5c6ae5c8cf8d228756710ff7eec0bb1b"
-
-GEM_NAME = "chef-zero"
-
-
-
-inherit rubygems
-inherit rubygentest
-inherit pkgconfig
 
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-faraday_1.4.3.bb
+++ b/recipes-rubygems/rubygems-faraday_1.4.3.bb
@@ -16,8 +16,8 @@ DEPENDS_class-native += "\
     rubygems-ruby2-keywords-native \
 "
 
-SRC_URI[md5sum] = "77cdd35f32618ae19e7fc2a13dfba443"
-SRC_URI[sha256sum] = "fbac4fc71c941a7030bdf65edc6e84de4e080e3164b48ac6bba390fdc099b01e"
+SRC_URI[md5sum] = "00b8922d7de2fd81e341c77ff0d1f8cb"
+SRC_URI[sha256sum] = "9ed6a26c93bdafef7170f0712e1036df45a098ab5acb8730e77016600dd5ad7e"
 
 GEM_NAME = "faraday"
 

--- a/recipes-rubygems/rubygems-puppet_7.8.0.bb
+++ b/recipes-rubygems/rubygems-puppet_7.8.0.bb
@@ -19,8 +19,8 @@ DEPENDS_class-native += "\
     rubygems-semantic-puppet-native \
 "
 
-SRC_URI[md5sum] = "81cfcab6f6998bf7cfbcf0c91a72a469"
-SRC_URI[sha256sum] = "4f28baea61b0f879d51567dc775e1c2df79c9f09b334e8fd4051cd7f01014445"
+SRC_URI[md5sum] = "a22a67dd03161889d9e1ecf848da0535"
+SRC_URI[sha256sum] = "a192df83b9e4c775cf14e557bb4114805335b9125b673042c3f67b4ed5f07ffa"
 
 GEM_NAME = "puppet"
 

--- a/recipes-rubygems/rubygems-serverspec_2.41.8.bb
+++ b/recipes-rubygems/rubygems-serverspec_2.41.8.bb
@@ -13,8 +13,8 @@ DEPENDS_class-native += "\
     rubygems-specinfra-native \
 "
 
-SRC_URI[md5sum] = "bd045d8100901f9a3ce6eaa5cc097202"
-SRC_URI[sha256sum] = "90c9b73ee7320c2707a7671493a0b023f1c7265604cb9a40f2805bb27cdbe4af"
+SRC_URI[md5sum] = "0a6e7e3c1b9345af4e05d39d8ce0a204"
+SRC_URI[sha256sum] = "c18d9e29cc499c3233d73ebe40b8d701f6bee447b8a34944586a66efde19f5aa"
 
 GEM_NAME = "serverspec"
 

--- a/recipes-rubygems/rubygems-train-core_3.7.4.bb
+++ b/recipes-rubygems/rubygems-train-core_3.7.4.bb
@@ -15,8 +15,8 @@ DEPENDS_class-native += "\
     rubygems-net-ssh-native \
 "
 
-SRC_URI[md5sum] = "b7bfbf61ff38756ec9b6f4ca86bf9ffc"
-SRC_URI[sha256sum] = "477f8fc8c5725d4a45b77d0df6680dcd064820c7171a5d05b3a05e4f906703eb"
+SRC_URI[md5sum] = "81d5f5ba4008de4bfe4d1e5729508fe2"
+SRC_URI[sha256sum] = "fbfe3eb8240572309102057e9c1435c716a3b0b4431ef3868fabd26b3b5483dc"
 
 GEM_NAME = "train-core"
 

--- a/recipes-rubygems/rubygems-train_3.7.4.bb
+++ b/recipes-rubygems/rubygems-train_3.7.4.bb
@@ -21,8 +21,8 @@ DEPENDS_class-native += "\
     rubygems-train-winrm-native \
 "
 
-SRC_URI[md5sum] = "0a1cba7fff82a4499199244c1746b3e3"
-SRC_URI[sha256sum] = "f9d72d312a3a913ebc0d0bf56a8ef3d33128ffc28cc2766f3be46aa8a0da1eb2"
+SRC_URI[md5sum] = "f22f4f9724556b0e1b80c344f389e220"
+SRC_URI[sha256sum] = "15a4f66271e90947c37b50d84155e73749ddd0ceeddab323d78348feec3ff135"
 
 GEM_NAME = "train"
 


### PR DESCRIPTION
* aws-sdk-core: update to 3.115.0
* faraday: update to 1.4.3
* train-core: update to 3.7.4
* activesupport: update to 6.1.4
* chef-zero: update to 15.0.7
* aws-sdk-cloudformation: update to 1.53.0
* aws-sdk-cloudwatchevents: update to 1.47.0
* train: update to 3.7.4
* aws-sdk-securityhub: update to 1.47.0
* aws-sdk-transfer: update to 1.35.0
* aws-sdk-cloudfront: update to 1.52.0
* puppet: update to 7.8.0
* aws-sdk-ec2: update to 1.245.0
* aws-sdk-eventbridge: update to 1.25.0
* activemodel: update to 6.1.4
* serverspec: update to 2.41.8