### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.479.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.479.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-SRC_URI[md5sum] = "d9972dc50f8895644af5b17794368b02"
-SRC_URI[sha256sum] = "1e07e2eed0ed307ac89ed44943911d252d0686a2a1187a4c13a3ae8b12a80d51"
+SRC_URI[md5sum] = "5d316a4041f38bc38071498adfdd9d79"
+SRC_URI[sha256sum] = "b087bfa8791b7d6614dcc2fb132527aeeda7e7ea50d34959369fa74fcf321a24"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cognitoidentityprovider_1.54.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cognitoidentityprovider_1.54.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "0df8287fd549ac261e31c736d5ae056f"
-SRC_URI[sha256sum] = "456c432bc3551b0431fd9cf6549142e633f22708ee7594aa35e5b4d2401d5b48"
+SRC_URI[md5sum] = "3a965f0f4de5192dd2edb897615936b9"
+SRC_URI[sha256sum] = "b5a5791acb45b0cb9053d2d392823effdec5e05c12ccfd949a4e0aebd13e150b"
 
 GEM_NAME = "aws-sdk-cognitoidentityprovider"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.117.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.117.0.bb
@@ -13,8 +13,8 @@ DEPENDS_class-native += "\
     rubygems-jmespath-native \
 "
 
-SRC_URI[md5sum] = "68e01602e1053d410fd1a57482b11277"
-SRC_URI[sha256sum] = "7516882a3ccbfed603849dcd51160714ec5c5fd0b6dfb98b6637d4d63e0d596e"
+SRC_URI[md5sum] = "9bbdd5313b8d01736e208ee540bc67fa"
+SRC_URI[sha256sum] = "5d65e093d71d3077436b4da29e9af363532e777605bd543b4d831efffd7a8ad5"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-databasemigrationservice_1.54.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-databasemigrationservice_1.54.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "1ce2f08c33bd63b75196909a2c4b2533"
-SRC_URI[sha256sum] = "865414c83054e4026548edb55adc8b6b9ae1abd70320173c5f7519d1565df74e"
+SRC_URI[md5sum] = "0ea2149498393f7e37dcaf91cb19a5de"
+SRC_URI[sha256sum] = "624f5f4acb3cd688fc8865b4e3adc6da8256758416ee3e760b800b5df75cdc8d"
 
 GEM_NAME = "aws-sdk-databasemigrationservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.249.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.249.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "47e1f553357a665c7ce00b56a590dc47"
-SRC_URI[sha256sum] = "a57d2351d2113f89c2df2bfdc209134c151a2adb8d8a3a0b9b5dea34e60e19e8"
+SRC_URI[md5sum] = "87a28871239b67cb79133cc832fc1bb4"
+SRC_URI[sha256sum] = "ae2afd89cb5d27a55a3ff86a9c914aaf7d1bb7306ad49fc7ed54d6bff0a1ded8"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.81.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.81.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "26e897e828bd952412f25f9759445b96"
-SRC_URI[sha256sum] = "fa029e1c80a936e8e7e10a1ee23c401775f679671ad2c268ecd7a260e87dd5e7"
+SRC_URI[md5sum] = "b5c4d56fd89df7c702c9c09d9daccfe8"
+SRC_URI[sha256sum] = "1beb9871d57bcf1fb33c3d6a722f8beb1b386b30d81e388a8f9fcff6994192b6"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eks_1.58.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eks_1.58.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "e9e3b657e13e9aad86576da19edd540b"
-SRC_URI[sha256sum] = "7b71e5b631fc40d47e928ddb561a8989ff8fa40781647bcba35d172026b8dba3"
+SRC_URI[md5sum] = "17e2f555f8f1a514eaa1c52abc0ed667"
+SRC_URI[sha256sum] = "c55c2c2f66ebafcac66237435c4b996862e7342deb6546985168b9f4dbc6e713"
 
 GEM_NAME = "aws-sdk-eks"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.90.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.90.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "58b66140b1366279ae4191738cb927e5"
-SRC_URI[sha256sum] = "496562b5c4480ec938fa24089c556e456a7eff0c72a0da9f53765aa68ca81ecf"
+SRC_URI[md5sum] = "905e9a6e0a6a1457797c1374a333b7bc"
+SRC_URI[sha256sum] = "f1dbdcec48d58107894b8e2d2e82e69809fc0381da25161fe002faf5ad32ca68"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-kinesis_1.32.1.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-kinesis_1.32.1.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "9a618b8d2620bcc5b6ac34000a69cd73"
-SRC_URI[sha256sum] = "6bde717c3b95ca2fdc780f2564df61cd3b7e989ebf0479b64a3bd99d4ec35e5e"
+SRC_URI[md5sum] = "da16e1c534194d77c75ec07939e2ad37"
+SRC_URI[sha256sum] = "de14529dad941fc4471c74e3e1111f32d435a5e380404f8930821b589582e675"
 
 GEM_NAME = "aws-sdk-kinesis"
 

