### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.602.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.602.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "346e8c1e6de4a4b55604a25a7d4aaac4"
-SRC_URI[sha256sum] = "ed797ac8096e48c66d06846b5563cdfe34670670019f89f699386a08e58cb479"
+SRC_URI[md5sum] = "c91fd276349859aa639cd2b2caeae8e7"
+SRC_URI[sha256sum] = "d033e21600e8c53c82063ddd69cd39ed2384ba88aabd6b12c8ddf2fa1ca13e26"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-athena_1.54.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-athena_1.54.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1e0dc777d9f4471ef0159cf7b097eb36"
-SRC_URI[sha256sum] = "9934d13d449b3cbc55ddfb734f1bff0760ad54e4a53d8f8a2867ab508a30faa3"
+SRC_URI[md5sum] = "a1ae2e53f4fac039b6c34b95823065a1"
+SRC_URI[sha256sum] = "45563dbef69023e6b4c880f816b1905d75becb82f4d3f7d5cd95e1a22ec51047"
 
 GEM_NAME = "aws-sdk-athena"
 

--- a/recipes-rubygems/rubygems-aws-sdk-databasemigrationservice_1.69.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-databasemigrationservice_1.69.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "3cc289b3402f367b0fe825d00d3c8ed3"
-SRC_URI[sha256sum] = "ecd5b63fa548cd2fd698780c10563a2f3c3066d5961ec227c27b7c4f8cc6ede4"
+SRC_URI[md5sum] = "1e8d18ae9ba58f87579ac98257690bd9"
+SRC_URI[sha256sum] = "687b98507b747b8218441223bcd53beacff6dc6e77607281e06447fdd1b3c552"
 
 GEM_NAME = "aws-sdk-databasemigrationservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.320.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.320.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f2a4971139e3bd3945cebf32ad9260c5"
-SRC_URI[sha256sum] = "f3d5e077d34750def3b5613a3e7a1abd014f18b998d22005f85818dea091822c"
+SRC_URI[md5sum] = "9250817d17d80dbfed7d24a997158e52"
+SRC_URI[sha256sum] = "ae7a06bab1aecd17cb93cee4cfe0daca83427ad8910f409b38264b007577fe26"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticloadbalancingv2_1.78.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticloadbalancingv2_1.78.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "df08df3ba244ed6cf7151b1f3443195f"
-SRC_URI[sha256sum] = "94edbfa52bc38200fd3af51259801edf7e0c4c6f8b8ef81421a46803aa77afd8"
+SRC_URI[md5sum] = "d88be5b5dece7b6991a900de33cb88b9"
+SRC_URI[sha256sum] = "00a7dadcd48a01ce80437cc6362155d5f9df9e8e6fba94a124759638abec140f"
 
 GEM_NAME = "aws-sdk-elasticloadbalancingv2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-emr_1.62.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-emr_1.62.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9c62fd6cfcc2ccea663a1c0c199fd379"
-SRC_URI[sha256sum] = "554233b0abf7c348fe64e35baee5d59df1b8ff5afb98161bc749efed3ba29742"
+SRC_URI[md5sum] = "d43cbf4985f7ec40b86b02c76968f555"
+SRC_URI[sha256sum] = "3242e57119e8a558fe82ac1206156bc80d74dedd4c9d398e6eca4364e8f7ba02"
 
 GEM_NAME = "aws-sdk-emr"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.114.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.114.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "4eebb3000615ccb3ddb3d6c4c68b050b"
-SRC_URI[sha256sum] = "18c147deab60fcc3c338498129837298fb1906a3de854fd00516b061b00ea07c"
+SRC_URI[md5sum] = "6b5313395d39a6937d4668482bec441f"
+SRC_URI[sha256sum] = "154ca81c0da3825c4c4a37dec0aebcaca9f963ea62d23688d48fb7256f178865"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.147.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.147.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7a3c7bd0f60cbce7e2bb750c64372ca2"
-SRC_URI[sha256sum] = "b76621131447fd7e670c50ee88e674bf3da967b912e0571aafe381d48b43d9de"
+SRC_URI[md5sum] = "7137a50fc15a09a12863ba90ebc01ff9"
+SRC_URI[sha256sum] = "359914df2b467c747f2013ed3e87f952033be14b3ff89846e0c83e3515aae38b"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-google-apis-core_0.7.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-core_0.7.0.bb
@@ -22,8 +22,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "48869a3e713a6fcb9c080afd5ea2415d"
-SRC_URI[sha256sum] = "29de1021f9fc7c4afd4759580bd2c463427d6d1c8f46189414fc65a977bf76a1"
+SRC_URI[md5sum] = "8a1293912d1160d6fda328b4c24f8449"
+SRC_URI[sha256sum] = "0d8e4bab9c1dab83950ee3156fbc1d166cf2799da4c62cdcb58149aec899501e"
 
 GEM_NAME = "google-apis-core"
 

--- a/recipes-rubygems/rubygems-google-apis-generator_0.8.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-generator_0.8.0.bb
@@ -19,8 +19,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "bb31379243c2fbda0a38afd2ee4a0379"
-SRC_URI[sha256sum] = "e5831085ea83bdd8346405e371fe7840719a6572867d1d3fd95795a3283f45cc"
+SRC_URI[md5sum] = "d711fd8473768919e2908dc6ecc728bd"
+SRC_URI[sha256sum] = "596f9c2ce1cba1605c76b228fbb85528ee6d31ef8d4f58917c06eba81870dd64"
 
 GEM_NAME = "google-apis-generator"
 

