### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.586.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.586.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "0aa5168286b2d2fa3347837e3b82dd48"
-SRC_URI[sha256sum] = "1816a86e7a55eddee1fd54415b41a1dabf3b959a55b0ca12c64aa187ec27c862"
+SRC_URI[md5sum] = "a86de78ef5fcb3a9fe3b4114a59eecff"
+SRC_URI[sha256sum] = "5a8dd7e7bfed01398a97dda262d01e75d221b5d8fe23965ba903b36be1e0f3e9"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.312.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.312.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "494870b6378ba9a80c645b862ec57274"
-SRC_URI[sha256sum] = "94f7d5c31091acd9769dc8050cc27623d166ec0401004948526916cbbb3edc15"
+SRC_URI[md5sum] = "d84c5b093dd1a238530136e6889c9b75"
+SRC_URI[sha256sum] = "35b00bd28d98dbf2bd5b6ec9b6c2587f3c8b475dfc8a82645afbf211a1934f8e"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-organizations_1.70.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-organizations_1.70.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c266844114dcb6ef8b7db9007616e81c"
-SRC_URI[sha256sum] = "8b727b83e334ef4a2b781d642ea349edd12450d22997972761b501900b27c2c3"
+SRC_URI[md5sum] = "dfb6dacf6f07d5036e1861695deb2c32"
+SRC_URI[sha256sum] = "d9d55ae007644514cc6d797a17b9a7d7e5ab75a5ad71b9b9cb1611ffe5ab6930"
 
 GEM_NAME = "aws-sdk-organizations"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.146.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.146.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "27d6d0458c914e4104c3e4a20f854281"
-SRC_URI[sha256sum] = "182e5d5b9edb91ec4ac6f9c4dd46e22f308100dc754ec65b5c0315a40c9fe421"
+SRC_URI[md5sum] = "7a3c7bd0f60cbce7e2bb750c64372ca2"
+SRC_URI[sha256sum] = "b76621131447fd7e670c50ee88e674bf3da967b912e0571aafe381d48b43d9de"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-aws-sdk-redshift_1.82.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-redshift_1.82.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "2483968601e67040994ab40712c28296"
-SRC_URI[sha256sum] = "6ef90b05f2fc40f918a08d723c689d08f5cd082a40267867e82cdff79abb24b5"
+SRC_URI[md5sum] = "b53ed99e3fd28f58afb828df8f50c1e8"
+SRC_URI[sha256sum] = "251786dfea60f3c252d74084fa204a667befd9189d2c5ca6d52959322471f73e"
 
 GEM_NAME = "aws-sdk-redshift"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.114.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.114.0.bb
@@ -17,8 +17,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6ba5d70f49cd6e93267ba287226c01e1"
-SRC_URI[sha256sum] = "f120adc5b96e7d55c90c902f916b15bb022ef4dcfac1958db4b52ba34e0aec9e"
+SRC_URI[md5sum] = "61d76cd9b2d4a3e19a5b4dc64988b5a7"
+SRC_URI[sha256sum] = "ce0f71df1a7b0fb1f88d40a70636ef1a9b08e69fb560694c5dab3f4ac7efcde4"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-aws-sdk-securityhub_1.65.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-securityhub_1.65.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e4c51e5c75e1e1797ee2e3327be9e094"
-SRC_URI[sha256sum] = "af3372455b5d9fbbed28d2c5c9d1309f1abaa29c0e47f90aa14e82c65567e032"
+SRC_URI[md5sum] = "e088b19290841ffe9b181d61431d2d47"
+SRC_URI[sha256sum] = "57f8772867658bba0432444c57efdc581fc40f4b810e0c7613ca0a1d04ad2dd2"
 
 GEM_NAME = "aws-sdk-securityhub"
 

--- a/recipes-rubygems/rubygems-aws-sdk-sqs_1.51.1.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-sqs_1.51.1.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "33bb515372994345e6760d2d8ebd078a"
-SRC_URI[sha256sum] = "0203a505e8a8ef3a69bffc21cf611a9a2d26c21a840736fdbb2c5006e2fbb216"
+SRC_URI[md5sum] = "1017ff1f13cb0b3ea1d17528fa4d47ec"
+SRC_URI[sha256sum] = "899142af4b7c17c29129fb771d2548b336503a60d3228c1b41d519f3856344a2"
 
 GEM_NAME = "aws-sdk-sqs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ssm_1.137.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ssm_1.137.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "ebc7937f8474a4630906b70c77cfbcf1"
