### PR TITLE
rubygems: use correct variables for selecting target architecture

### DIFF
--- a/classes/rubygems.bbclass
+++ b/classes/rubygems.bbclass
@@ -52,8 +52,8 @@ def get_gem_name_from_bpn(d):
     return gemName
 
 def get_cross_platform_folder(d):
-    target_arch = d.getVar("HOST_ARCH")
-    target_os = d.getVar("HOST_OS")
+    target_arch = d.getVar("BUILD_ARCH")
+    target_os = d.getVar("BUILD_OS")
     if target_os.endswith("linux"):
         target_os = target_os.replace('linux', 'linux-gnu')
     return target_arch + "-" + target_os


### PR DESCRIPTION
HOST_OS/HOST_ARCH refer to the host, while BUILD_OS/BUILD_ARCH
refer to the target. We want the target architecture in this case
so switch to using the BUILD_* prefixes.

Signed-off-by: Jack Mitchell <ml@embed.me.uk>