### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.45.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.45.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d86005bd540ece74648fd88ddfc486dd"
-SRC_URI[sha256sum] = "2f44f9403dd7d1059a63aa8885e7471f6b6a1425263566cccfee2c46f7571e2f"
+SRC_URI[md5sum] = "f8f85d7b346649538bbbd36d59b463d8"
+SRC_URI[sha256sum] = "98bfe40dc104c5cf4216dbf9c3e87822039a1f4744ccc2fadb0795e48d576363"
 
 GEM_NAME = "aws-sdk-cloudtrail"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.125.5.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.125.5.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b77575cb053b4f1ce47a0beb55252192"
-SRC_URI[sha256sum] = "17bd20eaa6d917f83a5e06a52e8ae84c4451a06286a8f125de0dc4a746e12a05"
+SRC_URI[md5sum] = "5c35394ba0843ddbf482f674f78cf142"
+SRC_URI[sha256sum] = "8de2db83f8f0dd98e2a0340a11c0acfe2907fc427c7149c71c5a8b766c19c8c4"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.295.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.295.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6f69b07b88ef73acafe587f4923f9d9d"
-SRC_URI[sha256sum] = "edcdc439672153d9b7eb423da3eb5595632c5c59750b75fbac81b542b8df269c"
+SRC_URI[md5sum] = "ae7ef27b98dbe1dad873088b7a1fcf0a"
+SRC_URI[sha256sum] = "b4536a28c8d925effdc45863ecafef7682ae8a080226ad86971cc17f40e6092a"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-guardduty_1.53.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-guardduty_1.53.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a711ae2d5edabb769e3d77340829b05a"
-SRC_URI[sha256sum] = "cc60fc4c1d76b4f358ea515b1b256e15d48ca017dde9f596e045c41b58a206e0"
+SRC_URI[md5sum] = "f57eb27dcfb0db11351118cedf4a1542"
+SRC_URI[sha256sum] = "062e48bba6f9c542a5c59c6857330bc6a550c0875a58ba0c53e1339496ab21c7"
 
 GEM_NAME = "aws-sdk-guardduty"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.111.2.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.111.2.bb
@@ -17,8 +17,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f6207ca059dab5bce1bf21eaaeebe5c6"
-SRC_URI[sha256sum] = "1c53f2d30b0cb2fe0545069ae300fd0f5982e3356e91dfe6773ae503da37f0dd"
+SRC_URI[md5sum] = "1febce41157884b77c802098e96eddf8"
+SRC_URI[sha256sum] = "f64372101608440549e0dde6bc5f62a80293c9419e5db6c1acedbd83035b40a4"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-cookstyle_7.30.3.bb
+++ b/recipes-rubygems/rubygems-cookstyle_7.30.3.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "fcf0da5a4bb56644beeb44fc57dfd733"
-SRC_URI[sha256sum] = "695762dbf722ebb9f619b13145cb2fa190f2f487b5adcd84fbbace73105a0652"
+SRC_URI[md5sum] = "cf42e67c2c09668b6f0fcb0695887f42"
+SRC_URI[sha256sum] = "14de754ba7569972a36ca6ee41f43db4ebe7a1e85a0e0b8018f75729cee73f53"
 
 GEM_NAME = "cookstyle"
 

--- a/recipes-rubygems/rubygems-corefoundation_0.3.10.bb
+++ b/recipes-rubygems/rubygems-corefoundation_0.3.10.bb
@@ -7,7 +7,9 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1814884814f0a48dea9ee270f29af6f6"
 
 EXTRA_DEPENDS:append = " "
-EXTRA_RDEPENDS:append = " libffi"
+EXTRA_RDEPENDS:append = " \
+    libffi \
+"
 
 DEPENDS:class-native += "\
     rubygems-ffi-native \
@@ -15,8 +17,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b67d0b8580e22ecc9fba8fe65fff1b14"
-SRC_URI[sha256sum] = "26e1a17c0bcf8db959dad25c85a4bbed280043981bf9ab29f0c5e2e8121dc755"
+SRC_URI[md5sum] = "137641076885053f464213c95d8320e1"
+SRC_URI[sha256sum] = "72370206c6e6eaba8ee323148870b7a4d09e466054dc84474e58462120323aa7"
 
 GEM_NAME = "corefoundation"
 

--- a/recipes-rubygems/rubygems-fast-gettext_2.2.0.bb
+++ b/recipes-rubygems/rubygems-fast-gettext_2.2.0.bb
@@ -4,15 +4,15 @@ DESCRIPTION = "A simple, fast, memory-efficient and threadsafe implementation of
 HOMEPAGE = "https://github.com/grosser/fast_gettext"
 
 LICENSE = "MIT & Ruby"
