### PR TITLE
ruby: disable rpaths

### DIFF
--- a/recipes-devtools/ruby_%.bbappend
+++ b/recipes-devtools/ruby_%.bbappend
@@ -1,2 +1,1 @@
 # SPDX-License-Identifier: MIT
-EXTRA_OECONF:remove = "--disable-rpath"


### PR DESCRIPTION
by reverting to the default proposed by the ruby base recipe

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>