### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.577.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.577.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c2e0ae922f7af3191fc79ebaaa1f2565"
-SRC_URI[sha256sum] = "dac1b3183b23333dad25911b08be94c0d65aed3c0963658fa5ce15680a6e888d"
+SRC_URI[md5sum] = "3426ff86810c9970a7698de445604cfc"
+SRC_URI[sha256sum] = "a97fa389c3ccb50c0d539f34a192137d45a0aa8fa602ddfdf7b605ca36e38066"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-athena_1.53.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-athena_1.53.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "ccd25c2ea6bc014b28b612f6359dbde2"
-SRC_URI[sha256sum] = "d98f8dafb48553d8b5a03a2d47c4e0bc2e1fa220c31327608cc8a1dd830d9cfe"
+SRC_URI[md5sum] = "1e0dc777d9f4471ef0159cf7b097eb36"
+SRC_URI[sha256sum] = "9934d13d449b3cbc55ddfb734f1bff0760ad54e4a53d8f8a2867ab508a30faa3"
 
 GEM_NAME = "aws-sdk-athena"
 

--- a/recipes-rubygems/rubygems-aws-sdk-batch_1.61.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-batch_1.61.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "4c07824a079fd18e13acecbf196b2153"
-SRC_URI[sha256sum] = "5ef577a169391671fa76a3a7011f798aad06df3eebe8e1d073ea89d9a901c935"
+SRC_URI[md5sum] = "f91ad489531ed562e86e73f946658a03"
+SRC_URI[sha256sum] = "ca9a4cb2fa78fd3f3bf9d089ea867fadc62f8a82160307eea2c1788448eb4460"
 
 GEM_NAME = "aws-sdk-batch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatch_1.64.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatch_1.64.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c72fb60c90f231b8f81216c6fe447bae"
-SRC_URI[sha256sum] = "17713fb906587400609cf19532e1c2a9280d41aa5efabb5eec6ddc57004df01b"
+SRC_URI[md5sum] = "78d965045a5a9105cc3c922ec72a55bd"
+SRC_URI[sha256sum] = "f4e0098a2802d1eef80f5ea72439992927dd09eb14eb21ace355794b98406b0b"
 
 GEM_NAME = "aws-sdk-cloudwatch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.130.1.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.130.1.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "0245e09c92509c3fc9a12f3042873af2"
-SRC_URI[sha256sum] = "7547757afb0e340e7011381635db468d9bbcd7c6ea97bfefdccf9069c0ddd593"
+SRC_URI[md5sum] = "b484033697135c0b500c8f2b731bb69b"
+SRC_URI[sha256sum] = "96aa459a7e3313252f02899feb31800eb38389e66937f7256d0a0c84d0993553"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.307.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.307.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "853c304c3c1763be7a2abe612e2cf161"
-SRC_URI[sha256sum] = "71ee22dad13190da98651630e91bf04ba6853ff6a7b4937dd7561caac768f1b6"
+SRC_URI[md5sum] = "57ee9fee7c66f52c40ebf7cab846c772"
+SRC_URI[sha256sum] = "e24ed7cc9599836124cd7ff71844097df2f92c6edbe89420e99412728179ab8d"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-efs_1.54.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-efs_1.54.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d049d515144d65c15070406cf9f44163"
-SRC_URI[sha256sum] = "6a1e591fd4bcaa66b3df9f02a2240ce4769cb9eded2a1d1cc5742a7f6521694b"
+SRC_URI[md5sum] = "bca705db42ac20701541570437bcf39f"
+SRC_URI[sha256sum] = "f8083d682c8745bbeb5473ef8051ee7d35fcb9a63c24e6911fdddb7c9fe5b066"
 
 GEM_NAME = "aws-sdk-efs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.109.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.109.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e3f1380ca2de1c4036b8864b488a2434"
