### PR TITLE
Revert "nokogiri: update to 1.12.3"

### DIFF
--- a/recipes-rubygems/rubygems-nokogiri_1.11.7.bb
+++ b/recipes-rubygems/rubygems-nokogiri_1.11.7.bb
@@ -4,13 +4,12 @@ DESCRIPTION = "Nokogiri (鋸) makes it easy and painless to work with XML and HT
 HOMEPAGE = "https://nokogiri.org"
 
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE-DEPENDENCIES.md;md5=2cf22f72d34436ea00c7c5fa20cc9242"
+LIC_FILES_CHKSUM = "file://LICENSE-DEPENDENCIES.md;md5=2fcfc4989eb71e592d2e85d26d7fa91c"
 
 EXTRA_DEPENDS:append = " \
     libxml2 \
     libxslt \
 "
-EXTRA_RDEPENDS:append = " "
 
 DEPENDS:class-native += "\
     rubygems-mini-portile2-native \
@@ -24,8 +23,8 @@ GEM_INSTALL_FLAGS:append = " \
     --use-system-libraries \
 "
 
-SRC_URI[md5sum] = "beb25087df63ec77bcfb4bba001a54d6"
-SRC_URI[sha256sum] = "d1975e30090ae723e05a6c9bd95fb795527e1a14d53a614735e2c3d8eef1e1e0"
+SRC_URI[md5sum] = "c49903a564d6f71765a04afc9c7ff974"
+SRC_URI[sha256sum] = "4976a9c9e796527d51dc6c311b9bd93a0233f6a7962a0f569aa5c782461836ef"
 
 GEM_NAME = "nokogiri"
 
@@ -37,7 +36,5 @@ RDEPENDS:${PN}:class-target += "\
     rubygems-mini-portile2 \
     rubygems-racc \
 "
-
-FILES:${PN}-staticdev += "${libdir}/ruby/gems/*/gems/*/ext/nokogiri/ports/*/libgumbo/*/lib/libgumbo.a"
 
 BBCLASSEXTEND = "native"


### PR DESCRIPTION
This reverts commit 6b0eac6fbba12b68e99463b4af6702f9871d24db.

Somehow the handling of the system libs changed heavily in last update
breaking all the builds