-LIC_FILES_CHKSUM = "file://lib/fast_gettext/vendor/string.rb;beginline=7;endline=7;md5=27f370e21efbc2fe795eed381d85ecd5"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=de73345c85d650bab85563ec6f1b2f9d"
 
 EXTRA_DEPENDS:append = " "
 EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "96084779e064eb2cf2d7d5c3b3a74c10"
-SRC_URI[sha256sum] = "0d095dbc5a003b3caea13b9569288703086ae05aac2cc6d7b0881c8e0a07ae15"
+SRC_URI[md5sum] = "b8cd6edebb266f28a771380236612c96"
+SRC_URI[sha256sum] = "01804331afce7b7c918e7ebe1951a3507b24b3a0c0617429725dbd4a2f234ad8"
 
 GEM_NAME = "fast_gettext"
 

--- a/recipes-rubygems/rubygems-ffi_1.15.5.bb
+++ b/recipes-rubygems/rubygems-ffi_1.15.5.bb
@@ -16,8 +16,8 @@ GEM_INSTALL_FLAGS:append = " \
     --with-opt-dir=${RECIPE_SYSROOT} \
 "
 
-SRC_URI[md5sum] = "a2187dd24311ae388a1e6756696f8427"
-SRC_URI[sha256sum] = "56cfca5261ead48688241236adfefb07a000a6d17184d7a4eed48d55b9675d6b"
+SRC_URI[md5sum] = "026cce18ef8ffc713be29c2ffc9d335b"
+SRC_URI[sha256sum] = "6f2ed2fa68047962d6072b964420cba91d82ce6fa8ee251950c17fca6af3c2a0"
 
 GEM_NAME = "ffi"
 

--- a/recipes-rubygems/rubygems-google-apis-core_0.4.2.bb
+++ b/recipes-rubygems/rubygems-google-apis-core_0.4.2.bb
@@ -6,6 +6,9 @@ HOMEPAGE = "https://github.com/google/google-api-ruby-client"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=7e6820981d59cdfac1e6538d3aacfd11"
 
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
 DEPENDS:class-native += "\
     rubygems-addressable-native \
     rubygems-googleauth-native \
@@ -17,8 +20,10 @@ DEPENDS:class-native += "\
     rubygems-webrick-native \
 "
 
-SRC_URI[md5sum] = "db03b189498cd9f1febb787b4a2b613f"
-SRC_URI[sha256sum] = "1e334ff47ce35680f0bb701abeaa94cbb48af77d7f62b96aa3293fca8c91ffdb"
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "16fe4046d7507e8521a2edb91cc0f046"
+SRC_URI[sha256sum] = "eb84fc47d74f8e71fdac93a132d09eee40b2943bdabd50683ad3a0f7e62e61a7"
 
 GEM_NAME = "google-apis-core"
 

--- a/recipes-rubygems/rubygems-puppet_7.14.0.bb
+++ b/recipes-rubygems/rubygems-puppet_7.14.0.bb
@@ -24,8 +24,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d776b039312b67e00f1b3b64790efebe"
-SRC_URI[sha256sum] = "463699dd37d5fe3c7cdbd9ab6ceb5e031f6908f6567575689f2a76744ba2ef28"
+SRC_URI[md5sum] = "921337b18efe44e98cdf41ae3e00669c"
+SRC_URI[sha256sum] = "0911a17f78bed6d805f52f05f187382d410692b2f90f0b3d67263e380f9f6bbd"
 
 GEM_NAME = "puppet"
 

--- a/recipes-rubygems/rubygems-rubocop_1.25.0.bb
+++ b/recipes-rubygems/rubygems-rubocop_1.25.0.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "RuboCop is a Ruby code style checking and code formatting tool.  
 HOMEPAGE = "https://rubocop.org/"
 
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=70ea0c9411b12875ee38aae3003e33fd"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=fc850d6ee0639e80c9a97e78a2daad32"
 
 EXTRA_DEPENDS:append = " "
 EXTRA_RDEPENDS:append = " "
@@ -22,8 +22,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a6e4c8d9d2d01da0ed32c5515a38d74c"
-SRC_URI[sha256sum] = "e01ede58cb413c08e6e5b8c6f4b92ec282e646158774b3f98595ae92c453c7ea"
+SRC_URI[md5sum] = "f6475873335244d5343fbd912e13e3ca"
+SRC_URI[sha256sum] = "723149a1d1809a13e61e7352f59b98ecd0f8219b88630030b20a45dc6a712e90"
 
 GEM_NAME = "rubocop"
 


### PR DESCRIPTION
* aws-sdk-core: update to 3.125.5
* ffi: update to 1.15.5
* google-apis-core: update to 0.4.2
* aws-sdk-s3: update to 1.111.2
* fast_gettext: update to 2.2.0
* corefoundation: update to 0.3.10
* cookstyle: update to 7.30.3
* aws-sdk-ec2: update to 1.295.0
* puppet: update to 7.14.0
* aws-sdk-cloudtrail: update to 1.45.0
* aws-sdk-guardduty: update to 1.53.0