-SRC_URI[sha256sum] = "09f5e79e185714ad26f4d36045ebfde702f3d7377a3ada38d6caa6053c03ad81"
+SRC_URI[md5sum] = "005d035ca9af19e8d73e528285ff693f"
+SRC_URI[sha256sum] = "16b1cc7d0b901982318dd8db13c4d14a05befe64f2f3755d231d160bc4a7282b"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.143.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.143.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "ca81069854ee3a8fdd38ec8ff85a03ed"
-SRC_URI[sha256sum] = "0d4f600cdb2e83592bf1d5d0b9ecf6796112118026dc2d346705ac1022f1fc4b"
+SRC_URI[md5sum] = "4e8aea25c0165b2b774fdfac7d36fdba"
+SRC_URI[sha256sum] = "0a4761ec763da89dceadddceeb3eb4b452c7da88f041a90d32cb2ab43052ac0f"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-faraday-net-http_2.0.2.bb
+++ b/recipes-rubygems/rubygems-faraday-net-http_2.0.2.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b49b0c0d18defa0d8d61e6967c8f6262"
-SRC_URI[sha256sum] = "f867b028552c3cf018b9293b58b993dc238ba62683568b3e194c673afe62d700"
+SRC_URI[md5sum] = "1489f4b5bc18d549a2b22e2f2a04e0e3"
+SRC_URI[sha256sum] = "10e593141a9f0c1d649c7eedc6ca656e43579c455037c4dcb792f865769327f0"
 
 GEM_NAME = "faraday-net_http"
 

--- a/recipes-rubygems/rubygems-flay_2.13.0.bb
+++ b/recipes-rubygems/rubygems-flay_2.13.0.bb
@@ -6,17 +6,22 @@ HOMEPAGE = "http://ruby.sadi.st/"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://README.rdoc;beginline=100;endline=123;md5=9729e7cc2f0b6cd88813876ac0335063"
 
-EXTRA_DEPENDS:append = " rubygems-gauntlet"
+EXTRA_DEPENDS:append = " \
+    rubygems-gauntlet \
+"
+EXTRA_RDEPENDS:append = " "
 
 DEPENDS:class-native += "\
-    rubygems-erubis-native \
+    rubygems-erubi-native \
     rubygems-path-expander-native \
     rubygems-ruby-parser-native \
     rubygems-sexp-processor-native \
 "
 
-SRC_URI[md5sum] = "b2c4d45c0654ac18a13288697c512a37"
-SRC_URI[sha256sum] = "677ff6fc3727ee297a25357e908dc9cf1243eb7e61b8852d595873a4907ac4d7"
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "5a5449d043b26dc25c2ee9e25d906677"
+SRC_URI[sha256sum] = "6baa1a93c5a8cb20ec99376f55c0f1aa00b7e97a3e673cb80d029be52d755486"
 
 GEM_NAME = "flay"
 
@@ -25,7 +30,7 @@ inherit rubygentest
 inherit pkgconfig
 
 RDEPENDS:${PN}:class-target += "\
-    rubygems-erubis \
+    rubygems-erubi \
     rubygems-path-expander \
     rubygems-ruby-parser \
     rubygems-sexp-processor \

--- a/recipes-rubygems/rubygems-flog_4.6.5.bb
+++ b/recipes-rubygems/rubygems-flog_4.6.5.bb
@@ -6,7 +6,10 @@ HOMEPAGE = "http://ruby.sadi.st/"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://README.rdoc;beginline=42;endline=65;md5=5db85eba7780ac1765a03fe0e5ec1657"
 
-EXTRA_DEPENDS:append = " rubygems-gauntlet"
+EXTRA_DEPENDS:append = " \
+    rubygems-gauntlet \
+"
+EXTRA_RDEPENDS:append = " "
 
 DEPENDS:class-native += "\
     rubygems-path-expander-native \
@@ -14,8 +17,10 @@ DEPENDS:class-native += "\
     rubygems-sexp-processor-native \
 "
 
-SRC_URI[md5sum] = "0c4d4707090126e0faa43063c089f24c"
-SRC_URI[sha256sum] = "b5aa03696c075a7d672cd5e24cee36e4b76c23e200a2add0618b834270d1c763"
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "3424608c6b398fb35761b52045a5de31"
+SRC_URI[sha256sum] = "4cbf4327307509cf058560599d456824b29b5d4c4c83b63ba126ef03a31582d6"
 
 GEM_NAME = "flog"
 

