### PR TITLE
Cherry pick from origin/master

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.482.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.482.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-SRC_URI[md5sum] = "ce01aa655cc5c8d79556f864de45fa50"
-SRC_URI[sha256sum] = "0ce35261854ee35582f760886ac921b2d0b73d65739415f9ee367e7022a942a2"
+SRC_URI[md5sum] = "4cdf12a51e2f616fb45b88d7dc3ae464"
+SRC_URI[sha256sum] = "84de92d1fbdb5c9590944cc79829b62ebc56ec6da6208642cfa464a226e08192"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-apigateway_1.64.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-apigateway_1.64.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "ff852b992b85f21a532eb270bb314331"
-SRC_URI[sha256sum] = "0f24c2a008e1f57750299cc8c396af69b8f858bf4796810e0b6c93d75b5e388d"
+SRC_URI[md5sum] = "b3c9ace1705083e1c48d11c336cd5fdc"
+SRC_URI[sha256sum] = "acc128faab05021cef7b0b671561492f9b28d2947b18eaf915b7b4d85cee9b96"
 
 GEM_NAME = "aws-sdk-apigateway"
 

--- a/recipes-rubygems/rubygems-aws-sdk-apigatewayv2_1.34.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-apigatewayv2_1.34.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "1531b648ffe4ac93c22d929b43239b17"
-SRC_URI[sha256sum] = "d9ed93d220c8c40eacae93f29c0ec5f651fed094ea930a9ac5f7a619ed109106"
+SRC_URI[md5sum] = "0ec57f5de7a001e14ecc411112f5b554"
+SRC_URI[sha256sum] = "14f9b8dd53fb406e60ba95408ca68ba98f523794cbfb13c95ea446a1ae3c62c9"
 
 GEM_NAME = "aws-sdk-apigatewayv2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-applicationautoscaling_1.53.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-applicationautoscaling_1.53.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "a7abe8aaf3f6167cdaef5ff729a3f71c"
-SRC_URI[sha256sum] = "d6594250212f93f0b90f16349809988ff921fa6b65b2e940fa0c47cf1a02e052"
+SRC_URI[md5sum] = "4e4f81069c621b84ae289a1da1ce3123"
+SRC_URI[sha256sum] = "b03606569d33d412424e11a810bf62278a143f590e56c1d9eb24cdf7e4ad4993"
 
 GEM_NAME = "aws-sdk-applicationautoscaling"
 

--- a/recipes-rubygems/rubygems-aws-sdk-athena_1.39.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-athena_1.39.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "8ed407af8c54f7b7c3e0dca830b15fb2"
-SRC_URI[sha256sum] = "1203ef5959c898fe29e895cd13d307ab76ba5ad5b9f73b037eb92bfa9017dd93"
+SRC_URI[md5sum] = "93eb90180a2fe7afc216cd102828d68b"
+SRC_URI[sha256sum] = "e00537359c38c90ee062175038ca3d468c811410f406c60987db7857754f788b"
 
 GEM_NAME = "aws-sdk-athena"
 

--- a/recipes-rubygems/rubygems-aws-sdk-autoscaling_1.66.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-autoscaling_1.66.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "cd12a55f4054b949f9304dbf6044697d"
-SRC_URI[sha256sum] = "8d2ae38dcba972fc19e7b08f254eb6abeade67c45d9ee3529eef90a311237aa6"
+SRC_URI[md5sum] = "578e13ac946a6e267f3abf33728856e0"
+SRC_URI[sha256sum] = "05287b71f0a668c5738e546fd6b06607642400a58d08a3f0be81b3cdcbe36c56"
 
 GEM_NAME = "aws-sdk-autoscaling"
 

--- a/recipes-rubygems/rubygems-aws-sdk-batch_1.50.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-batch_1.50.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "376a1114ba27cbfc41e167b4be074740"
-SRC_URI[sha256sum] = "80b99350e9977ad9958bd664c96f6241d0d16594382c0443490ad6d6f7f6a875"
+SRC_URI[md5sum] = "2445aad836b8118e989a74b801dbafa2"
+SRC_URI[sha256sum] = "22c772ef8347b51f52d9ead02593d76b624b13b772707cc8144203ab2bf8885e"
 
 GEM_NAME = "aws-sdk-batch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-budgets_1.40.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-budgets_1.40.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "200244da9dffacabf60eee838ece9891"
-SRC_URI[sha256sum] = "dd841360e99583c877344cfc9ba12f9d0415cda713729620795deeb32bb10b13"
+SRC_URI[md5sum] = "b9f089439a43a8fd9fba73515077cda7"
+SRC_URI[sha256sum] = "5b40d5c2dde2e88d1c5cca835f995eab36a470c4ac4c1ee8f3bf01cb2e65ecf1"
 
 GEM_NAME = "aws-sdk-budgets"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudformation_1.55.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudformation_1.55.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "0eaa43628b3a45039d576d2816c6992a"
-SRC_URI[sha256sum] = "c333f09d492d7fced12e71ce11a4b2d1866ae6da64f036a4d0910492f918fd96"
+SRC_URI[md5sum] = "5357bbcb0157810986918cf44ac37f67"
+SRC_URI[sha256sum] = "9485117ac9d0d178f585acebc79d38edac989054d0b2d601bb855a0bb779d474"
 
 GEM_NAME = "aws-sdk-cloudformation"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.55.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.55.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "9e04ba31852a94ca472260b335cadb31"
