### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.251.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.251.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "87a28871239b67cb79133cc832fc1bb4"
-SRC_URI[sha256sum] = "ae2afd89cb5d27a55a3ff86a9c914aaf7d1bb7306ad49fc7ed54d6bff0a1ded8"
+SRC_URI[md5sum] = "282c11a02a7c0b954b4ad2813b33617d"
+SRC_URI[sha256sum] = "e72b63994c5c881259a0dfee9ee9bb55878f98eef1e5cabed9582308d298446f"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticloadbalancingv2_1.64.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticloadbalancingv2_1.64.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "afca8496e9f58a3a4e86e818274a9862"
-SRC_URI[sha256sum] = "bc3aecf86923ce62e21f179701a350d53e244c130a83893d7ec9c3edc07978fb"
+SRC_URI[md5sum] = "2d81f8e6f539c3ecc92e47b4e68de72a"
+SRC_URI[sha256sum] = "16671fa65ebaa0961517b817052c625efcd1d0674fcddb32a393f82afd1540ec"
 
 GEM_NAME = "aws-sdk-elasticloadbalancingv2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-iam_1.57.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-iam_1.57.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "5a27a3acadd0d755807139b0a933729c"
-SRC_URI[sha256sum] = "f08ea20960f80855ed541b6e56973164985df749b244572d190481b4d4526034"
+SRC_URI[md5sum] = "5dd7a1519d044238fc3a0a61b2ae4758"
+SRC_URI[sha256sum] = "9ee04362fd6e125f9c079623b909b2deafc7abf923f45bd34763edc6c023ad5a"
 
 GEM_NAME = "aws-sdk-iam"
 

--- a/recipes-rubygems/rubygems-aws-sdk-lambda_1.64.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-lambda_1.64.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "f072994111f8f9d849ab2054309a7f0a"
-SRC_URI[sha256sum] = "7f3ffc279f476475cfdb8c991f11a49b78a6f9cd7dc62fb5ec3707e93eb58909"
+SRC_URI[md5sum] = "961fcec43fd8c4d7c03e5052a92b6213"
+SRC_URI[sha256sum] = "3e54bfdd03e80df13eaa9ccbbc7dfaec4d8846969744ce7f3411e2978c8e1761"
 
 GEM_NAME = "aws-sdk-lambda"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.122.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.122.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "44be33886fbd1e73df3b1352557c2c1a"
-SRC_URI[sha256sum] = "684012eab148892c333f212c1da596e6090a039cf1761d30cefa3093a00e8864"
+SRC_URI[md5sum] = "68c19b713299bb071c4f17a6dfa3c18f"
+SRC_URI[sha256sum] = "3590ff97e306e3fd7a7908cacb83615c5ed824b13605ad20dcffe81ff7a05453"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.96.2.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.96.2.bb
@@ -12,8 +12,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "0378cbef612bc262b09f0b535745ba61"
-SRC_URI[sha256sum] = "d004844475c3d06514e78696e8dab7e2a2653b861f00c8137782897a6b5b4860"
+SRC_URI[md5sum] = "4e5be630412758dd575e002fda5940bd"
+SRC_URI[sha256sum] = "1c3b4609963de97366c641c057d0e1064b184f5a9cec3c0d746bcde9450ff9e1"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-aws-sdk-securityhub_1.48.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-securityhub_1.48.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "2897103dc4b4e0b944f7112e0253c24a"
-SRC_URI[sha256sum] = "406b01c357c73cf368d37936d9667e83025e9c4fd2ee58c6df103ab8ddedc550"
+SRC_URI[md5sum] = "719f49328d10ffa6ce008459ecd2ed81"
+SRC_URI[sha256sum] = "ed9bfabeb43e008980dd2feba8223800b5027f3ccd28840f80059c333055fb02"
 
 GEM_NAME = "aws-sdk-securityhub"
 

--- a/recipes-rubygems/rubygems-chef-config_17.3.48.bb
+++ b/recipes-rubygems/rubygems-chef-config_17.3.48.bb
@@ -15,8 +15,8 @@ DEPENDS_class-native += "\
     rubygems-tomlrb-native \
 "
 
-SRC_URI[md5sum] = "32c16ef50c45ed8364f73e75c4e23159"
-SRC_URI[sha256sum] = "4d03dd2ae76b25646547bea8797bd0912315101c7c68837d195cb703b00aaca1"
+SRC_URI[md5sum] = "253b74622c0c86f6433b04b6c7c95c8e"
+SRC_URI[sha256sum] = "6ddb0643a2eb1102d596e0ea94bfd22c0b933a2f5d867de1229d75e2b764331b"
 
 GEM_NAME = "chef-config"
 

