### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.670.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.670.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "80002b26cd608469677dd7427bf6b26f"
-SRC_URI[sha256sum] = "da7c7dc9565209be047d82c7f850637c95872499070b7c4a2eeacc167911e6d4"
+SRC_URI[md5sum] = "126ec034502ad71c08b1e253818ac603"
+SRC_URI[sha256sum] = "a9cf1ba27e47b929b52bb3328aed2b31350d04c2adfbc59886a9dc41d0f26272"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-athena_1.59.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-athena_1.59.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b19c095350ab24fa994e43facad6ae8e"
-SRC_URI[sha256sum] = "4957c1be9680d5cc9434a7e09ccf0b8bf279c774da930d3ba8f1483aed0cfdbb"
+SRC_URI[md5sum] = "c6ad6b2c3b2b5cc79f953f25bb6fec0f"
+SRC_URI[sha256sum] = "9cae691e65726d9459d4dcb607773c53a64653690909d5b7d39f28daa32a9d74"
 
 GEM_NAME = "aws-sdk-athena"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatch_1.69.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatch_1.69.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "582ab49c88d083d193bc78bc1efa8f2d"
-SRC_URI[sha256sum] = "083737d950b28f4f0cce2ceaeb658dad28708da0590332bc8818dc497d971c61"
+SRC_URI[md5sum] = "b79d3a9664a9286e8c5a294d2db607fd"
+SRC_URI[sha256sum] = "37cfce3ed9e5be7b1330c0365a66ec64bca39fe33c69205b4f7472e7df5be5d2"
 
 GEM_NAME = "aws-sdk-cloudwatch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.57.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.57.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e9fbd9c9844aeaffcb93c23c5376aaf4"
-SRC_URI[sha256sum] = "bc9052ee4822bd9d2248b403802013c0e51fafe2dd9f0d5d5498620e8bc9c8c7"
+SRC_URI[md5sum] = "4191de39953ff64b5d162c7a91e23fb3"
+SRC_URI[sha256sum] = "77ed21be1a714bba2a12874095bb3f3a9acaf9397275b1ea705b43e00ddd324d"
 
 GEM_NAME = "aws-sdk-cloudwatchlogs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-configservice_1.86.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-configservice_1.86.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "be2350491ba829afa2ababba1c797522"
-SRC_URI[sha256sum] = "ce09d130e1b3e469fc81950b505668d73f80c09802288e2eb1724f28dc119ddb"
+SRC_URI[md5sum] = "5b7f0adefdb4d3c8c8ad1c79b5aaec4b"
+SRC_URI[sha256sum] = "5547e5e20485c9af6f9959a6e51ae2b12bdde17469e0c1bff7729e680ab8d8b8"
 
 GEM_NAME = "aws-sdk-configservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.168.3.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.168.3.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c4da729b1c0baeb313c2ed536ca317b3"
-SRC_URI[sha256sum] = "2b83c2cc0dde47293a9ff4f4ad1c4d49913c718d0daba8d1b357b5315fdad6ee"
+SRC_URI[md5sum] = "258ba0319802e20500f9fc0217208762"
+SRC_URI[sha256sum] = "fd277eada5454880a60919fa1c03cbb60c41547cf1f6cb829a287ea20ac38ebc"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.353.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.353.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6e6ffcaf29a8ac13574e6595f0b68c6f"
-SRC_URI[sha256sum] = "19cfce8605e9d8c75b2d5151848186f77855781a6ac95f1fb82d1a22b3d59139"
+SRC_URI[md5sum] = "6d5c6d86e0ea1c0970c046fbc3a49b07"
+SRC_URI[sha256sum] = "69c22f96cd6615387e85092dbefc3f729ddcc49e90d1bc0d9d0be3ffe337407d"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.107.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.107.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a18a526cb5fc5e3150e08b1996b3d19e"
-SRC_URI[sha256sum] = "5272d830823e91db024c8d2ab4f05406093103ace1f7bcb5e8a888655a2750f8"
+SRC_URI[md5sum] = "dcd86e52e2c520d4e343bfcb21d54855"
+SRC_URI[sha256sum] = "92d4c5e545f35c8347674437bde42e6a22eee2034e76da997446a62aefd5b5e6"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-efs_1.56.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-efs_1.56.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b00208214b23fe3519f9f517b200d545"
-SRC_URI[sha256sum] = "9883469ee34967711896f73cec3cd24bb87b038dcc590ed8a4ea3c34aaac7fd4"
+SRC_URI[md5sum] = "ef2fe0d9e0926920a0e728c2d1c8e8d9"
+SRC_URI[sha256sum] = "11deca28343d5be15aeec5f639159b7a74c34f483c628cd74dd5e29bcdb69c9f"
 
 GEM_NAME = "aws-sdk-efs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eks_1.80.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eks_1.80.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "bf0a93487f73ac917eeff227eaf62bdb"
