### PR TITLE
Package update

### DIFF
--- a/lib/oeqa/runtime/cases/rubygems_rubygems_faraday_rack.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_faraday_rack.py
@@ -1,0 +1,7 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_faraday_rack(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_faraday_rack(self):
+        self.gem_is_installed("faraday-rack")
+

--- a/packagegroups-rubygems/packagegroup-rubygems.bb
+++ b/packagegroups-rubygems/packagegroup-rubygems.bb
@@ -120,6 +120,7 @@ RDEPENDS:${PN} += "\
     rubygems-faraday-net-http \
     rubygems-faraday-net-http-persistent \
     rubygems-faraday-patron \
+    rubygems-faraday-rack \
     rubygems-fast-gettext \
     rubygems-ffi \
     rubygems-ffi-libarchive \

--- a/packagegroups-rubygems/packagegroup-rubygems.bb
+++ b/packagegroups-rubygems/packagegroup-rubygems.bb
@@ -289,3 +289,4 @@ RDEPENDS:${PN} += "\
     rubygems-yard \
     rubygems-zeitwerk \
 "
+

--- a/recipes-rubygems/rubygems-aws-partitions_1.484.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.484.0.bb
@@ -6,8 +6,8 @@ HOMEPAGE = "https://github.com/aws/aws-sdk-ruby"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-SRC_URI[md5sum] = "4cdf12a51e2f616fb45b88d7dc3ae464"
-SRC_URI[sha256sum] = "84de92d1fbdb5c9590944cc79829b62ebc56ec6da6208642cfa464a226e08192"
+SRC_URI[md5sum] = "82c4061dae3595dbf635e7e44daec68e"
+SRC_URI[sha256sum] = "99d7012bce7ea555adecf1902af7744628adc173ff65eba516b3feba10705004"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-athena_1.40.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-athena_1.40.0.bb
@@ -11,8 +11,8 @@ DEPENDS:class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "93eb90180a2fe7afc216cd102828d68b"
-SRC_URI[sha256sum] = "e00537359c38c90ee062175038ca3d468c811410f406c60987db7857754f788b"
+SRC_URI[md5sum] = "224ee9828b309fd8c58ea736d9a31d34"
+SRC_URI[sha256sum] = "5f4dd3d56132f85667949102980450b9561e69de6d4b04c248dd262cee05dc16"
 
 GEM_NAME = "aws-sdk-athena"
 

--- a/recipes-rubygems/rubygems-aws-sdk-autoscaling_1.67.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-autoscaling_1.67.0.bb
@@ -11,8 +11,8 @@ DEPENDS:class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "578e13ac946a6e267f3abf33728856e0"
-SRC_URI[sha256sum] = "05287b71f0a668c5738e546fd6b06607642400a58d08a3f0be81b3cdcbe36c56"
+SRC_URI[md5sum] = "d77db5b60ab2e93ec90bd3168daa847f"
+SRC_URI[sha256sum] = "b0ea1ed64566841ddb07ed3bd0a9259cff3152f25dc38a334ab8bef4e54e2562"
 
 GEM_NAME = "aws-sdk-autoscaling"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eventbridge_1.28.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eventbridge_1.28.0.bb
@@ -11,8 +11,8 @@ DEPENDS:class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "5fcf973b1e80c60db400c1b224e2c07b"
-SRC_URI[sha256sum] = "f70f6216ffe64209119a72a470a5addf0f9051f981f68803a2fb8f4777ef0619"
+SRC_URI[md5sum] = "72fe9597a607dc83490bc17b328c9343"
+SRC_URI[sha256sum] = "0388dc0276926cd7cb407a7354731b08540da93387269120ecb29a949fab43bf"
 
 GEM_NAME = "aws-sdk-eventbridge"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.93.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.93.0.bb
@@ -11,8 +11,8 @@ DEPENDS:class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "4a900172826dfc4a51bb1c326e467a67"
-SRC_URI[sha256sum] = "57728b0405b7248b609d265af1969be7c8c3301d5242d4529695d5be96c8b141"
+SRC_URI[md5sum] = "6059565c5913ddfc195beb6e0facf2be"
+SRC_URI[sha256sum] = "01a5b57bb1e92d6d3519327929b27709a48b4aa78d630645d37653fd97958b50"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.125.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.125.0.bb
@@ -11,8 +11,8 @@ DEPENDS:class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "9722078c8838d0261f4dcae255ef3f5d"
-SRC_URI[sha256sum] = "e6737be61e9ab95e76ea5b67b34c82adc61bc6d7a3dd6d76c44d9c43405444a8"
+SRC_URI[md5sum] = "9f0fc64bde8a0f4ae3e349aebf2c6758"
+SRC_URI[sha256sum] = "e712c3a53ffc402a5e357eb8cba9e7faa05c3e5db6e7bf2a9e874a34767c9075"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-aws-sdk-redshift_1.68.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-redshift_1.68.0.bb
@@ -11,8 +11,8 @@ DEPENDS:class-native += "\
     rubygems-aws-sigv4-native \
 "
 
-SRC_URI[md5sum] = "60bc106452fa5dc8eda9b967cf63bc4e"
-SRC_URI[sha256sum] = "e3ad1f1814a81c287e082bb2d0a5e9f5964a157be5fc6d372f88940a1e780245"
+SRC_URI[md5sum] = "562990bb96c8d53d9c52bb59c74bdc1a"
+SRC_URI[sha256sum] = "f0719ff2bb10e740169695bed2f0e93e34b8b46afb0f68a703da975072215b10"
 
 GEM_NAME = "aws-sdk-redshift"
 

--- a/recipes-rubygems/rubygems-faraday-middleware_1.1.0.bb
+++ b/recipes-rubygems/rubygems-faraday-middleware_1.1.0.bb
@@ -9,19 +9,18 @@ LIC_FILES_CHKSUM = "file://LICENSE.md;md5=a59d0c4589d25cc5037028f3465378d6"
 DEPENDS:class-native += "\
     rubygems-faraday-native \
 "
-RDEPENDS:${PN}:class-target += "\
-    rubygems-faraday \
-"
 
-SRC_URI[md5sum] = "3fe1c76b1a7ad0a0b38ca0a7e4b74a93"
-SRC_URI[sha256sum] = "19e808539681bbf2e65df30dfbe27bb402bde916a1dceb4c7496dbe8de14334a"
+SRC_URI[md5sum] = "651322519b2b961bf27f78bf54fe8f92"
+SRC_URI[sha256sum] = "442288d81bdb48dccadf5463e256582850a2cc654ef5cd281f941c7b1cbcec4d"
 
 GEM_NAME = "faraday_middleware"
-
-
 
 inherit rubygems
 inherit rubygentest
 inherit pkgconfig
+
+RDEPENDS:${PN}:class-target += "\
+    rubygems-faraday \
+"
 
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-faraday-rack_1.0.0.bb
+++ b/recipes-rubygems/rubygems-faraday-rack_1.0.0.bb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: faraday-rack"
+DESCRIPTION = "Faraday adapter for Rack"
+HOMEPAGE = "https://github.com/lostisland/faraday-rack"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=20830660ee48a0c845a62aad77c18f4a"
+
+SRC_URI[md5sum] = "e1f15e1a8e72e3d38c7973550e11925e"
+SRC_URI[sha256sum] = "ef60ec969a2bb95b8dbf24400155aee64a00fc8ba6c6a4d3968562bcc92328c0"
+
+GEM_NAME = "faraday-rack"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-faraday_1.6.0.bb
+++ b/recipes-rubygems/rubygems-faraday_1.6.0.bb
@@ -14,12 +14,13 @@ DEPENDS:class-native += "\
     rubygems-faraday-net-http-native \
     rubygems-faraday-net-http-persistent-native \
     rubygems-faraday-patron-native \
+    rubygems-faraday-rack-native \
     rubygems-multipart-post-native \
     rubygems-ruby2-keywords-native \
 "
 
-SRC_URI[md5sum] = "a813238de0bc88b12cb4f8f9d7a96175"
-SRC_URI[sha256sum] = "c3e4bbf81f80defffc43a0f5bb44b4beeada3bae02f52afad74f5165084ff8f6"
+SRC_URI[md5sum] = "fb36ece9dede937e9ed73057f633b0a7"
+SRC_URI[sha256sum] = "fe8941d7424911c4624379b2c0b2cff3efcd623b834c01fd66315a9da807b176"
 
 GEM_NAME = "faraday"
 
@@ -35,6 +36,7 @@ RDEPENDS:${PN}:class-target += "\
     rubygems-faraday-net-http \
     rubygems-faraday-net-http-persistent \
     rubygems-faraday-patron \
+    rubygems-faraday-rack \
     rubygems-multipart-post \
     rubygems-ruby2-keywords \
 "

--- a/recipes-rubygems/rubygems-reek_6.0.5.bb
+++ b/recipes-rubygems/rubygems-reek_6.0.5.bb
@@ -17,8 +17,8 @@ DEPENDS:class-native += "\
     rubygems-rainbow-native \
 "
 
-SRC_URI[md5sum] = "275f3a29a87228a4f6b2de3940dbf532"
-SRC_URI[sha256sum] = "b70bc41d2f2a34eba744060337752c4575e0b5ac4cf10a86b3afaaf78fc3054a"
+SRC_URI[md5sum] = "80ce170c086b22b07009256658dd7e36"
+SRC_URI[sha256sum] = "98b83ad7e96015d3db55f6efab795aff45e8eefbcb17db01894e0636e859d3e9"
 
 GEM_NAME = "reek"
 

--- a/scripts/dev-requirements.txt
+++ b/scripts/dev-requirements.txt
@@ -1,3 +1,3 @@
-oelint-parser>=1.0.7
+oelint-parser>=1.2.0
 scancode-toolkit>=3.2.0
 semantic-version>=2.8.0

--- a/scripts/requirements-package-bot.txt
+++ b/scripts/requirements-package-bot.txt
@@ -1,5 +1,5 @@
 github3.py
 python-git
-oelint-parser>=1.0.7
+oelint-parser>=1.2.0
 scancode-toolkit>=3.2.0
 semantic-version>=2.8.0


### PR DESCRIPTION
* reek: update to 6.0.5
* aws-sdk-autoscaling: update to 1.67.0
* aws-sdk-eventbridge: update to 1.28.0
* aws-sdk-redshift: update to 1.68.0
* faraday: update to 1.6.0
* aws-sdk-rds: update to 1.125.0
* aws-sdk-athena: update to 1.40.0
* faraday_middleware: update to 1.1.0
* aws-partitions: update to 1.484.0
* aws-sdk-glue: update to 1.93.0