--- a/recipes-rubygems/rubygems-chef-utils_17.3.48.bb
+++ b/recipes-rubygems/rubygems-chef-utils_17.3.48.bb
@@ -10,8 +10,8 @@ DEPENDS_class-native += "\
     rubygems-concurrent-ruby-native \
 "
 
-SRC_URI[md5sum] = "3c8711330c7f6c6697740cfac7a0c7a8"
-SRC_URI[sha256sum] = "a264bdbd5df46253eaf7f3f5812857a76b81d5b96f51d102efdffe44ac66c6cc"
+SRC_URI[md5sum] = "7bbbfa687ee235867ffcdf8058748170"
+SRC_URI[sha256sum] = "2cdde3512dd35dc8e5fc7de6b7018e1ef0f9b7902456511298532396c0b40f55"
 
 GEM_NAME = "chef-utils"
 

--- a/recipes-rubygems/rubygems-chef_17.3.48.bb
+++ b/recipes-rubygems/rubygems-chef_17.3.48.bb
@@ -8,6 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=8f7bb094c7232b058c7e9f2e431f389c"
 
 DEPENDS_class-native += "\
     rubygems-addressable-native \
+    rubygems-aws-sdk-secretsmanager-native \
     rubygems-chef-config-native \
     rubygems-chef-utils-native \
     rubygems-chef-vault-native \
@@ -35,8 +36,8 @@ DEPENDS_class-native += "\
     rubygems-uuidtools-native \
 "
 
-SRC_URI[md5sum] = "e436da7f78fa680648cda071551a7ec6"
-SRC_URI[sha256sum] = "eaa653e081b5f677a6f8f86f6e0ae311628e5c79a247909160592ca19412b067"
+SRC_URI[md5sum] = "472986bbad120568c5b5aaf82912cae1"
+SRC_URI[sha256sum] = "d985a90d07e49b92092bc667ee7837861e8135e0231c473cd726fd7b1e3d1696"
 
 GEM_NAME = "chef"
 