-SRC_URI[sha256sum] = "a7a935e9c159c0a2fdc6deea972dd7c7c62144f52ed570315a68472cbc5d75e9"
+SRC_URI[md5sum] = "eff974e1f8999be6c4edcf8b21e771cf"
+SRC_URI[sha256sum] = "f50fa93a649a59e1e47310846d26259bb90c29a303570cce210c3df18555d222"
 
 GEM_NAME = "aws-sdk-eks"
 

--- a/recipes-rubygems/rubygems-aws-sdk-firehose_1.50.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-firehose_1.50.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "ca619ec7b880f9975dc888d0589a734e"
-SRC_URI[sha256sum] = "0aa01a0d5845916517caee4e1677e54b12619af0fb3a1c0a6f11a9fb4ca3196e"
+SRC_URI[md5sum] = "a06d8c9fcdf60fd2688a7db6217cb7b8"
+SRC_URI[sha256sum] = "d5b6e924a799f3f422e409d09a2ae1826ac5db9ad3d84e638941d1daf0b59f0a"
 
 GEM_NAME = "aws-sdk-firehose"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.126.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.126.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1e3acba3a7993633683595c0b34064c1"
-SRC_URI[sha256sum] = "fe0cb2e747fb76028e88bc42f9cd5ed10cee4e8d86295ce31088e92e22fcbd5d"
+SRC_URI[md5sum] = "3a6bbf9ae64aa57b50a1ad63f3fab466"
+SRC_URI[sha256sum] = "6c3e5a4685922a84d555f4dccdda47c06e2c6ddb04e6bffd631270731bf13486"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-kms_1.60.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-kms_1.60.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "461714750fc7afffc190eee0013def23"
-SRC_URI[sha256sum] = "6c002ebf8e404625c8338ca12ae69b1329399f9dc1b0ebca474e00ff06700153"
+SRC_URI[md5sum] = "4f2055b2e640a721d8f24b01528bd7a3"
+SRC_URI[sha256sum] = "a4607bec9b76697a8ca5d0c1605ebe75284386fd79075a8bd2d82bdae2cbc301"
 
 GEM_NAME = "aws-sdk-kms"
 

--- a/recipes-rubygems/rubygems-aws-sdk-lambda_1.88.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-lambda_1.88.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "8e89a954046cf7d9281166895333e0bd"
-SRC_URI[sha256sum] = "86e73d365c436d565cbc1cbfc6c50e7961b54bb0f312b72b4145f74501dca567"
+SRC_URI[md5sum] = "937ba6e10e070e4efaa30b2e592e3a54"
+SRC_URI[sha256sum] = "586271477d994c8cc9c14890dd1591fc4920a4c8fe04fb6d6816d9b20431ae05"
 
 GEM_NAME = "aws-sdk-lambda"
 

--- a/recipes-rubygems/rubygems-aws-sdk-organizations_1.72.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-organizations_1.72.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e97431a1e15d45199a5a90b854df3433"
-SRC_URI[sha256sum] = "140b565b8dde347d592643784acdd074cf2a92a5020fdf188e56b6a65109b9ac"
+SRC_URI[md5sum] = "9ca45a2628d0965ce7c3a2fa11917de4"
+SRC_URI[sha256sum] = "ed75c49b6317cae543b8f4ff50b1d75d680a46c0383ad342c28b8ef201a76233"
 
 GEM_NAME = "aws-sdk-organizations"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.161.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.161.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f4fce3adab8361cfd576a892aac86aa5"
-SRC_URI[sha256sum] = "07a79313dd9ef2dc61c6325932a763a03697add9335bf2fd40fddfc72802f028"
+SRC_URI[md5sum] = "8aaf9c0b0fa9161d0c4b742d04b4375a"
+SRC_URI[sha256sum] = "0117e55d33b4ae3e8fbd37ee977d3d9d63e96d8506ff9d36dfb15feaeeb552af"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.117.2.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.117.2.bb
@@ -17,8 +17,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a1078a9fe9ff7e57660e44d18dbab5ea"
-SRC_URI[sha256sum] = "76f6dac5baeb2b78616eb34c6af650c1b7a15c1078b169d1b27e8421904c509d"
+SRC_URI[md5sum] = "a9af472b1ba487e15366924a8630222e"
+SRC_URI[sha256sum] = "2159b3cbc45fc4a129f178ce54770023684fad078ce5c0577e8005fe1143ebf6"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3control_1.58.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3control_1.58.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "8400ca6acf6e6b195d60374f4e64b288"
-SRC_URI[sha256sum] = "b72e07a6294355184580f58d2f7d15899e5451759167a692359e4d1761b4ef70"
+SRC_URI[md5sum] = "0b3aa040e7f984834ac63d3a50503807"
+SRC_URI[sha256sum] = "240aff41eba3cfb4beaacbaa7376647cb8f889c6695f2a799f0980a33df95f9d"
 
 GEM_NAME = "aws-sdk-s3control"
 

