### PR TITLE
ci: use plain SSTATE_DIR instead of mirror

### DIFF
--- a/.github/workflows/cron-master-qemu86-64-pkgupdate.yml
+++ b/.github/workflows/cron-master-qemu86-64-pkgupdate.yml
@@ -71,8 +71,8 @@ jobs:
       - name: activate (caches)
         uses: priv-kweihmann/meta-sca-ci-utils/addvar@latest
         with:
-          variable: SSTATE_MIRRORS
-          value: "file://.* file:///${WORKSPACE}/sstate-cache/PATH"
+          variable: SSTATE_DIR
+          value: "${WORKSPACE}/sstate-cache"
       - if: env.BUILD_GLIBC == '1'
         name: build (glibc)
         uses: priv-kweihmann/meta-sca-ci-utils/buildstep@latest

--- a/.github/workflows/pr-master-qemu86-64-glibc.yml
+++ b/.github/workflows/pr-master-qemu86-64-glibc.yml
@@ -63,8 +63,8 @@ jobs:
       - name: activate (caches)
         uses: priv-kweihmann/meta-sca-ci-utils/addvar@latest
         with:
-          variable: SSTATE_MIRRORS
-          value: "file://.* file:///${WORKSPACE}/sstate-cache/PATH"
+          variable: SSTATE_DIR
+          value: "${WORKSPACE}/sstate-cache"
       - if: env.BUILD_GLIBC == '1'
         name: build (glibc)
         uses: priv-kweihmann/meta-sca-ci-utils/buildstep@latest


### PR DESCRIPTION
as a mirror would require a hash server as well.
Changing SSTATE_DIR is more than enough

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>