-SRC_URI[sha256sum] = "3d7bea60f91bda08e3084794bddd1442649fb16379298f2f47dc797daefbb057"
+SRC_URI[md5sum] = "7ea0c8f5c886c6c1280fb4b0eed0b65b"
+SRC_URI[sha256sum] = "1f94148020b5b3ce8526e7121f8931e91d114fb484155efda368a5b818f2e148"
 
 GEM_NAME = "aws-sdk-cloudfront"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudhsm_1.32.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudhsm_1.32.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "56c5fb55cffeb0dba290b3848491086d"
-SRC_URI[sha256sum] = "9511eb23a55644bccbcd7928876fa4060be779235cd354d55d045d6c8aba9ade"
+SRC_URI[md5sum] = "7d839b95cd67ecc9f01dd10c7e54dbbb"
+SRC_URI[sha256sum] = "ae9cf97d8252d30a9b468874619c27c4349cfa7f1cd3ada192bfd97b1e01f525"
 
 GEM_NAME = "aws-sdk-cloudhsm"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudhsmv2_1.35.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudhsmv2_1.35.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "3dee6b27d9d608863402eadc7e2c55eb"
-SRC_URI[sha256sum] = "7a7a06c174a7c4c1fe386d6f0ba056df38d17ad9497826cc239987464e1bbee4"
+SRC_URI[md5sum] = "85a69faa0c00f56e2c2c22d93ed20a18"
+SRC_URI[sha256sum] = "cea5a786b6a08a79ff65a88c92f0a6bc697328c1cefa32ba35bad9ce74426d5a"
 
 GEM_NAME = "aws-sdk-cloudhsmv2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.37.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.37.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "441c24f4dcf7122aa9cf24cab852baf0"
-SRC_URI[sha256sum] = "baf0c3f8583044b79b48af1a058fc7864f16c9228bf39a83fe85bf61ad7af644"
+SRC_URI[md5sum] = "d8b591f926d5e74c69ed5f79adae4556"
+SRC_URI[sha256sum] = "a4097d9a93a3669ebcaa73aef97f3e1573d4237198a86ceb43c253a260d06d7a"
 
 GEM_NAME = "aws-sdk-cloudtrail"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatch_1.54.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatch_1.54.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "6a8e83d0eccbf71a06e3c7b0a6a8f7dc"
-SRC_URI[sha256sum] = "c8937d420ccd5d8c233d098bc18c8df3775a984c3de1313e6feaacd244b34d87"
+SRC_URI[md5sum] = "d921b19600a5c4c1e85d3b4d1ac8adcb"
+SRC_URI[sha256sum] = "f38ae9b2d9af30cb3c1f997a08e3172c590fc8c687c7e12c559decf6ad9262d8"
 
 GEM_NAME = "aws-sdk-cloudwatch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatchevents_1.49.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatchevents_1.49.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "842ab516196c74a577d5d97cebe6f598"
-SRC_URI[sha256sum] = "f656112028bba844731e213ca5a3e19dfede606409152f4d61094fe91f41ccbb"
+SRC_URI[md5sum] = "4af26517cb689f581c03104fc5a2e8ec"
+SRC_URI[sha256sum] = "ed835ce26ffe95ce41440e03608a2ff91f00b93f829dac625c5806ef15b77914"
 
 GEM_NAME = "aws-sdk-cloudwatchevents"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.43.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.43.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "07c469d0b0e1296a49ffe0b9b8bbb6d2"
-SRC_URI[sha256sum] = "10dbaaed14661b0149b852166ea656ab5b3a05ab86b746b174d7157162a46d17"
+SRC_URI[md5sum] = "cd2c129577d7745a5f297b6ee1678935"
+SRC_URI[sha256sum] = "a9cf2b7be44078eec4515505783fd0bf65637742363601b15220477897ab6101"
 
 GEM_NAME = "aws-sdk-cloudwatchlogs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-codecommit_1.44.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-codecommit_1.44.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "d6010fcaf3d9406073a8e507850e64d1"
-SRC_URI[sha256sum] = "d0fed017872442c244a5327d38bdc47627976e621048fc91e0296d2b9fc7e901"
+SRC_URI[md5sum] = "f2cbc8659753c2cfd1b47f93079c6993"
+SRC_URI[sha256sum] = "f775c2eacb028553653908bad8377dc2b4bb4cb3cf9f36bc3d44b6ff0422c4a7"
 
 GEM_NAME = "aws-sdk-codecommit"
 

--- a/recipes-rubygems/rubygems-aws-sdk-codedeploy_1.42.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-codedeploy_1.42.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "9957ec214a7b87422876d1ae49f4d381"
-SRC_URI[sha256sum] = "14fb7dbb9951c446c4455e0c77c9f859826e44ddb9fcdd3a1d0faa01c615958a"
+SRC_URI[md5sum] = "94645cea42309babffb88dc927d51227"
+SRC_URI[sha256sum] = "5b2594e6579f80307bcff9fb88c20faa2ac367294a5943d3add5e5759bc0b9e8"
 
 GEM_NAME = "aws-sdk-codedeploy"
 

--- a/recipes-rubygems/rubygems-aws-sdk-codepipeline_1.46.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-codepipeline_1.46.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "e20143b2bb17cbcc237e53e0472abe15"
-SRC_URI[sha256sum] = "5093d594860a3257e54d9034e945cf7148e7e24bc7a47699774a531edd080f49"
+SRC_URI[md5sum] = "2df4efa10784c3e4ad95e5c8af5db1f8"
+SRC_URI[sha256sum] = "7d830b13a2e4b575e68e4375ad4957a48f6c6920068fa93238ba135c2837691c"
 
 GEM_NAME = "aws-sdk-codepipeline"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cognitoidentity_1.33.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cognitoidentity_1.33.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "71a405c550f889fe29812d2c7046b0a2"