-SRC_URI[sha256sum] = "b4d993d29b34b1d29cf80f3e6f3beafec1d11f3af652e2c99e071bd888f30432"
+SRC_URI[md5sum] = "98e9612c1976a815041dee095472f715"
+SRC_URI[sha256sum] = "63ca2872094d83c4f599772bae0ae67df1af06bbb4efce416e37c66bfab89d38"
 
 GEM_NAME = "aws-sdk-ssm"
 

--- a/recipes-rubygems/rubygems-aws-sdk-synthetics_1.27.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-synthetics_1.27.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "0ca3e80a9bebe54ceea5e3e00b4734c9"
-SRC_URI[sha256sum] = "4dfa9084bd90066b7333a56cddb90acb21a7801ef1837607743a70667ce4436a"
+SRC_URI[md5sum] = "2ea2470ceca5f9268c61ed7fe325dee0"
+SRC_URI[sha256sum] = "466f6b01863a0f62856ea5c307344c876193aa0eba69e298d7951f17a506a415"
 
 GEM_NAME = "aws-sdk-synthetics"
 

--- a/recipes-rubygems/rubygems-faraday_2.3.0.bb
+++ b/recipes-rubygems/rubygems-faraday_2.3.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "ab0bd0b6237157f9d51c29836b873e97"
-SRC_URI[sha256sum] = "ccb092a9f95a409df1da5e840d1fa20d610f195435c622b8b793cb629c5773f9"
+SRC_URI[md5sum] = "1a29401d5de169d15de990dc3610d94e"
+SRC_URI[sha256sum] = "53382490743a40d6551bfc7d7b4bc681cf21068cf74e8f76319ce5cd53d27de7"
 
 GEM_NAME = "faraday"
 

--- a/recipes-rubygems/rubygems-nokogiri_1.13.5.bb
+++ b/recipes-rubygems/rubygems-nokogiri_1.13.5.bb
@@ -24,8 +24,8 @@ GEM_INSTALL_FLAGS:append = " \
     --use-system-libraries \
 "
 
-SRC_URI[md5sum] = "f24736b4181a95a591e0cfa1163f68cd"
-SRC_URI[sha256sum] = "0d46044eb39271e3360dae95ed6061ce17bc0028d475651dc48db393488c83bc"
+SRC_URI[md5sum] = "3c43c82df74fe06982eec2e1ffe6afa6"
+SRC_URI[sha256sum] = "e15570ec6d46921a3de5f5b057b027cc0c4f32775353c00e8c8dfbe443741e78"
 
 GEM_NAME = "nokogiri"
 

--- a/recipes-rubygems/rubygems-rubycritic_4.7.0.bb
+++ b/recipes-rubygems/rubygems-rubycritic_4.7.0.bb
@@ -6,6 +6,9 @@ HOMEPAGE = "https://github.com/whitesmith/rubycritic"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=ebcb01890999ed287441ae4afce9a346"
 
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
 DEPENDS:class-native += "\
     rubygems-flay-native \
     rubygems-flog-native \
@@ -19,8 +22,10 @@ DEPENDS:class-native += "\
     rubygems-virtus-native \
 "
 
-SRC_URI[md5sum] = "2b98ea1abcc1ae9dc8507e144bc0d29a"
-SRC_URI[sha256sum] = "1530cbd82a48e75909bc74efc89e0d0901359aa86d2806ce385d68d703b19095"
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "15cf351929a5947255b653b143a0ed74"
+SRC_URI[sha256sum] = "4aadff039c86b2defad010682f45d8e687454fb98a7ac8766ef7f2307c73120c"
 
 GEM_NAME = "rubycritic"
 


### PR DESCRIPTION
* faraday: update to 2.3.0
* aws-sdk-s3: update to 1.114.0
* aws-sdk-securityhub: update to 1.65.0
* aws-sdk-ec2: update to 1.312.0
* aws-sdk-sqs: update to 1.51.1
* aws-sdk-organizations: update to 1.70.0
* aws-sdk-rds: update to 1.146.0
* aws-sdk-synthetics: update to 1.27.0
* aws-partitions: update to 1.586.0
* aws-sdk-ssm: update to 1.137.0
* rubocop: update to 1.29.0
* aws-sdk-redshift: update to 1.82.0
* nokogiri: update to 1.13.5
* rubycritic: update to 4.7.0