--- a/recipes-rubygems/rubygems-nokogiri_1.13.4.bb
+++ b/recipes-rubygems/rubygems-nokogiri_1.13.4.bb
@@ -24,8 +24,8 @@ GEM_INSTALL_FLAGS:append = " \
     --use-system-libraries \
 "
 
-SRC_URI[md5sum] = "2e70abfe6b72009b4fb8270db74c388a"
-SRC_URI[sha256sum] = "bf1b1bceff910abb0b7ad825535951101a0361b859c2ad1be155c010081ecbdc"
+SRC_URI[md5sum] = "f24736b4181a95a591e0cfa1163f68cd"
+SRC_URI[sha256sum] = "0d46044eb39271e3360dae95ed6061ce17bc0028d475651dc48db393488c83bc"
 
 GEM_NAME = "nokogiri"
 

--- a/recipes-rubygems/rubygems-parser_3.1.2.0.bb
+++ b/recipes-rubygems/rubygems-parser_3.1.2.0.bb
@@ -17,8 +17,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "beed3c0d0c7e0267d73aba9e53c4a364"
-SRC_URI[sha256sum] = "6c70fda4fd38329c5105a0818c65e0e3adc7ef96e841a61696040bb5f7834f7d"
+SRC_URI[md5sum] = "200b0c40b91990b035ce599e9a347360"
+SRC_URI[sha256sum] = "eda4d7b49bbfddad3b6ca9cdfb23302eec6cf73c2e808b6d5b0cc9161f7c0e76"
 
 GEM_NAME = "parser"
 

--- a/recipes-rubygems/rubygems-public-suffix_4.0.7.bb
+++ b/recipes-rubygems/rubygems-public-suffix_4.0.7.bb
@@ -4,10 +4,15 @@ DESCRIPTION = "PublicSuffix can parse and decompose a domain name into top level
 HOMEPAGE = "https://simonecarletti.com/code/publicsuffix-ruby"
 
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=4c89161c761aa8e9188cee9f19125f9c"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2a74ef4eea0924a177f516b68666a34f"
 
-SRC_URI[md5sum] = "a8709e7242bf05183a56e10fca4d0e9d"
-SRC_URI[sha256sum] = "a99967c7b2d1d2eb00e1142e60de06a1a6471e82af574b330e9af375e87c0cf7"
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "060e68307f51276ee6750c05c14d7c2d"
+SRC_URI[sha256sum] = "8be161e2421f8d45b0098c042c06486789731ea93dc3a896d30554ee38b573b8"
 
 GEM_NAME = "public_suffix"
 

--- a/recipes-rubygems/rubygems-rubocop-ast_1.17.0.bb
+++ b/recipes-rubygems/rubygems-rubocop-ast_1.17.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "86c5b39c3ab58d66565f3d862ad6a92c"
-SRC_URI[sha256sum] = "9b0fd1323293863dc5c97ae85c3e55512eb33e8f6ebf1208ead11d4f05faa2ad"
+SRC_URI[md5sum] = "971c5e422e7e74790715c878c97815d8"
+SRC_URI[sha256sum] = "1d97643ec7d6e1771fcb7f444a2439d42472fe0957fa0406fb83c35cf2fc31cd"
 
 GEM_NAME = "rubocop-ast"
 


### PR DESCRIPTION
* aws-sdk-core: update to 3.130.1
* parser: update to 3.1.2.0
* faraday-net_http: update to 2.0.2
* aws-sdk-ec2: update to 1.307.0
* aws-sdk-rds: update to 1.143.0
* aws-sdk-batch: update to 1.61.0
* flog: update to 4.6.5
* aws-sdk-efs: update to 1.54.0
* rubocop-ast: update to 1.17.0
* aws-sdk-glue: update to 1.109.0
* aws-sdk-cloudwatch: update to 1.64.0
* nokogiri: update to 1.13.4
* public_suffix: update to 4.0.7
* aws-sdk-athena: update to 1.53.0
* rubocop: update to 1.27.0
* flay: update to 2.13.0