--- a/recipes-rubygems/rubygems-aws-sdk-securityhub_1.73.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-securityhub_1.73.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "5607d8491633443e26aabcc4fe8617bf"
-SRC_URI[sha256sum] = "7527ddeba9e13df4622859319a516377d3a2548d2a7ba091640f67cb5932d304"
+SRC_URI[md5sum] = "ba9383f4bdbfab60d456c354f02a8d0b"
+SRC_URI[sha256sum] = "6effa536b6a00eb0118ae8fa3d92fe59ebba38ef2f74859ac9d46fdda94758be"
 
 GEM_NAME = "aws-sdk-securityhub"
 

--- a/recipes-rubygems/rubygems-aws-sdk-sns_1.57.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-sns_1.57.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "16c30c31be4a638873f4e69632850712"
-SRC_URI[sha256sum] = "5184f009aa368db49efa8d33c7ae1d7dbc1fee7f07d47a6d2043cd7e4d8e88c5"
+SRC_URI[md5sum] = "e86e6b8d008263da43ac8d4ff3f38438"
+SRC_URI[sha256sum] = "eab292953a4ce14717d03eb98019e641f187b404712dc17cdd8645924f33d0f1"
 
 GEM_NAME = "aws-sdk-sns"
 

--- a/recipes-rubygems/rubygems-aws-sdk-sqs_1.52.1.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-sqs_1.52.1.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b1de8455f8f255e565aadaaec5bfe124"
-SRC_URI[sha256sum] = "a7876603551557c5c6bba2b300e2f6490978087542dd03ca1fbfcfc62c3ac8c9"
+SRC_URI[md5sum] = "dae3fc328c917c01f78c3ab778d7c83d"
+SRC_URI[sha256sum] = "2721dd29d36ae5e01163cc84164b0ef57a2b02756ff30e3b70dedaf3809039c2"
 
 GEM_NAME = "aws-sdk-sqs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-states_1.51.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-states_1.51.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6cce2d7a3df521e5757b3403d2f313c1"
-SRC_URI[sha256sum] = "a442897fc800db69588162c19bdd7927e157d66dae47a37b373edfa67bf6b114"
+SRC_URI[md5sum] = "94ef14544b08155b4ca7a5591e3d165e"
+SRC_URI[sha256sum] = "048d9a06de9cf081da4966bcb2f90ddbe07b98d3d6a57c702eff35e8fcb17b04"
 
 GEM_NAME = "aws-sdk-states"
 

--- a/recipes-rubygems/rubygems-rubocop-ast_1.24.0.bb
+++ b/recipes-rubygems/rubygems-rubocop-ast_1.24.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f624f62f2a29de7060750f82212596a5"
-SRC_URI[sha256sum] = "fe4bafaa0a6ccf400849fb720f9dd2428b07b00fcdeeec33a8f1146e0c1e38e2"
+SRC_URI[md5sum] = "a0bc48b44631be2b0d5bb0b8c5d0b5d7"
+SRC_URI[sha256sum] = "a917dc38015ccfa4397d34e71adaca2187ec7f2adc903f1af909fb6b097a136b"
 
 GEM_NAME = "rubocop-ast"
 


### PR DESCRIPTION
* aws-sdk-core: update to 3.168.3
* rspec-core: update to 3.12.0
* rspec-expectations: update to 3.12.0
* aws-sdk-s3: update to 1.117.2
* rspec: update to 3.12.0
* aws-sdk-athena: update to 1.59.0
* aws-sdk-efs: update to 1.56.0
* aws-sdk-securityhub: update to 1.73.0
* aws-sdk-ecs: update to 1.107.0
* aws-sdk-s3control: update to 1.58.0
* aws-sdk-sns: update to 1.57.0
* aws-sdk-lambda: update to 1.88.0
* aws-sdk-configservice: update to 1.86.0
* aws-sdk-ec2: update to 1.353.0
* aws-sdk-cloudwatchlogs: update to 1.57.0
* aws-sdk-rds: update to 1.161.0
* aws-sdk-sqs: update to 1.52.1
* aws-sdk-cloudwatch: update to 1.69.0
* aws-sdk-organizations: update to 1.72.0
* aws-sdk-eks: update to 1.80.0
* aws-sdk-glue: update to 1.126.0
* rubocop-ast: update to 1.24.0
* aws-sdk-firehose: update to 1.50.0
* aws-sdk-states: update to 1.51.0