-SRC_URI[sha256sum] = "02cf80f09e969eb1cc5c8cb3a4c7918910ab45b308da4149ec737e166326ed4c"
+SRC_URI[md5sum] = "02bb6e46a64e27356168ea3fb00226b2"
+SRC_URI[sha256sum] = "363a979cae08a67e5e8dbbc52fb3a3bb6263b579128319a3c872d58b55bd75c6"
 
 GEM_NAME = "aws-sdk-cognitoidentity"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cognitoidentityprovider_1.56.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cognitoidentityprovider_1.56.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "3a965f0f4de5192dd2edb897615936b9"
-SRC_URI[sha256sum] = "b5a5791acb45b0cb9053d2d392823effdec5e05c12ccfd949a4e0aebd13e150b"
+SRC_URI[md5sum] = "7b9ff507199e913819ca9fa57809cc92"
+SRC_URI[sha256sum] = "d0b62e9840ecdbcfcdee0b8a60915a6aa6336d66d810a1c0131aefe34b9357e6"
 
 GEM_NAME = "aws-sdk-cognitoidentityprovider"
 

--- a/recipes-rubygems/rubygems-aws-sdk-configservice_1.64.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-configservice_1.64.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "eba9af60e0acb75ce364eead06cb8f54"
-SRC_URI[sha256sum] = "b38cc03b1d51740dd64270c0a97ffe6b7c066560d057e088c2c99700ae84d16f"
+SRC_URI[md5sum] = "2f92060abc814478fa9c264310d83829"
+SRC_URI[sha256sum] = "a11a2b8ed637f7195f016256f740060f7522d12301e98369e88bcac2d39dee74"
 
 GEM_NAME = "aws-sdk-configservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.119.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.119.0.bb
@@ -13,8 +13,8 @@ DEPENDS_class-native += "\
     rubygems-jmespath-native \
 "
 
-SRC_URI[md5sum] = "264ded83b366e7cc146f605621e115b8"
-SRC_URI[sha256sum] = "0180c936ecfb714061491e5370bd0f3a4709b22d2c252ffd9380b35edbc6cb27"
+SRC_URI[md5sum] = "f5d2b0e9e97527f45cd4b473c7d64cb6"
+SRC_URI[sha256sum] = "e088f128218a6af8e395df763f63da610f9956176182cc78ca01072261b1feab"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-costandusagereportservice_1.33.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-costandusagereportservice_1.33.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "51044be98195a0b3cfa5231dedba08e5"
-SRC_URI[sha256sum] = "237cf9ece5cc32cd819070b46505b6209a1b43263c9f69529682b43e070085ea"
+SRC_URI[md5sum] = "6efea5b6da058ab6d222568123e60da0"
+SRC_URI[sha256sum] = "862452df500abfa40c166a552c375b07c57f81529b1c484b85764dde167e7794"
 
 GEM_NAME = "aws-sdk-costandusagereportservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-databasemigrationservice_1.56.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-databasemigrationservice_1.56.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "0ea2149498393f7e37dcaf91cb19a5de"
-SRC_URI[sha256sum] = "624f5f4acb3cd688fc8865b4e3adc6da8256758416ee3e760b800b5df75cdc8d"
+SRC_URI[md5sum] = "9a6d79fafcb78e8bd1a92c2516770a25"
+SRC_URI[sha256sum] = "54d92a111a0d246b0340a9087b7a422e55cdad5f883d455900ac4bdb40820d0b"
 
 GEM_NAME = "aws-sdk-databasemigrationservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-dynamodb_1.62.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-dynamodb_1.62.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "0bdedc1a816b8ca39736d84b6e741679"
-SRC_URI[sha256sum] = "23068906fc5945b30ec06ea8d9a7bf12b7553bbfe999c2fef4f1b3b4ffacdab5"
+SRC_URI[md5sum] = "1d965a6edfa3fa739d57bf8852ef0c79"
+SRC_URI[sha256sum] = "5adff277d3a6a3129d53a1af816b15a3d8aa5f50379453180e8d7a64e8abaa25"
 
 GEM_NAME = "aws-sdk-dynamodb"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecr_1.44.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecr_1.44.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "e53a38299343c7a7cd5820a71cbad154"
-SRC_URI[sha256sum] = "2a733de04c9b00d68f0941c334bd272f45c4c289300d3fa23cfda2d1eaf2be64"
+SRC_URI[md5sum] = "de94bf1853b9d32ba0bb1bb4b10f5814"
+SRC_URI[sha256sum] = "c7038721148cfbe37d6ca52eb894d7ccbf9c9588a2596a2af3c24f7147682bed"
 
 GEM_NAME = "aws-sdk-ecr"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecrpublic_1.5.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecrpublic_1.5.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "20e186cdea58d25be2e86c9c214ecb8e"
-SRC_URI[sha256sum] = "d9f9b57d208f38cd48ff9efdb944a3a9db2d4ea2c6b307f7cce46eb2b7dd24ae"
+SRC_URI[md5sum] = "e0eefddc81d0a53e116995b3c3a20eaa"
+SRC_URI[sha256sum] = "d28b540e5a2b29b8f9c31ac85325a62aa19feccd9028d8c62e5956b76748271f"
 
 GEM_NAME = "aws-sdk-ecrpublic"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.83.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.83.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "b5c4d56fd89df7c702c9c09d9daccfe8"
