### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.636.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.636.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9b7251b4d7975ba3e3177b9c5af65971"
-SRC_URI[sha256sum] = "185067709bac1a7866ac4f64c7f8e42bdc2ddf3aac6ee7020f76587d1832e0f6"
+SRC_URI[md5sum] = "2c940441a52d0ce08bf912f1630a4a8b"
+SRC_URI[sha256sum] = "a22727fd83d09d4b10e770b210bd40ab2361d2fdaa73d4b59bafc16a629076e9"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.51.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.51.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d19fc18cbff32f1ba57df755327735ec"
-SRC_URI[sha256sum] = "19d7b7f5c2770f68f424a7fb7560817fa330727a6ae9ea78e410f84d9ba9a3e7"
+SRC_URI[md5sum] = "c8b25c25891dd3682631bc7c58bdc2a1"
+SRC_URI[sha256sum] = "cb9670fe8b8dbf7be84da11c3c470239d22e9bac7452bc04b3371ff6d608c946"
 
 GEM_NAME = "aws-sdk-cloudtrail"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.154.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.154.0.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9be2fe8f07ea9a636a16c4c6c1291ab4"
-SRC_URI[sha256sum] = "88c97cfebe73a266ba9fc0b893bca8d9484251a2433f2c4f62eda2bbb5b5f083"
+SRC_URI[md5sum] = "3e834ccf6dee037735477952d2d6bf3c"
+SRC_URI[sha256sum] = "6064382b3ecaea762971e803dba942aaaa391fda23bfbd5817fa199fdf998d0b"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.338.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.338.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a5d2c3a427623680cb429a6a70794f43"
-SRC_URI[sha256sum] = "377c3fc3acd43cffc38b3444dac1b9b01c7832578d0dc8190154d86ff7c7c347"
+SRC_URI[md5sum] = "41bdb685134c48f81ddaae110550d770"
+SRC_URI[sha256sum] = "7a152d76140282df80eef8b8d35fd6a7ae1808a6a6c5be606cb5c26ef06775ff"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.119.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.119.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a988126bd58a025bfc0d6199ef1c1190"
-SRC_URI[sha256sum] = "41180680d281c16d73de7936a6b398a6636d5b572517c46cbcefb208e59d7176"
+SRC_URI[md5sum] = "e548dee05777b8f63f6cc727f592438f"
+SRC_URI[sha256sum] = "b867505784a8dbe65b15db58081330247ed3c12bc9540b4fa1a4c6d602e4dc67"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.156.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.156.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "14bc6b19ee1037922acd6cc0afb7c2be"
-SRC_URI[sha256sum] = "8db0c105c87dad1267c0765881f60eb3f560346e2701ececebce9b449c07737f"
+SRC_URI[md5sum] = "b0a5f4d536716a3fb465f054f4923270"
+SRC_URI[sha256sum] = "6e80b738fdd4c8019de4d7dbf861b893b970996100e7284451bc61b6fbcbbf42"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3control_1.51.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3control_1.51.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "616befa943b03d45af70a844413f3194"
-SRC_URI[sha256sum] = "0dbdcf919f386f63d6c78f609eaed6979d352e1ab12a1ebdef394d03a4ede2bf"
+SRC_URI[md5sum] = "5bc58fc832e503dd6e924d591f9559df"
+SRC_URI[sha256sum] = "9e21507561691258dc59ddce18cffde44df69242847cc78ff1805060e5fef75a"
 
 GEM_NAME = "aws-sdk-s3control"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ssm_1.140.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ssm_1.140.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e985ec40c607921e2c4fbbbed01b9073"
-SRC_URI[sha256sum] = "5f60335d1281a226e153b7fcda97649f601976db45126399688f7441004d70c7"
+SRC_URI[md5sum] = "767f5801272ab1e5d851496f33e25fd8"
+SRC_URI[sha256sum] = "b1c497e39fcda28947366da95ee314aed013e1a3a30ca68cc45214166f1865bb"
 
 GEM_NAME = "aws-sdk-ssm"
 

--- a/recipes-rubygems/rubygems-excon_0.92.5.bb
+++ b/recipes-rubygems/rubygems-excon_0.92.5.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f52d975a35e063d5618428d09cc4e12f"
-SRC_URI[sha256sum] = "654da693df23a8dcf26ea4b390c98225b094370eb82e2e09aec191fca639ac31"
+SRC_URI[md5sum] = "02a4bf21fdf4d4d3cba810d56c9a94f9"
+SRC_URI[sha256sum] = "192d125a1b342601b6e180e91d9807cbc9c2244152dd11ef60b4f3e3c5a18761"
 
 GEM_NAME = "excon"
 

--- a/recipes-rubygems/rubygems-google-apis-core_0.9.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-core_0.9.0.bb
@@ -22,8 +22,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "86ce104acd7bea85529f54050c042a71"
-SRC_URI[sha256sum] = "8d38122f4460071f016cdfe037ca25396d16fd9c4b1aa87efa15894fcf957f7a"
+SRC_URI[md5sum] = "0137048439f864de7a0e63a6523ee473"
+SRC_URI[sha256sum] = "8ce6e7f887e6e37323e2d6954335a366fd1dc3b25b12f90e149feb5ed82735f1"
 
 GEM_NAME = "google-apis-core"
 

--- a/recipes-rubygems/rubygems-google-apis-generator_0.10.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-generator_0.10.0.bb
@@ -19,8 +19,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "0fc8207979f414be7f28847373f15bef"
-SRC_URI[sha256sum] = "12c0d73e21d19c52fa5313ef52c649ce0ef7207ea9d517fa0ed6132556e5abb0"
+SRC_URI[md5sum] = "d58b748d2f34c429aae98faa6eff38a6"
+SRC_URI[sha256sum] = "d2bae85dd0cce4134b3b4145bc8b4f8bc52144146f541e8ee6d04607af5727d2"
 
 GEM_NAME = "google-apis-generator"
 


### PR DESCRIPTION
* aws-sdk-core: update to 3.154.0
* google-apis-core: update to 0.9.0
* excon: update to 0.92.5
* aws-sdk-s3control: update to 1.51.0
* aws-sdk-glue: update to 1.119.0
* aws-sdk-cloudtrail: update to 1.51.0
* google-apis-generator: update to 0.10.0
* aws-partitions: update to 1.636.0
* aws-sdk-ec2: update to 1.338.0
* aws-sdk-rds: update to 1.156.0
* aws-sdk-ssm: update to 1.140.0