### PR TITLE
pkgupdateskip: prevent jekyll upgrade

### DIFF
--- a/.pkgupdateskip
+++ b/.pkgupdateskip
@@ -6,3 +6,5 @@ rspec-support;~=3.12
 rspec;~=3.12
 rubocop;>=1.43.0
 concurrent-ruby;~=1.1
+jekyll;>=4.3.1
+jekyll-sass-converter;~=2.2


### PR DESCRIPTION
latest **point** release of jekyll injects a architecture specific gem 'sass-converter' which is available only for arm, arm64 and x64 - additionally this gem tries to pull stuff from the internet while compiling.
This is simply not the way bitbake build system operates.

Prevent any further updates to the gems jekyll and jekyll-sass-converter.

Closes #457
Closes #438

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>