-SRC_URI[sha256sum] = "1beb9871d57bcf1fb33c3d6a722f8beb1b386b30d81e388a8f9fcff6994192b6"
+SRC_URI[md5sum] = "9b40a3573f480977e2283f4863dad6b0"
+SRC_URI[sha256sum] = "9698ca32b327afaf915d39a7097c6a07ef54bbb82fcb62f52e02dabb447e3872"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-efs_1.42.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-efs_1.42.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "ed6e5129f981fcfc3646f3fbe2557cb2"
-SRC_URI[sha256sum] = "4cbb8b889aa37c06129c96d6349e45f561d868530af79e1a6f01334ea7760aad"
+SRC_URI[md5sum] = "4485ccd1b6de925e9097811c4a225f46"
+SRC_URI[sha256sum] = "38fc58933c8663e5c1bb53fd3f97802fbbdc50e1de71b49cfa92b5f0f863c25c"
 
 GEM_NAME = "aws-sdk-efs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eks_1.60.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eks_1.60.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "17e2f555f8f1a514eaa1c52abc0ed667"
-SRC_URI[sha256sum] = "c55c2c2f66ebafcac66237435c4b996862e7342deb6546985168b9f4dbc6e713"
+SRC_URI[md5sum] = "611113d6f3b79f04cc4a9be21d573aba"
+SRC_URI[sha256sum] = "b6f35e135c056da01c0c714640326c96818046145e75a0a6abe7867badf0cac9"
 
 GEM_NAME = "aws-sdk-eks"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticache_1.59.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticache_1.59.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "f89297a72624ece5441d48e8d8025e10"
-SRC_URI[sha256sum] = "d4e6cdae3b4b659731c85c5f10f3bf4edada247a01890b9c50264f5518610dba"
+SRC_URI[md5sum] = "1057ebd00dfced38ba6a28e8c5c64892"
+SRC_URI[sha256sum] = "fac50e51f4d2fe2b505c8784bea3388eae0cc8fff26d740cbdbcff757c5a8781"
 
 GEM_NAME = "aws-sdk-elasticache"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticbeanstalk_1.44.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticbeanstalk_1.44.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "b9ae4d067598ce0e0c1b1c5b6553bc66"
-SRC_URI[sha256sum] = "e23f07446ec5b9e6e836b39805b38a7026d3c361e1c42775365aa5e9a4432e25"
+SRC_URI[md5sum] = "6f48aeac26eb54a708e66c38f1da8af4"
+SRC_URI[sha256sum] = "ef0424af3465bf3b160fcab4556a62b030db8b142c3a1a6fbf11ca84edecffc3"
 
 GEM_NAME = "aws-sdk-elasticbeanstalk"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticloadbalancing_1.33.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticloadbalancing_1.33.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "113198cac9163b51676603aee25ed2ec"
-SRC_URI[sha256sum] = "630f8a47d4de0ce280f0b442a67a5bd40915149f6e82007cb5ba7b611bea7748"
+SRC_URI[md5sum] = "72cb209e45caab3c7e04a9a76834117c"
+SRC_URI[sha256sum] = "6e0ff4214ac26587bebb4f443594d0d2956ad11ab908777ca7db659926604a15"
 
 GEM_NAME = "aws-sdk-elasticloadbalancing"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticloadbalancingv2_1.66.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticloadbalancingv2_1.66.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "2d81f8e6f539c3ecc92e47b4e68de72a"
-SRC_URI[sha256sum] = "16671fa65ebaa0961517b817052c625efcd1d0674fcddb32a393f82afd1540ec"
+SRC_URI[md5sum] = "4d48b6a032efab1f9d91bd05f0744fed"
+SRC_URI[sha256sum] = "69939001a04fe14aaee7908336042894c865bbc5903f67ca296edec85a7eb34e"
 
 GEM_NAME = "aws-sdk-elasticloadbalancingv2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticsearchservice_1.54.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticsearchservice_1.54.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "b2e8463f3a9a44bc1b653701a023d447"
-SRC_URI[sha256sum] = "d8219d19bc57d411e1d63348c2c7f36c272232b06b258d43276294745e25b817"
+SRC_URI[md5sum] = "936cef5937d41f4542df39744005c443"
+SRC_URI[sha256sum] = "8fe8c15f8021a0bbfb02577955409854615a37e1c4b101c6937a4328c18bc709"
 
 GEM_NAME = "aws-sdk-elasticsearchservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eventbridge_1.27.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eventbridge_1.27.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "004fcd40e89f3923f2387d22fd0add6d"
-SRC_URI[sha256sum] = "8bc6244a5f05ae5ab8f0a291370be1a5309bbc3f8b5bfbe5d503297ba50b93b1"
+SRC_URI[md5sum] = "5fcf973b1e80c60db400c1b224e2c07b"
+SRC_URI[sha256sum] = "f70f6216ffe64209119a72a470a5addf0f9051f981f68803a2fb8f4777ef0619"
 
 GEM_NAME = "aws-sdk-eventbridge"
 

--- a/recipes-rubygems/rubygems-aws-sdk-firehose_1.39.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-firehose_1.39.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "4b32d3a4757988a95f583322d4f4376f"
-SRC_URI[sha256sum] = "2ff1d6ee3e08bedb0991721fd0967bbb438ddca2f242113016533116f69782fa"
+SRC_URI[md5sum] = "9a3d4d057d2782113348c31143e65ef0"
+SRC_URI[sha256sum] = "5e5e0d099019931fb74c75d117f519aedbfc6ee72b094abbfa2ce5122613c258"
 
 GEM_NAME = "aws-sdk-firehose"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.92.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.92.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "905e9a6e0a6a1457797c1374a333b7bc"