--- a/recipes-rubygems/rubygems-net-ssh_7.0.1.bb
+++ b/recipes-rubygems/rubygems-net-ssh_7.0.1.bb
@@ -6,12 +6,15 @@ HOMEPAGE = "https://github.com/net-ssh/net-ssh"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=6c99c0cc0901fbc3607fe997f9898d69"
 
-SRC_URI[md5sum] = "383afadb1bd66a458a5d8d2d60736b3d"
-SRC_URI[sha256sum] = "8905c1f9209fb216c59cc631c2e4085b1a9660598da6de0f20323264d993e34a"
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "2ac500ae0a9c578b64d8c3a4bff741c0"
+SRC_URI[sha256sum] = "59a7607d93b7c97979df51afbaa97ac6e6fcd315778151c0b521ca13178ae3e2"
 
 GEM_NAME = "net-ssh"
-
-
 
 inherit rubygems
 inherit rubygentest

--- a/recipes-rubygems/rubygems-rack_2.2.4.bb
+++ b/recipes-rubygems/rubygems-rack_2.2.4.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "239514a8bcb454ce64d355a998ac2ef1"
-SRC_URI[sha256sum] = "8c728da28f6d800c3839d226fdbce702c94eeb68e25e752b6c2f2be7c1d338ac"
+SRC_URI[md5sum] = "8adda585ad9eed36e7c90a3116832328"
+SRC_URI[sha256sum] = "ea2232b638cbd919129c8c8ad8012ecaccc09f848152a7e705d2139d0137ac2b"
 
 GEM_NAME = "rack"
 

--- a/recipes-rubygems/rubygems-rubocop_1.31.1.bb
+++ b/recipes-rubygems/rubygems-rubocop_1.31.1.bb
@@ -10,6 +10,7 @@ EXTRA_DEPENDS:append = " "
 EXTRA_RDEPENDS:append = " "
 
 DEPENDS:class-native += "\
+    rubygems-json-native \
     rubygems-parallel-native \
     rubygems-parser-native \
     rubygems-rainbow-native \
@@ -22,8 +23,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9733eed98541bdda1514aa29d0fb6282"
-SRC_URI[sha256sum] = "e1fcbed368d823ff8bbda00819f0abf0d522a914dfe62499884fcb6df0ff1d21"
+SRC_URI[md5sum] = "fe14c1057b5755934b4aff6be9e05021"
+SRC_URI[sha256sum] = "bc8cbc2ca284d31785e3379bad610447e4cb43688a6db38c0c4f50c0c3afca19"
 
 GEM_NAME = "rubocop"
 
@@ -32,6 +33,7 @@ inherit rubygentest
 inherit pkgconfig
 
 RDEPENDS:${PN}:class-target += "\
+    rubygems-json \
     rubygems-parallel \
     rubygems-parser \
     rubygems-rainbow \

--- a/recipes-rubygems/rubygems-train-core_3.10.1.bb
+++ b/recipes-rubygems/rubygems-train-core_3.10.1.bb
@@ -20,8 +20,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "96dc22dd6fd08a4d3bce6a0826c6623b"
-SRC_URI[sha256sum] = "a457bd27999026954ddd37baf4256a9ac0b28ac92b08d2eb3cd0773ea4a0bda9"
+SRC_URI[md5sum] = "07b9228d66b618e65e7969129d5bed7c"
+SRC_URI[sha256sum] = "6ba3780bbfde003d943c0081202a2e035fe6fcc6b493549b9e8c0b2af012917c"
 
 GEM_NAME = "train-core"
 

--- a/recipes-rubygems/rubygems-train_3.10.1.bb
+++ b/recipes-rubygems/rubygems-train_3.10.1.bb
@@ -26,8 +26,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "2d2cb9988330a6a263f536f6031856e2"
-SRC_URI[sha256sum] = "9e75d6a5b3ee3ec656379fe398f9573198fdc02a86a37012d45f199ecff4f7f5"
+SRC_URI[md5sum] = "7729f8258e646cc91c56cd34b8068dcf"
+SRC_URI[sha256sum] = "209ec8aa273965ffe7f2e3dbee553737e5a08ccea3f5f390b891df12ac51d9de"
 
 GEM_NAME = "train"
 


### PR DESCRIPTION
* net-ssh: update to 7.0.1
* train-core: update to 3.10.1
* google-apis-core: update to 0.7.0
* google-apis-generator: update to 0.8.0
* aws-sdk-databasemigrationservice: update to 1.69.0
* train: update to 3.10.1
* aws-sdk-glue: update to 1.114.0
* rubocop: update to 1.31.1
* aws-partitions: update to 1.602.0
* aws-sdk-rds: update to 1.147.0
* rack: update to 2.2.4
* aws-sdk-athena: update to 1.54.0
* aws-sdk-emr: update to 1.62.0
* aws-sdk-ec2: update to 1.320.0
* aws-sdk-elasticloadbalancingv2: update to 1.78.0