### PR TITLE
Update ruby-cross to 3.0.2

### DIFF
--- a/recipes-devtools/ruby-cross_3.0.2.bb
+++ b/recipes-devtools/ruby-cross_3.0.2.bb
@@ -41,7 +41,7 @@ SRC_URI_append = " \
                   file://0001-Makefile-cross-compile-fixes.patch \
                  "
 
-SRC_URI[sha256sum] = "369825db2199f6aeef16b408df6a04ebaddb664fb9af0ec8c686b0ce7ab77727"
+SRC_URI[sha256sum] = "5085dee0ad9f06996a8acec7ebea4a8735e6fac22f22e2d98c3f2bc3bef7e6f1"
 
 S = "${WORKDIR}/ruby-${PV}"
 


### PR DESCRIPTION
Closes #182

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>