-SRC_URI[sha256sum] = "f1dbdcec48d58107894b8e2d2e82e69809fc0381da25161fe002faf5ad32ca68"
+SRC_URI[md5sum] = "4a900172826dfc4a51bb1c326e467a67"
+SRC_URI[sha256sum] = "57728b0405b7248b609d265af1969be7c8c3301d5242d4529695d5be96c8b141"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-guardduty_1.47.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-guardduty_1.47.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "6a1e558bde0439cc7445e010ebec999a"
-SRC_URI[sha256sum] = "7e0a438efd0b8c193625eb6d3ee0a74991a3bec83ac563fb4c21537f5cc27562"
+SRC_URI[md5sum] = "1cc5ff5d47abe37f49d9c815669a4047"
+SRC_URI[sha256sum] = "fb91fd4f46af07cf9454567f59c79218356d2714371df77a1709a9817d63135d"
 
 GEM_NAME = "aws-sdk-guardduty"
 

--- a/recipes-rubygems/rubygems-aws-sdk-iam_1.59.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-iam_1.59.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "5dd7a1519d044238fc3a0a61b2ae4758"
-SRC_URI[sha256sum] = "9ee04362fd6e125f9c079623b909b2deafc7abf923f45bd34763edc6c023ad5a"
+SRC_URI[md5sum] = "09dfa240c7748b3c00e361f027436973"
+SRC_URI[sha256sum] = "b064b014827ce42d01e6bacfb14418d122cfa3f7a459fd8c2df1bba76e055599"
 
 GEM_NAME = "aws-sdk-iam"
 

--- a/recipes-rubygems/rubygems-aws-sdk-kafka_1.38.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-kafka_1.38.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "6fc0099178cb5a18867a715264f84154"
-SRC_URI[sha256sum] = "0ceebef8b5a9271fce759a84a7feed54d0a5bfa9d03fe1f19be7f9bb1c9b7c5d"
+SRC_URI[md5sum] = "6ac85f79ddcd1f6ff514558898a18e2b"
+SRC_URI[sha256sum] = "c79ebf768a2413ddb730d980220c44f3607e0c2157f4bbd7b3067c5087e3fcf3"
 
 GEM_NAME = "aws-sdk-kafka"
 

--- a/recipes-rubygems/rubygems-aws-sdk-kinesis_1.34.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-kinesis_1.34.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "da16e1c534194d77c75ec07939e2ad37"
-SRC_URI[sha256sum] = "de14529dad941fc4471c74e3e1111f32d435a5e380404f8930821b589582e675"
+SRC_URI[md5sum] = "d70383dcd5e6b51e438868942f2d7e1d"
+SRC_URI[sha256sum] = "5fcd58517f65dacac774f61a5dcbe59133dd4557a43326c3a4b28e977fe5a7f3"
 
 GEM_NAME = "aws-sdk-kinesis"
 

--- a/recipes-rubygems/rubygems-aws-sdk-lambda_1.66.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-lambda_1.66.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "961fcec43fd8c4d7c03e5052a92b6213"
-SRC_URI[sha256sum] = "3e54bfdd03e80df13eaa9ccbbc7dfaec4d8846969744ce7f3411e2978c8e1761"
+SRC_URI[md5sum] = "bff5611e471e86c03861c593556e10d1"
+SRC_URI[sha256sum] = "b496661a1b1f0c496ae45eed6854596abe752d348893f8f6657b59013ba01b44"
 
 GEM_NAME = "aws-sdk-lambda"
 

--- a/recipes-rubygems/rubygems-aws-sdk-organizations_1.61.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-organizations_1.61.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "c4630d65ddc1631a63689c191e444c4a"
-SRC_URI[sha256sum] = "549df22a9573d85d14c114731de60b4689d0a62e17a46d6bbd651ec3e0f1bfac"
+SRC_URI[md5sum] = "6778cb4f59348aefe220b1d9bb1d3ad9"
+SRC_URI[sha256sum] = "e05db85fa201a8d166a7ed2e24482e1e90d94f66a8731f5d484a861c48e05fe6"
 
 GEM_NAME = "aws-sdk-organizations"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ram_1.28.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ram_1.28.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "96a2e75c39247cb52d29fb35fc23e5d4"
-SRC_URI[sha256sum] = "4c09b74c1117e2d8dd54ae50c32e1b1251440c400c80277bc0c9b73d4bd6a666"
+SRC_URI[md5sum] = "322947cabc35f3916ea3318b8f0e4433"
+SRC_URI[sha256sum] = "85eed1b1b0cfa664ff5cdb80bf712fdbeef875c028cf4eb587444c0c93bdee99"
 
 GEM_NAME = "aws-sdk-ram"
 

--- a/recipes-rubygems/rubygems-aws-sdk-redshift_1.67.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-redshift_1.67.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "9272d0aeaadbf6033b12bd9edca63491"
-SRC_URI[sha256sum] = "2d89efa770746edf00200c86c9d3d994de71598dcff57f9ef7a20889935aacd2"
+SRC_URI[md5sum] = "60bc106452fa5dc8eda9b967cf63bc4e"
+SRC_URI[sha256sum] = "e3ad1f1814a81c287e082bb2d0a5e9f5964a157be5fc6d372f88940a1e780245"
 
 GEM_NAME = "aws-sdk-redshift"
 

