### PR TITLE
mongo: remove spec/support/ocsp

### DIFF
--- a/recipes-rubygems/rubygems-mongo_2.18.2.bb
+++ b/recipes-rubygems/rubygems-mongo_2.18.2.bb
@@ -24,6 +24,10 @@ inherit rubygems
 inherit rubygentest
 inherit pkgconfig
 
+do_compile:prepend() {
+    sed -i 's#"spec/support/ocsp".freeze,##g' ${GEM_SPEC_FILE}
+}
+
 RDEPENDS:${PN}:class-target += "\
     rubygems-bson \
 "


### PR DESCRIPTION
as upstream is still discussing about how to solve this issue for over 2 years now, we are going to just remove the reference from the generated specfile.

Closes #437

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>