### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.589.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.589.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "4f40b43e4336a44ce85204a973d5cf10"
-SRC_URI[sha256sum] = "f55f830803d27cd8ed314050ce2fc2c58f9218189f58e28ce967b582dd120b6f"
+SRC_URI[md5sum] = "4fff8aaf888b775c9a74d9126c983f39"
+SRC_URI[sha256sum] = "1827d227f5dc276a683a12a705e029ca613c73d3ffdf64923a9e142ec43297ae"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-batch_1.62.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-batch_1.62.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f91ad489531ed562e86e73f946658a03"
-SRC_URI[sha256sum] = "ca9a4cb2fa78fd3f3bf9d089ea867fadc62f8a82160307eea2c1788448eb4460"
+SRC_URI[md5sum] = "e359981e4f119cfa7bf844e21f3ee584"
+SRC_URI[sha256sum] = "c8cab288b2b34acde1c63e12f80eda5743e60e8cbc6a1bddb1eda47b43ccb2db"
 
 GEM_NAME = "aws-sdk-batch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.65.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.65.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "ebd967dbd00308719c2459a2b460c026"
-SRC_URI[sha256sum] = "93854b12828f7375a01ee6c50302d3f87c76cb4fe5d47420085b92f069addc1a"
+SRC_URI[md5sum] = "35ac9b681188e94fcf18585b20d41f1a"
+SRC_URI[sha256sum] = "77ae0d2a9a4b397695297bd491733ab2a5f0e98450740a3212ac23f53629d041"
 
 GEM_NAME = "aws-sdk-cloudfront"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.53.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.53.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "4e60f10dbaca5113af340d88bfbadc8b"
-SRC_URI[sha256sum] = "85ad82393068fa789094f0ccbfe9db98c9447a96e65d072d87e1d518203a3e81"
+SRC_URI[md5sum] = "9c72b56425ecf173b281920ed49652af"
+SRC_URI[sha256sum] = "50a0ddf9e04581a63a3f3d4e9be248e1f62e5ec4e24cb7f44fcb758454ee4506"
 
 GEM_NAME = "aws-sdk-cloudwatchlogs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.131.1.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.131.1.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "771d77a917c64ae20e4e688703e89f5c"
-SRC_URI[sha256sum] = "5629c5d58f508c7fd4cfd4ee46a96b7c3f2f85094058f3194cc93eebb65a5241"
+SRC_URI[md5sum] = "4c9fc65a85ca5d7834ef0570754f9503"
+SRC_URI[sha256sum] = "481c602d682b61abccb4e9f5b64750907bb49758f6f31b3bec599819951a3f7a"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.112.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.112.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "260d89dfa3c5e3b6027dff2e8751504f"
-SRC_URI[sha256sum] = "2e82acfb6c99c8308315bccdac61cfb9b184eb0f8de0d0bdfdc95ac5935ce3b7"
+SRC_URI[md5sum] = "beeb7c6a51c484a0913fd33a67fa37ab"
+SRC_URI[sha256sum] = "5b2c19acd241bcc5724e3b723c21aecfaa1a1edf8c11b8007e30eaec472e23de"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-kms_1.57.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-kms_1.57.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b7f89a7dc6a08a72c470a7d4d8887b3a"
-SRC_URI[sha256sum] = "c3790147ec895e198c23e36d6949e57a8ea225de0dfb96393ebe85de3076ac91"
+SRC_URI[md5sum] = "e55001eccd15da740ea08c39f19584a9"
+SRC_URI[sha256sum] = "ffd7dbb9b4251f29d4f508af761d0addd7035a346a88e3481cdb4dc548e51bd5"
 
 GEM_NAME = "aws-sdk-kms"
 