--- a/recipes-rubygems/rubygems-aws-sdk-route53_1.52.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-route53_1.52.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "538c3f7ed6fcc3e120e9c3f83da0b112"
-SRC_URI[sha256sum] = "91731c7da583ecb9198811a4c8df3c25dc319a2eca9a8e18c350bd41cee7ddd2"
+SRC_URI[md5sum] = "2d3b9a9505c64199cf900a98b85ef24f"
+SRC_URI[sha256sum] = "9b60edbcf82aad0e5bc34d0e1a7b904e6a4197beeba4b8edbdb47dd6afc40cc7"
 
 GEM_NAME = "aws-sdk-route53"
 

--- a/recipes-rubygems/rubygems-aws-sdk-route53domains_1.32.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-route53domains_1.32.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "2810c4319c90524cb296ee139cb93a53"
-SRC_URI[sha256sum] = "2652e73281dc07da720c87b08a226cab696dac07137bb36116329bf14bbc7ed3"
+SRC_URI[md5sum] = "feb74f20794623659e1da302a8357344"
+SRC_URI[sha256sum] = "5245564a4a8e43c45067c7675075e56067914f7548d3ad88478d00c6a8437340"
 
 GEM_NAME = "aws-sdk-route53domains"
 

--- a/recipes-rubygems/rubygems-aws-sdk-route53resolver_1.28.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-route53resolver_1.28.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "b36dda742d1f0f552e81f019f31953bd"
-SRC_URI[sha256sum] = "46271c494cd34efef0824bcb2a129c4332dc5259e3440568cdd786770eaeed82"
+SRC_URI[md5sum] = "cbabc6a4b8a2c8e3776b107f8e1ae432"
+SRC_URI[sha256sum] = "219576cd2eb81fabcc1a52343f33d7e44564916ccbd3263946c96b86a6a95668"
 
 GEM_NAME = "aws-sdk-route53resolver"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.98.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.98.0.bb
@@ -12,8 +12,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "4e5be630412758dd575e002fda5940bd"
-SRC_URI[sha256sum] = "1c3b4609963de97366c641c057d0e1064b184f5a9cec3c0d746bcde9450ff9e1"
+SRC_URI[md5sum] = "e4c53ecebca9fc69c05964f32c284ca8"
+SRC_URI[sha256sum] = "892f9fa187fec0ae81d0187717a2df0813b82edbc8c35f663a96758664b0291d"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-aws-sdk-secretsmanager_1.48.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-secretsmanager_1.48.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "4e948f7078635dbf43f7ab49f7da2f7a"
-SRC_URI[sha256sum] = "718438609e3353a92dc5aa45c36c2ac016f96d1ad03c4f07f49c56117d1a7d76"
+SRC_URI[md5sum] = "81d93cdf37d499ac5db89c5380979544"
+SRC_URI[sha256sum] = "c9b6d9a4068876618d897b25ce8f252087cec912ee787b6eb72bb0c10bf0bee6"
 
 GEM_NAME = "aws-sdk-secretsmanager"
 

--- a/recipes-rubygems/rubygems-aws-sdk-securityhub_1.50.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-securityhub_1.50.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "719f49328d10ffa6ce008459ecd2ed81"
-SRC_URI[sha256sum] = "ed9bfabeb43e008980dd2feba8223800b5027f3ccd28840f80059c333055fb02"
+SRC_URI[md5sum] = "260b90497c0228d49fe6c5e53bedd4b4"
+SRC_URI[sha256sum] = "bc27ba20a8b620976b7f61bda942c99bc9a2d8c274817e746068b599a50d49b7"
 
 GEM_NAME = "aws-sdk-securityhub"
 

--- a/recipes-rubygems/rubygems-aws-sdk-servicecatalog_1.62.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-servicecatalog_1.62.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "d4f57bfbd715059d4f986b20d6dae65e"
-SRC_URI[sha256sum] = "47238975e6ec0dc406dddf1a62fc750b33acec97ec2beb75b67f4859f25d5dfe"
+SRC_URI[md5sum] = "72557eba5bd9c4db3ccfea39b24ae01a"
+SRC_URI[sha256sum] = "9039fe5e491b8abae360693a2e92a225a1e3468e8dc266643bf5382f5009c8fd"
 
 GEM_NAME = "aws-sdk-servicecatalog"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ses_1.40.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ses_1.40.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "b1d326abab073f6ed4de885f17080e70"
-SRC_URI[sha256sum] = "d04322b6995f9270f54e75b49c225bbd3175f8c157f82fdc6be69ba0a12ed225"
+SRC_URI[md5sum] = "3ea014c6c3b5fce441044ef50f137f4c"
+SRC_URI[sha256sum] = "7eeec687b7fa5bb3d1b31424ff2b069d743dba66f201237aff403f63a9b93899"
 
 GEM_NAME = "aws-sdk-ses"
 

--- a/recipes-rubygems/rubygems-aws-sdk-shield_1.40.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-shield_1.40.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "592480ff8b53db3da0413e0a4b6c8bb0"
-SRC_URI[sha256sum] = "41c05d5453e7de5747ade66bafac596fcfe1941362224b3d827a476c052476dc"
+SRC_URI[md5sum] = "55df697b3978e6d57a38b13f9a7661da"
+SRC_URI[sha256sum] = "b49c7809d4543e7f95da809bf805cf183cf4509073fbc51af7f3fe9da82dc96a"
 
 GEM_NAME = "aws-sdk-shield"
 