@@ -55,6 +56,7 @@ do_install_append() {
 
 RDEPENDS_${PN}_class-target += "\
     rubygems-addressable \
+    rubygems-aws-sdk-secretsmanager \
     rubygems-chef-config \
     rubygems-chef-utils \
     rubygems-chef-vault \

--- a/recipes-rubygems/rubygems-google-apis-core_0.4.1.bb
+++ b/recipes-rubygems/rubygems-google-apis-core_0.4.1.bb
@@ -17,8 +17,8 @@ DEPENDS_class-native += "\
     rubygems-webrick-native \
 "
 
-SRC_URI[md5sum] = "3d0687b3c815ad736c9fe282e6a65f34"
-SRC_URI[sha256sum] = "7a0028c41b134f7925bf6c7b60226fd3f24753e48ae1eefc9e974637e7af7ee0"
+SRC_URI[md5sum] = "db03b189498cd9f1febb787b4a2b613f"
+SRC_URI[sha256sum] = "1e334ff47ce35680f0bb701abeaa94cbb48af77d7f62b96aa3293fca8c91ffdb"
 
 GEM_NAME = "google-apis-core"
 

--- a/recipes-rubygems/rubygems-inspec-bin_4.38.9.bb
+++ b/recipes-rubygems/rubygems-inspec-bin_4.38.9.bb
@@ -10,8 +10,8 @@ DEPENDS_class-native += "\
     rubygems-inspec-native \
 "
 
-SRC_URI[md5sum] = "1a1e15a76d80a2dc3dfc3206a5829419"
-SRC_URI[sha256sum] = "a4ed6a4e341cca985a6a72954d50a821ad5808aa5a7401ed3d5668b684ff855c"
+SRC_URI[md5sum] = "2b63febc743e280b36f0d7bf585219bf"
+SRC_URI[sha256sum] = "06ac64feb82c8adec4757e46acf2873d8aece46bcd9741974633edbaad5ca6c1"
 
 GEM_NAME = "inspec-bin"
 

--- a/recipes-rubygems/rubygems-inspec-core_4.38.9.bb
+++ b/recipes-rubygems/rubygems-inspec-core_4.38.9.bb
@@ -31,8 +31,8 @@ DEPENDS_class-native += "\
     rubygems-tty-table-native \
 "
 
-SRC_URI[md5sum] = "7342d86c9302431ce405abf9683e74e9"
-SRC_URI[sha256sum] = "fe525c1b33168c1cdeec31bebbe98aafedaaf87fc32068a638827ef710104898"
+SRC_URI[md5sum] = "ae5dd39c34a0471a95283bf08536f1e9"
+SRC_URI[sha256sum] = "d4b7f62ba96df66148f0f8ba07a78a2179de7ec0c6e830460f455a93890e940b"
 
 GEM_NAME = "inspec-core"
 

--- a/recipes-rubygems/rubygems-inspec_4.38.9.bb
+++ b/recipes-rubygems/rubygems-inspec_4.38.9.bb
@@ -17,8 +17,8 @@ DEPENDS_class-native += "\
     rubygems-train-winrm-native \
 "
 
-SRC_URI[md5sum] = "7a9dcfbd9120a87776215ba502ef787f"
-SRC_URI[sha256sum] = "331f3adff5ddbc5a0e0e3adb90543490945b12ae41298ae401f3e5321bbe9c3e"
+SRC_URI[md5sum] = "d4eb6368c64334ce49dff15840d35a15"
+SRC_URI[sha256sum] = "256fcad08903b980baa0a91e861dba5ff72cba209c5163232af5af96927e7924"
 
 GEM_NAME = "inspec"
 

--- a/recipes-rubygems/rubygems-listen_3.6.0.bb
+++ b/recipes-rubygems/rubygems-listen_3.6.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-rb-inotify-native \
 "
 
-SRC_URI[md5sum] = "13acebd3800bdea503c24808f61a3847"
-SRC_URI[sha256sum] = "d2f6425068347454936c75bf3b9fc0f925b40d17ba7df752031c8c083b195b40"
+SRC_URI[md5sum] = "263bd6742583d73d1628d77914193e6c"
+SRC_URI[sha256sum] = "f095d31f66f8cef7142d0658697961900f3ee3d3223980a3bc8ca9a449f307b7"
 
 GEM_NAME = "listen"
 

--- a/recipes-rubygems/rubygems-ohai_17.3.1.bb
+++ b/recipes-rubygems/rubygems-ohai_17.3.1.bb
@@ -21,8 +21,8 @@ DEPENDS_class-native += "\
     rubygems-wmi-lite-native \
 "
 
-SRC_URI[md5sum] = "6fb471f3ed24be521945114e7a2e8920"
-SRC_URI[sha256sum] = "064261cfc51f2c2a841d0081a2b94705491382871dfc64c3e916ab57f736b511"
+SRC_URI[md5sum] = "b9a991973d58e273a95eb80f3e6540c7"
+SRC_URI[sha256sum] = "b641f92758c21696b642131d1b268ec013a13d0f8f36387624bcba43eccc6cd9"
 
 GEM_NAME = "ohai"
 

--- a/recipes-rubygems/rubygems-puppet_7.9.0.bb
+++ b/recipes-rubygems/rubygems-puppet_7.9.0.bb
@@ -19,8 +19,8 @@ DEPENDS_class-native += "\
     rubygems-semantic-puppet-native \
 "
 
-SRC_URI[md5sum] = "a22a67dd03161889d9e1ecf848da0535"
-SRC_URI[sha256sum] = "a192df83b9e4c775cf14e557bb4114805335b9125b673042c3f67b4ed5f07ffa"
+SRC_URI[md5sum] = "a7890ae0e572e1a5d852669a66b1d445"
+SRC_URI[sha256sum] = "59075fa2069694c0f7d3e9de1e14fe2f49f976e58d7210c7aa47a12cd9191101"
 
 GEM_NAME = "puppet"
 


### PR DESCRIPTION
* chef-utils: update to 17.3.48
* google-apis-core: update to 0.4.1
* chef-config: update to 17.3.48
* inspec-core: update to 4.38.9
* aws-sdk-securityhub: update to 1.48.0
* aws-sdk-elasticloadbalancingv2: update to 1.64.0
* aws-sdk-lambda: update to 1.64.0
* aws-sdk-rds: update to 1.122.0
* ohai: update to 17.3.1
* aws-sdk-s3: update to 1.96.2
* puppet: update to 7.9.0
* listen: update to 3.6.0
* inspec: update to 4.38.9
* aws-sdk-ec2: update to 1.251.0
* aws-sdk-iam: update to 1.57.0
* chef: update to 17.3.48
* inspec-bin: update to 4.38.9