--- a/recipes-rubygems/rubygems-aws-sdk-servicecatalog_1.71.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-servicecatalog_1.71.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "803bde7015148fa9d3a746106aadda74"
-SRC_URI[sha256sum] = "2ec9c59a62e709a348f830d4d88a931e14b413a46a278a42bb23b5f4fefb7409"
+SRC_URI[md5sum] = "4ce9e5a4aab606519174c106e74c0ed3"
+SRC_URI[sha256sum] = "8f9194439fb2311e16796bb9c54668ff37ec14e9822c02a263154033228ed154"
 
 GEM_NAME = "aws-sdk-servicecatalog"
 

--- a/recipes-rubygems/rubygems-aws-sdk-transfer_1.55.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-transfer_1.55.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "5f2c0ce8bdf12442215b679f3c79169e"
-SRC_URI[sha256sum] = "23dd5948a0eb3306346959422fbe3336e8d8f2fe370f2590ed16564b51fa71cd"
+SRC_URI[md5sum] = "83082a1dad44c9f170594e2da2e85484"
+SRC_URI[sha256sum] = "4c8d149f88b277848ea70e455b7b00582985ad86d9f70bc7ac55628c2305073d"
 
 GEM_NAME = "aws-sdk-transfer"
 

--- a/recipes-rubygems/rubygems-faraday-net-http_2.0.3.bb
+++ b/recipes-rubygems/rubygems-faraday-net-http_2.0.3.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1489f4b5bc18d549a2b22e2f2a04e0e3"
-SRC_URI[sha256sum] = "10e593141a9f0c1d649c7eedc6ca656e43579c455037c4dcb792f865769327f0"
+SRC_URI[md5sum] = "a394ca04056dd6d39d010e485362dcb9"
+SRC_URI[sha256sum] = "66514e7a7d8277fe0ae9f3bf3ca4dae28ee1c0d8cc587f412b0aaf19a5656fd5"
 
 GEM_NAME = "faraday-net_http"
 

--- a/recipes-rubygems/rubygems-google-apis-core_0.5.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-core_0.5.0.bb
@@ -22,8 +22,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "16fe4046d7507e8521a2edb91cc0f046"
-SRC_URI[sha256sum] = "eb84fc47d74f8e71fdac93a132d09eee40b2943bdabd50683ad3a0f7e62e61a7"
+SRC_URI[md5sum] = "9b5bae28d538b9b3aad9fb4fcfdd0566"
+SRC_URI[sha256sum] = "bb1bb19dac8e8295a2a9396e3793c3fe643a950fbc27d7277ebb4cc3369b461b"
 
 GEM_NAME = "google-apis-core"
 

--- a/recipes-rubygems/rubygems-representable_3.2.0.bb
+++ b/recipes-rubygems/rubygems-representable_3.2.0.bb
@@ -6,14 +6,19 @@ HOMEPAGE = "https://github.com/trailblazer/representable/"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=05037c2d4aa35dcc8c2db40a1b0e6a14"
 
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
 DEPENDS:class-native += "\
     rubygems-declarative-native \
     rubygems-trailblazer-option-native \
     rubygems-uber-native \
 "
 
-SRC_URI[md5sum] = "5e3fb8dd379540b518d8aeba16f93a7b"
-SRC_URI[sha256sum] = "dacfd01d46ee2c398cf78aa74a3269dd52adc38fdae32c3d3fe5fa4cd2ffbc27"
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "aa68d0efd2a736faca840a1e6e72448e"
+SRC_URI[sha256sum] = "cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace"
 
 GEM_NAME = "representable"
 


### PR DESCRIPTION
* aws-sdk-core: update to 3.131.1
* google-apis-core: update to 0.5.0
* aws-sdk-kms: update to 1.57.0
* faraday-net_http: update to 2.0.3
* aws-sdk-batch: update to 1.62.0
* aws-sdk-transfer: update to 1.55.0
* aws-sdk-servicecatalog: update to 1.71.0
* aws-sdk-cloudwatchlogs: update to 1.53.0
* aws-sdk-cloudfront: update to 1.65.0
* aws-sdk-glue: update to 1.112.0