--- a/recipes-rubygems/rubygems-aws-sdk-sms_1.31.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-sms_1.31.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "7516f88fec2950a5213e2ba0295a8e87"
-SRC_URI[sha256sum] = "f6c12c1a8c0805d09e40e4024e71813e21b8d94496ecec18f9e7cec2ecee0dcf"
+SRC_URI[md5sum] = "adaf5c432fb65f6ffa532abfdeb47fc5"
+SRC_URI[sha256sum] = "5d7848e630e7672b935a7abf4088d02f160b69fde87b655990580a3223b57bca"
 
 GEM_NAME = "aws-sdk-sms"
 

--- a/recipes-rubygems/rubygems-aws-sdk-sns_1.44.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-sns_1.44.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "ac4f4158ef2fb0c2cbd8f8dd34ec7e45"
-SRC_URI[sha256sum] = "9a762f9b9fb3f7fe7f38f94bf35946bbbd47d14332ef6182ead11917ecd3be3a"
+SRC_URI[md5sum] = "783e45f09cf5328d9a8e422f60a22ccf"
+SRC_URI[sha256sum] = "836a881dc88754a7dbf5e5eb8d74d2d0c07c0c2466fb26f9cd08c9bcad26989b"
 
 GEM_NAME = "aws-sdk-sns"
 

--- a/recipes-rubygems/rubygems-aws-sdk-sqs_1.42.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-sqs_1.42.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "a3bde4dc39cef0109a84982960576e25"
-SRC_URI[sha256sum] = "09e561106b8789faec54470ff1c42d9d624775e4bd450b6c52bd091b1d647285"
+SRC_URI[md5sum] = "c8a683153885459b8b0581bbe21b8c95"
+SRC_URI[sha256sum] = "2ab7f721cc8d3370532b1b4e050f0618059984f518fb225a0a889355860e03cd"
 
 GEM_NAME = "aws-sdk-sqs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ssm_1.114.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ssm_1.114.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "859c83518f7ee45d0632907d3aa9f5a0"
-SRC_URI[sha256sum] = "38954885e34b9ea59a52695e3ae2465c94f5ee100bd453ae095ad537a4996a41"
+SRC_URI[md5sum] = "a94b80bff8c8fb48a11d3a08303140bd"
+SRC_URI[sha256sum] = "9d70ccf0a226973ad76d7f063b9883445f0c1738f29c1d38fdf24323c168ccef"
 
 GEM_NAME = "aws-sdk-ssm"
 

--- a/recipes-rubygems/rubygems-aws-sdk-states_1.41.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-states_1.41.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "2ff74191a02ec0dba192f5203c30cce2"
-SRC_URI[sha256sum] = "90296d8e5278e83aaef259e83eb4df0f8755ddaa1b51410468af65d2274c4a02"
+SRC_URI[md5sum] = "5a8bcdc973f7538393a24921b5d88d93"
+SRC_URI[sha256sum] = "884822198a74b34f49f12b8c73a04059a30a3957cb7d1abc1078cb5d260e20d5"
 
 GEM_NAME = "aws-sdk-states"
 

--- a/recipes-rubygems/rubygems-aws-sdk-transfer_1.37.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-transfer_1.37.0.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "13ff979362e9d46b07fe510c9726b28b"
-SRC_URI[sha256sum] = "a3446473628075d0e9677a774b4e0002990302ed9f86e3be2689f70a6ab22245"
+SRC_URI[md5sum] = "f4e538331c574670cbbb4ea8dff93259"
+SRC_URI[sha256sum] = "9dc507f76e78a21d29f25231243715b7ce66674d444a6730d6a69b2e51dcf216"
 
 GEM_NAME = "aws-sdk-transfer"
 

--- a/recipes-rubygems/rubygems-chef-telemetry_1.1.1.bb
+++ b/recipes-rubygems/rubygems-chef-telemetry_1.1.1.bb
@@ -11,8 +11,8 @@ DEPENDS_class-native += "\
     rubygems-concurrent-ruby-native \
 "
 
-SRC_URI[md5sum] = "972ecbac8182c4116c6789b38d157f4e"
-SRC_URI[sha256sum] = "8ba5064939789122ee2afffcd4dda4112507a8b129a4440dec7ba4ef5b470b53"
+SRC_URI[md5sum] = "f36634eb90ad4f480c9726e2935eac02"
+SRC_URI[sha256sum] = "bd004fd20cd0677936d3ada881b1d318185a76186e1774634542366707633151"
 
 GEM_NAME = "chef-telemetry"
 

--- a/recipes-rubygems/rubygems-googleauth_0.17.0.bb
+++ b/recipes-rubygems/rubygems-googleauth_0.17.0.bb
@@ -15,8 +15,8 @@ DEPENDS_class-native += "\
     rubygems-signet-native \
 "
 
-SRC_URI[md5sum] = "aa1c2f1c3bf0905782308e9b4f51f4a7"
-SRC_URI[sha256sum] = "057c72865a94a5c55d51fb8702635dfb0fe02085f67a417542285cb61022c75f"
+SRC_URI[md5sum] = "a6659347f51ba2d81c7a24c96fe9321b"
+SRC_URI[sha256sum] = "988594556ca5319e5fca21b263f152a9b97df1e1024ccdf780d828563a7e020c"
 
 GEM_NAME = "googleauth"
 

--- a/recipes-rubygems/rubygems-train-core_3.8.1.bb
+++ b/recipes-rubygems/rubygems-train-core_3.8.1.bb
@@ -15,8 +15,8 @@ DEPENDS_class-native += "\
     rubygems-net-ssh-native \
 "
 