--- a/recipes-rubygems/rubygems-aws-sdk-redshift_1.65.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-redshift_1.65.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "111e1b85c2f1df84be2e5c528efe6c0b"
-SRC_URI[sha256sum] = "2cdb1def9da7d11f4463566a091480db255481436a8da97d10fe5491643e1872"
+SRC_URI[md5sum] = "9272d0aeaadbf6033b12bd9edca63491"
+SRC_URI[sha256sum] = "2d89efa770746edf00200c86c9d3d994de71598dcff57f9ef7a20889935aacd2"
 
 GEM_NAME = "aws-sdk-redshift"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ssm_1.112.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ssm_1.112.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "27bbf97bc33e2556275ff0a4c1013a69"
-SRC_URI[sha256sum] = "f38fafe5b71a1b11ab50751c3dc78eb6e9683732c289eb787f26881202dd4456"
+SRC_URI[md5sum] = "859c83518f7ee45d0632907d3aa9f5a0"
+SRC_URI[sha256sum] = "38954885e34b9ea59a52695e3ae2465c94f5ee100bd453ae095ad537a4996a41"
 
 GEM_NAME = "aws-sdk-ssm"
 

--- a/recipes-rubygems/rubygems-excon_0.85.0.bb
+++ b/recipes-rubygems/rubygems-excon_0.85.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/excon/excon"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=8b04a0291ec55b31563a50b191b72cb1"
 
-SRC_URI[md5sum] = "733ac13884bfa67f9b87047aeb35e9d9"
-SRC_URI[sha256sum] = "746959de8a506ad5ebc4318d2ea6e0c4b6674fa915d64284e20371be84cadaa0"
+SRC_URI[md5sum] = "f23826d2b87acfddc85e1b794d133169"
+SRC_URI[sha256sum] = "ea0c472e3231eed9d851c3dd8b4cacab66f8fe096ab4f86036a235230577d3c7"
 
 GEM_NAME = "excon"
 

--- a/recipes-rubygems/rubygems-faraday-net-http-persistent_1.2.0.bb
+++ b/recipes-rubygems/rubygems-faraday-net-http-persistent_1.2.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/lostisland/faraday-net_http_persistent"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=20830660ee48a0c845a62aad77c18f4a"
 
-SRC_URI[md5sum] = "ae97b1005af8471b25b27c87e361ded0"
-SRC_URI[sha256sum] = "6a2654cac6311421a6d218aaf104bff333425768d025723b19fb1dcacb404c50"
+SRC_URI[md5sum] = "e13bafd2297cbf703e0385e142c9ce62"
+SRC_URI[sha256sum] = "0b0cbc8f03dab943c3e1cc58d8b7beb142d9df068b39c718cd83e39260348335"
 
 GEM_NAME = "faraday-net_http_persistent"
 

--- a/recipes-rubygems/rubygems-faraday_1.5.1.bb
+++ b/recipes-rubygems/rubygems-faraday_1.5.1.bb
@@ -18,8 +18,8 @@ DEPENDS_class-native += "\
     rubygems-ruby2-keywords-native \
 "
 
-SRC_URI[md5sum] = "f76b42b360cda06c66b20d5904534d17"
-SRC_URI[sha256sum] = "5001f0d51f989c9a37298e888e518bbdb0dc3ffc7c0931255da9d25b488c8b3f"
+SRC_URI[md5sum] = "a813238de0bc88b12cb4f8f9d7a96175"
+SRC_URI[sha256sum] = "c3e4bbf81f80defffc43a0f5bb44b4beeada3bae02f52afad74f5165084ff8f6"
 
 GEM_NAME = "faraday"
 

--- a/recipes-rubygems/rubygems-ruby2-keywords_0.0.5.bb
+++ b/recipes-rubygems/rubygems-ruby2-keywords_0.0.5.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/ruby/ruby2_keywords"
 LICENSE = "Ruby & BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4cf5ceb8f271a96fe2e4ab32bc1e828d"
 
-SRC_URI[md5sum] = "5e7c39f4ff29e86a992d6c98bc9160d3"
-SRC_URI[sha256sum] = "3ae3189c2e1d2f60204dcceedf890ff49dd28979771e2576016a3ee73b668e97"
+SRC_URI[md5sum] = "89bc1e9231e63a0f93599772ae871e03"
+SRC_URI[sha256sum] = "ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef"
 
 GEM_NAME = "ruby2_keywords"
 


### PR DESCRIPTION
* aws-sdk-core: update to 3.117.0
* faraday: update to 1.5.1
* aws-sdk-cognitoidentityprovider: update to 1.54.0
* aws-sdk-eks: update to 1.58.0
* excon: update to 0.85.0
* aws-sdk-databasemigrationservice: update to 1.54.0
* aws-sdk-redshift: update to 1.65.0
* aws-sdk-glue: update to 1.90.0
* aws-sdk-ec2: update to 1.249.0
* aws-sdk-ecs: update to 1.81.0
* aws-sdk-ssm: update to 1.112.0
* aws-sdk-kinesis: update to 1.32.1