### PR TITLE
fix cross compiling for architectures other than x86_64

### DIFF
--- a/classes/rubygems.bbclass
+++ b/classes/rubygems.bbclass
@@ -40,6 +40,7 @@ EXTRA_RDEPENDS ?= ""
 EXTRA_DEPENDS ?= ""
 
 RUBYLIB:class-target = "${STAGING_LIBDIR_NATIVE}/ruby/${GEMLIB_VERSION}/${@get_build_platform_folder(d)}"
+RUBYPLATFORM:class-target = "${@get_target_platform_folder(d)}"
 CFLAGS:append = " -DHAVE_GCC_CAS"
 
 def get_gem_name_from_bpn(d):
@@ -58,6 +59,12 @@ def get_build_platform_folder(d):
         build_os = build_os.replace('linux', 'linux-gnu')
     return build_arch + "-" + build_os
 
+def get_target_platform_folder(d):
+    target_arch = d.getVar("HOST_ARCH")
+    target_os = d.getVar("HOST_OS")
+    if target_os.endswith("linux"):
+        target_os = target_os.replace('linux', 'linux-gnu')
+    return target_arch + "-" + target_os
 
 do_gem_unpack() {
     export RUBYLIB=${RUBYLIB}
@@ -105,6 +112,7 @@ python do_arch_patch_config() {
     if bb.data.inherits_class('native', d):
         return
     _map = {
+        "arch": d.expand("${RUBYPLATFORM}"),
         "AR": d.expand("${AR}"),
         "AS": d.expand("${AS}"),
         "CC": d.expand("${CC}"),

--- a/classes/rubygems.bbclass
+++ b/classes/rubygems.bbclass
@@ -39,7 +39,7 @@ GEM_INSTALL_FLAGS ?= ""
 EXTRA_RDEPENDS ?= ""
 EXTRA_DEPENDS ?= ""
 
-RUBYLIB:class-target = "${STAGING_LIBDIR_NATIVE}/ruby/${GEMLIB_VERSION}/${@get_cross_platform_folder(d)}"
+RUBYLIB:class-target = "${STAGING_LIBDIR_NATIVE}/ruby/${GEMLIB_VERSION}/${@get_build_platform_folder(d)}"
 CFLAGS:append = " -DHAVE_GCC_CAS"
 
 def get_gem_name_from_bpn(d):
@@ -51,12 +51,12 @@ def get_gem_name_from_bpn(d):
         gemName = bpn
     return gemName
 
-def get_cross_platform_folder(d):
-    target_arch = d.getVar("HOST_ARCH")
-    target_os = d.getVar("HOST_OS")
-    if target_os.endswith("linux"):
-        target_os = target_os.replace('linux', 'linux-gnu')
-    return target_arch + "-" + target_os
+def get_build_platform_folder(d):
+    build_arch = d.getVar("BUILD_ARCH")
+    build_os = d.getVar("BUILD_OS")
+    if build_os.endswith("linux"):
+        build_os = build_os.replace('linux', 'linux-gnu')
+    return build_arch + "-" + build_os
 
 
 do_gem_unpack() {


### PR DESCRIPTION
this allows me to build and install ffi based modules on an aarch64 platform, simple test was performed by installing and requiring the ffi-libarchive gem which loaded without errors.