-SRC_URI[md5sum] = "81d5f5ba4008de4bfe4d1e5729508fe2"
-SRC_URI[sha256sum] = "fbfe3eb8240572309102057e9c1435c716a3b0b4431ef3868fabd26b3b5483dc"
+SRC_URI[md5sum] = "62d83edf7d31319de0b3acd8cb707600"
+SRC_URI[sha256sum] = "d710aae3fb1d799be344a7e59c287afd57621f64b4a4987585999abeb79ebc1b"
 
 GEM_NAME = "train-core"
 

--- a/recipes-rubygems/rubygems-train_3.8.1.bb
+++ b/recipes-rubygems/rubygems-train_3.8.1.bb
@@ -21,8 +21,8 @@ DEPENDS_class-native += "\
     rubygems-train-winrm-native \
 "
 
-SRC_URI[md5sum] = "f22f4f9724556b0e1b80c344f389e220"
-SRC_URI[sha256sum] = "15a4f66271e90947c37b50d84155e73749ddd0ceeddab323d78348feec3ff135"
+SRC_URI[md5sum] = "9253ee5d9ca4e2b3aa21f47b0370fcae"
+SRC_URI[sha256sum] = "978917382554891081c5bf1ac5e34304d0b8d5596256c69a29659aa8f14a5244"
 
 GEM_NAME = "train"
 


### PR DESCRIPTION
* chef-utils: update to 17.3.48
* google-apis-core: update to 0.4.1
* chef-config: update to 17.3.48
* aws-sdk-securityhub: update to 1.48.0
* aws-sdk-elasticloadbalancingv2: update to 1.64.0
* aws-sdk-lambda: update to 1.64.0
* ohai: update to 17.3.1
* aws-sdk-s3: update to 1.96.2
* listen: update to 3.6.0
* aws-sdk-iam: update to 1.57.0
* chef: update to 17.3.48
* train-core: update to 3.8.1
* googleauth: update to 0.17.0
* aws-sdk-secretsmanager: update to 1.48.0
* aws-sdk-cloudhsm: update to 1.32.0
* aws-sdk-codedeploy: update to 1.42.0
* train: update to 3.8.1
* aws-sdk-organizations: update to 1.61.0
* aws-sdk-cognitoidentityprovider: update to 1.56.0
* aws-sdk-securityhub: update to 1.50.0
* aws-sdk-elasticsearchservice: update to 1.54.0
* aws-sdk-eventbridge: update to 1.27.0
* aws-sdk-applicationautoscaling: update to 1.53.0
* aws-sdk-elasticbeanstalk: update to 1.44.0
* aws-sdk-dynamodb: update to 1.62.0
* aws-sdk-elasticloadbalancing: update to 1.33.0
* aws-sdk-s3: update to 1.98.0
* aws-sdk-cloudwatch: update to 1.54.0
* aws-sdk-apigatewayv2: update to 1.34.0
* aws-sdk-cloudformation: update to 1.55.0
* aws-sdk-cloudwatchevents: update to 1.49.0
* aws-sdk-cloudhsmv2: update to 1.35.0
* aws-sdk-sqs: update to 1.42.0
* aws-sdk-autoscaling: update to 1.66.0
* aws-sdk-batch: update to 1.50.0
* aws-sdk-cloudfront: update to 1.55.0
* aws-sdk-codepipeline: update to 1.46.0
* aws-sdk-configservice: update to 1.64.0
* aws-sdk-servicecatalog: update to 1.62.0
* aws-sdk-costandusagereportservice: update to 1.33.0
* aws-sdk-elasticache: update to 1.59.0
* aws-sdk-kafka: update to 1.38.0
* aws-sdk-sns: update to 1.44.0
* aws-sdk-ecr: update to 1.44.0
* aws-sdk-sms: update to 1.31.0
* aws-sdk-redshift: update to 1.67.0
* aws-sdk-ses: update to 1.40.0
* aws-sdk-lambda: update to 1.66.0
* aws-sdk-route53: update to 1.52.0
* aws-sdk-apigateway: update to 1.64.0
* aws-sdk-elasticloadbalancingv2: update to 1.66.0
* aws-sdk-kinesis: update to 1.34.0
* aws-sdk-codecommit: update to 1.44.0
* aws-sdk-ecs: update to 1.83.0
* aws-sdk-cognitoidentity: update to 1.33.0
* aws-sdk-eks: update to 1.60.0
* aws-sdk-databasemigrationservice: update to 1.56.0
* aws-sdk-shield: update to 1.40.0
* aws-sdk-states: update to 1.41.0
* aws-sdk-ecrpublic: update to 1.5.0
* chef-telemetry: update to 1.1.1
* aws-sdk-efs: update to 1.42.0
* aws-sdk-glue: update to 1.92.0
* aws-sdk-cloudwatchlogs: update to 1.43.0
* aws-sdk-ssm: update to 1.114.0
* aws-sdk-budgets: update to 1.40.0
* aws-sdk-cloudtrail: update to 1.37.0
* aws-sdk-route53resolver: update to 1.28.0
* aws-sdk-iam: update to 1.59.0
* aws-sdk-transfer: update to 1.37.0
* aws-sdk-firehose: update to 1.39.0
* aws-sdk-guardduty: update to 1.47.0
* aws-sdk-route53domains: update to 1.32.0
* aws-sdk-ram: update to 1.28.0
* aws-sdk-athena: update to 1.39.0