### PR TITLE
Package update

### DIFF
--- a/files/lint/oelint-custom/rule_license.py
+++ b/files/lint/oelint-custom/rule_license.py
@@ -230,6 +230,7 @@ class RubygemsLicense(Rule):
         "tcl",
         "unfs3",
         "vim",
+        "WTFPL",
     ]
 
     LAYER_LICENSE_DIR = "files/licenses"

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_options.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_options.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_options(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_options(self):
+        self.gem_is_installed("options")
+
+    def test_load_options(self):
+        self.gem_is_loadable("options")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_progress_bar.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_progress_bar.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_progress_bar(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_progress_bar(self):
+        self.gem_is_installed("progress_bar")
+
+    def test_load_progress_bar(self):
+        self.gem_is_loadable("progress_bar")
+

--- a/packagegroups-rubygems/packagegroup-rubygems.bb
+++ b/packagegroups-rubygems/packagegroup-rubygems.bb
@@ -215,6 +215,7 @@ RDEPENDS:${PN} += "\
     rubygems-nokogiri \
     rubygems-nori \
     rubygems-ohai \
+    rubygems-options \
     rubygems-os \
     rubygems-parallel \
     rubygems-parser \
@@ -223,6 +224,7 @@ RDEPENDS:${PN} += "\
     rubygems-path-expander \
     rubygems-pathutil \
     rubygems-plist \
+    rubygems-progress-bar \
     rubygems-proxifier \
     rubygems-pry \
     rubygems-public-suffix \

--- a/recipes-rubygems/rubygems-aws-partitions_1.568.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.568.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "be1662a963769e2b7d74e6f8b55ad715"
-SRC_URI[sha256sum] = "8907f8ba0453028af1bb892760aafb57d3754791e32d632e65032fff01a8c95f"
+SRC_URI[md5sum] = "aed070a1e90f9a53ff6913ebaec2b42f"
+SRC_URI[sha256sum] = "a4707a87eb1b872f6d4fa6ffe1a6508efb9dfbe7601fd9caba9fb10ecd3be2aa"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cognitoidentityprovider_1.65.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cognitoidentityprovider_1.65.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "df16f41329094ceb65daa607fdff738f"
-SRC_URI[sha256sum] = "c8567dad2eace0c217c6ba6c6b3ef8884c8a4defa592cf6638c43b6a15f5e33f"
+SRC_URI[md5sum] = "7b6c07dc1deb650e8f267810079a2ea5"
+SRC_URI[sha256sum] = "8a53ab2c05d1aab9add4fc612cb4a0391cab519e8914c0252a222d53107cfc37"
 
 GEM_NAME = "aws-sdk-cognitoidentityprovider"
 

--- a/recipes-rubygems/rubygems-aws-sdk-configservice_1.75.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-configservice_1.75.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "dd06fec83a33f2cca86340a347f06626"
-SRC_URI[sha256sum] = "6f0c03bd07bed5cfe59e4ab69ce8b413f5fc4f2f3d36e0e4b5e35df1a7cfe106"
+SRC_URI[md5sum] = "044f238e296f7957cd6001e246edc8b0"
+SRC_URI[sha256sum] = "c3e53b47994e157edb2114d5027c6a5c2a02067d38df41f6337562957d88adc7"
 
 GEM_NAME = "aws-sdk-configservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.303.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.303.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "3343ee593d5dc8504ea86418b6032e2b"
-SRC_URI[sha256sum] = "6835b3b575105997dcd2532518b196c94d9939be698a96ef3888fbe927cfa98f"
+SRC_URI[md5sum] = "d2ff835fc0670aea3720c1a7e41b452d"
+SRC_URI[sha256sum] = "7254a43ea31a6c548a6949c938277df0078bc719a73ff1320b61b5a7b47c638a"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.98.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.98.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "53b334e15cdd660a94f6bdbe55e1f3c4"
-SRC_URI[sha256sum] = "a45e51eb168416702150fd1e5d93c8ba8bf66861fa38801422edf7f70321e55a"
+SRC_URI[md5sum] = "a82eeeb0344e1c405f51607e5f8151e4"
+SRC_URI[sha256sum] = "16ce75f854cc6b93ac3129a419c268b75223906a746c7db1f9d8cb2f68f0a273"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticache_1.75.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticache_1.75.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "997acca9cddeecf1ca006d2796108bc0"
-SRC_URI[sha256sum] = "4faae430c26ffd3070db339af027b629bd2df2758c3ef9e013bea7e307c6f2a8"
+SRC_URI[md5sum] = "b195c79469978d113cb66ff40c861e14"
+SRC_URI[sha256sum] = "a989f86a4ce4d33605c87b536bae7c10ea41a95ba8cd9108ac337d53972bf219"
 
 GEM_NAME = "aws-sdk-elasticache"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.108.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.108.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f690735c01070cf2e675501307c956bf"
-SRC_URI[sha256sum] = "a3d1200509747967dc3a55eae978cef12ebbcf076c866d8bb874f760b8b70581"
+SRC_URI[md5sum] = "e3f1380ca2de1c4036b8864b488a2434"
+SRC_URI[sha256sum] = "09f5e79e185714ad26f4d36045ebfde702f3d7377a3ada38d6caa6053c03ad81"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.142.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.142.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7623987051bdf589b24f256dba87ff34"
-SRC_URI[sha256sum] = "6d24e5c3684a2637424e7a77b774224843b3451d0dcc12fd1bb93e9e99827db2"
+SRC_URI[md5sum] = "ca81069854ee3a8fdd38ec8ff85a03ed"
+SRC_URI[sha256sum] = "0d4f600cdb2e83592bf1d5d0b9ecf6796112118026dc2d346705ac1022f1fc4b"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-excon_0.92.0.bb
+++ b/recipes-rubygems/rubygems-excon_0.92.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "2697bbc0dc832b1ef6ec5de083c064f3"
-SRC_URI[sha256sum] = "e47408ada7784a8eea4faa3b779127c609cb1fb024b6da12bc6cadf02dc8210d"
+SRC_URI[md5sum] = "702fd98dfe5590ea78602c19f4cd2898"
+SRC_URI[sha256sum] = "9c6fed9a5cf2d5f621eb1cf80a72b7a91a42099a42d3d8689a9971b48a26cef9"
 
 GEM_NAME = "excon"
 

--- a/recipes-rubygems/rubygems-faraday-rack_2.0.0.bb
+++ b/recipes-rubygems/rubygems-faraday-rack_2.0.0.bb
@@ -6,13 +6,26 @@ HOMEPAGE = "https://github.com/lostisland/faraday-rack"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=20830660ee48a0c845a62aad77c18f4a"
 
-SRC_URI[md5sum] = "e1f15e1a8e72e3d38c7973550e11925e"
-SRC_URI[sha256sum] = "ef60ec969a2bb95b8dbf24400155aee64a00fc8ba6c6a4d3968562bcc92328c0"
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+DEPENDS:class-native += "\
+    rubygems-faraday-native \
+"
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "3633c44746f1f4a11febca8fd82ec61b"
+SRC_URI[sha256sum] = "41759651c9e8baba520c21f807a8787dbb8480c2dbe64569264346ffad6b0461"
 
 GEM_NAME = "faraday-rack"
 
 inherit rubygems
 inherit rubygentest
 inherit pkgconfig
+
+RDEPENDS:${PN}:class-target += "\
+    rubygems-faraday \
+"
 
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-inspec-bin_5.7.9.bb
+++ b/recipes-rubygems/rubygems-inspec-bin_5.7.9.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e90d3d94cf2b734c32c2b915bd8a147d"
-SRC_URI[sha256sum] = "e1a5c44df2263f26d8a4673b1f32a5f12eb7a1d4ab0a9cbd171a9d46f8470b07"
+SRC_URI[md5sum] = "cb68a9a03d57962232f8796afff5996f"
+SRC_URI[sha256sum] = "66c8393f31bde87c386aa08759f36da708f2d45c8b7edfed5d5878db45d4727d"
 
 GEM_NAME = "inspec-bin"
 

--- a/recipes-rubygems/rubygems-inspec-core_5.7.9.bb
+++ b/recipes-rubygems/rubygems-inspec-core_5.7.9.bb
@@ -36,8 +36,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "90d0313d6ec063d9b1a94f0ede772281"
-SRC_URI[sha256sum] = "7d5dddc24f4dee1dc1b2a48f57941e89b126570067bee509c6a39b76da8b6fa1"
+SRC_URI[md5sum] = "8222e19db40bacdfdbbd1846e4a061b9"
+SRC_URI[sha256sum] = "a8936e4a6c2892219b98de93d1935ad1e3df6081914a36fb1cc70bee81ab2112"
 
 GEM_NAME = "inspec-core"
 

--- a/recipes-rubygems/rubygems-inspec_5.7.9.bb
+++ b/recipes-rubygems/rubygems-inspec_5.7.9.bb
@@ -14,6 +14,7 @@ DEPENDS:class-native += "\
     rubygems-faraday-middleware-native \
     rubygems-inspec-core-native \
     rubygems-mongo-native \
+    rubygems-progress-bar-native \
     rubygems-rake-native \
     rubygems-train-aws-native \
     rubygems-train-habitat-native \
@@ -23,8 +24,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1901047d61519da8e930d9d1e4cf5a7d"
-SRC_URI[sha256sum] = "518a70d709031fcc674b9a941afb7798124f134c3018145207bda32ce7e80301"
+SRC_URI[md5sum] = "05a415cd9cbdb21577b4e45a9190660c"
+SRC_URI[sha256sum] = "8da4bfd9fc7acb5ca4f9e9d7bb8ee684afabaa52b7e617b8692e43699657da22"
 
 GEM_NAME = "inspec"
 
@@ -42,6 +43,7 @@ RDEPENDS:${PN}:class-target += "\
     rubygems-faraday-middleware \
     rubygems-inspec-core \
     rubygems-mongo \
+    rubygems-progress-bar \
     rubygems-rake \
     rubygems-train \
     rubygems-train-aws \

--- a/recipes-rubygems/rubygems-kramdown_2.3.2.bb
+++ b/recipes-rubygems/rubygems-kramdown_2.3.2.bb
@@ -6,12 +6,17 @@ HOMEPAGE = "http://kramdown.gettalong.org"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://COPYING;md5=efa42ef946dcb15e4ee38ea3aeedf2b0"
 
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
 DEPENDS:class-native += "\
     rubygems-rexml-native \
 "
 
-SRC_URI[md5sum] = "1324f4af5b0b15d96066d2654fbe7d15"
-SRC_URI[sha256sum] = "59e938cfa42a3d6169b295727fe09c4c91d742336c8fbd1042529f4db664ab49"
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "99ee9255319afa646e8f81def9234db4"
+SRC_URI[sha256sum] = "cb4530c2e9d16481591df2c9336723683c354e5416a5dd3e447fa48215a6a71c"
 
 GEM_NAME = "kramdown"
 

--- a/recipes-rubygems/rubygems-options_2.3.2.bb
+++ b/recipes-rubygems/rubygems-options_2.3.2.bb
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: options"
+DESCRIPTION = "parse options from *args cleanly"
+HOMEPAGE = "https://github.com/ahoward/options"
+
+LICENSE = "Ruby"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Ruby;md5=105fc57d3f4d3122db32912f3e6107d0"
+
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "bda39dc56a42378d9f10ef0ba27ce2a9"
+SRC_URI[sha256sum] = "32413a4b9e363234eed2eecfb2a1a9deb32810f72c54820a37a62f65b905c5e8"
+
+GEM_NAME = "options"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-progress-bar_1.3.3.bb
+++ b/recipes-rubygems/rubygems-progress-bar_1.3.3.bb
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: progress_bar"
+DESCRIPTION = "Give people feedback about long-running tasks without overloading them with information: Use a progress bar, like Curl or Wget!"
+HOMEPAGE = "http://github.com/paul/progress_bar"
+
+LICENSE = "WTFPL"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=6c79afcc5a5e0f48a4a5a5687a026b3e"
+
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+DEPENDS:class-native += "\
+    rubygems-highline-native \
+    rubygems-options-native \
+"
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "c779cd919a7133d68a3f0703fd156e85"
+SRC_URI[sha256sum] = "873018c6c94a2c33c9d10109719c14d6004d3bbd4d385691fba9c9560b347b12"
+
+GEM_NAME = "progress_bar"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS:${PN}:class-target += "\
+    rubygems-highline \
+    rubygems-options \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-unf-ext_0.0.8.1.bb
+++ b/recipes-rubygems/rubygems-unf-ext_0.0.8.1.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c9edacd569f20eca47bcf350cbc7980e"
-SRC_URI[sha256sum] = "cd8f69915afccd3766400bf4f5f18038a57a75a2efde4c21fabfc96b6f8dab4a"
+SRC_URI[md5sum] = "21e2d17d515bd0de6f6e0900fda908ca"
+SRC_URI[sha256sum] = "bfe72d0e07c1420e5e6c36a39c352a2f9c664e0910c58f9c977f08bc3a10c12d"
 
 GEM_NAME = "unf_ext"
 


### PR DESCRIPTION
* kramdown: update to 2.3.2
* inspec-core: update to 5.7.9
* excon: update to 0.92.0
* aws-sdk-configservice: update to 1.75.0
* aws-partitions: update to 1.568.0
* aws-sdk-ecs: update to 1.98.0
* rubocop: update to 1.26.0
* aws-sdk-rds: update to 1.142.0
* aws-sdk-glue: update to 1.108.0
* unf_ext: update to 0.0.8.1
* aws-sdk-ec2: update to 1.303.0
* aws-sdk-cognitoidentityprovider: update to 1.65.0
* aws-sdk-elasticache: update to 1.75.0
* faraday-rack: update to 2.0.0