### PR TITLE
Package update

### DIFF
--- a/.pkgupdateskip
+++ b/.pkgupdateskip
@@ -5,7 +5,7 @@ rspec-mocks;~=3.12
 rspec-support;~=3.12
 rspec;~=3.12
 rubocop;>=1.43.0
-rubocop-ast;>=1.26.0
+rubocop-ast;>=1.25.0
 concurrent-ruby;~=1.1
 jekyll;>=4.3.1
 jekyll-sass-converter;>2.3.0

--- a/recipes-rubygems/rubygems-aws-partitions_1.716.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.716.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a375d485fe17e7b44d63349b1e33bbbe"
-SRC_URI[sha256sum] = "05a876d21c4d8e21c57665194db6b840b9d6bd8c700ad47aa7cf0218a8e8edb6"
+SRC_URI[md5sum] = "7cde95be8cdff199a6f0d44899627156"
+SRC_URI[sha256sum] = "e162383276cca88e5c3028e6afa5b520ecfe1394ce11c3db3b863aba58bfc4b7"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.76.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.76.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f95467a9e279fa63fc18d6ac761ca0ec"
-SRC_URI[sha256sum] = "b4d8d2852522ba6b3b4d64401df7929cd08af163aa669c881278d8b01c0cfd83"
+SRC_URI[md5sum] = "3944c3ce14f03541b2796fbe784c653c"
+SRC_URI[sha256sum] = "be79637c5ea08155c40978e5fd023fe85b92005f0b70229c3e3ba6bb33c7d949"
 
 GEM_NAME = "aws-sdk-cloudfront"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.111.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.111.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "cc15b607a24916a5d3f398f0f9ddba85"
-SRC_URI[sha256sum] = "7b46a16a9928f87a42d418b30d20f4d91d66814fb83cb64a827075bfdfc90ce3"
+SRC_URI[md5sum] = "9117ca91b9353b0305bca2f38a350398"
+SRC_URI[sha256sum] = "5033bdc126a2cbb39ee55110420fb7cf9f6e1900f69421fdadc5f9c65e78b8a2"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-guardduty_1.64.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-guardduty_1.64.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "aa070e5c946e175d56273b4887e47e66"
-SRC_URI[sha256sum] = "c1f9436e7c39e8df9188ba73a675d05fb622dec4e1323f0ab885dbff670c12b8"
+SRC_URI[md5sum] = "b528acfdc662b72631e9ffabac852a39"
+SRC_URI[sha256sum] = "c5db5925854a7f871d8f86930866e72c1b1bdca5d7fe3c156ca4607566f0e77e"
 
 GEM_NAME = "aws-sdk-guardduty"
 

--- a/recipes-rubygems/rubygems-aws-sdk-redshift_1.91.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-redshift_1.91.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a402676f7e970a618fb2a6211f00efcc"
-SRC_URI[sha256sum] = "d7b09dc6768f5ad2b4b5e23152ab335ee82729c8e127285042a07614af214d88"
+SRC_URI[md5sum] = "113736c1bca65dfc92766a5039220d7b"
+SRC_URI[sha256sum] = "73735193a4fb5dd6ae773bf84639fae84a86db14cb57bb389830ff178411bbea"
 
 GEM_NAME = "aws-sdk-redshift"
 

--- a/recipes-rubygems/rubygems-aws-sdk-securityhub_1.78.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-securityhub_1.78.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "310d0788c562d8053907aad97bf67108"
-SRC_URI[sha256sum] = "5a3dbb0ba226352e7b691852ef6c3c6af210eb33decd8ea5895b2addd6ca59f9"
+SRC_URI[md5sum] = "4e29cd3d02101beffd46d17a78097e76"
+SRC_URI[sha256sum] = "41f05ae7c4b12cfbcced746ea4549f65132be31ec91a782bf8fe8e6ea9c1169a"
 
 GEM_NAME = "aws-sdk-securityhub"
 

--- a/recipes-rubygems/rubygems-aws-sdk-servicecatalog_1.76.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-servicecatalog_1.76.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a33aea28600acc57ddeab0f0caac2ffb"
-SRC_URI[sha256sum] = "070012be998e6aed05fbc638c908c1babb8fb067743257e4895c25fcbb7e4d99"
+SRC_URI[md5sum] = "b1e4b038d216902f07760c209259530b"
+SRC_URI[sha256sum] = "fdb4c98008af89cb2b3a98a561f8f1b407e9895cb6b18bde09b8912c557c16c4"
 
 GEM_NAME = "aws-sdk-servicecatalog"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ssm_1.149.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ssm_1.149.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b9a480e4518ef10bf26b82c881b194c3"
-SRC_URI[sha256sum] = "41a07cad16e24571a8b9500c07b89f94516acccfe580ab10e5fbf55bf6cede17"
+SRC_URI[md5sum] = "9b158d110c8e56a409a63dbe9b82cb24"
+SRC_URI[sha256sum] = "85de98ce8fa991602aeb3ebc0cf985457cb6a9690e7c1347951c4f067c5ba552"
 
 GEM_NAME = "aws-sdk-ssm"
 

--- a/recipes-rubygems/rubygems-google-apis-discovery-v1_0.14.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-discovery-v1_0.14.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "60a9f0bff4c1dfa19c14ab4ad1c845bb"
-SRC_URI[sha256sum] = "c89070b1e5b094b2c20c7f840b16beb7bd5d58e76262f1d1ca35e9823067095c"
+SRC_URI[md5sum] = "cd370c28fc74d1d67e9abd6c3f8bfad1"
+SRC_URI[sha256sum] = "a2236bee42f3150b83a255f4b6024761d80a8126b69d208855729c9e26f42b3d"
 
 GEM_NAME = "google-apis-discovery_v1"
 

--- a/recipes-rubygems/rubygems-ohai_18.1.0.bb
+++ b/recipes-rubygems/rubygems-ohai_18.1.0.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Ohai profiles your system and emits JSON"
 HOMEPAGE = "https://github.com/chef/ohai/"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=e3edf03f3aa19ea46e101aa4b956c206"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=8f7bb094c7232b058c7e9f2e431f389c"
 
 EXTRA_DEPENDS:append = " "
 EXTRA_RDEPENDS:append = " "
@@ -26,8 +26,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "495ecf1d0138451181278f5d848942f2"
-SRC_URI[sha256sum] = "0355c38b0f04b080505051c2bf822d3f1757995310efa7ef784a2ba046270c8f"
+SRC_URI[md5sum] = "9e0a5cfcf712e52322b434b494d36154"
+SRC_URI[sha256sum] = "fa04e06231835ec4c728f00f1fd23f7939ff6886619dbf4a18cc1796379de933"
 
 GEM_NAME = "ohai"
 

--- a/recipes-rubygems/rubygems-plist_3.7.0.bb
+++ b/recipes-rubygems/rubygems-plist_3.7.0.bb
@@ -6,12 +6,15 @@ HOMEPAGE = "https://github.com/patsplat/plist"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=e8d008d5070d56bbd0361ddc7178b9e4"
 
-SRC_URI[md5sum] = "ff419f2d7585ad4ed70abbb984e99af3"
-SRC_URI[sha256sum] = "f468bcf6b72ec6d1585ed6744eb4817c1932a5bf91895ed056e69b7f12ca10f2"
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "9b90cbd9c65736ce38b11651c54a16ad"
+SRC_URI[sha256sum] = "703ca90a7cb00e8263edd03da2266627f6741d280c910abbbac07c95ffb2f073"
 
 GEM_NAME = "plist"
-
-
 
 inherit rubygems
 inherit rubygentest


### PR DESCRIPTION
* plist: update to 3.7.0
* aws-sdk-cloudfront: update to 1.76.0
* aws-sdk-guardduty: update to 1.64.0
* ohai: update to 18.1.0
* rubocop-ast: update to 1.25.0
* aws-sdk-redshift: update to 1.91.0
* google-apis-discovery_v1: update to 0.14.0
* aws-sdk-ssm: update to 1.149.0
* aws-sdk-servicecatalog: update to 1.76.0
* aws-sdk-ecs: update to 1.111.0
* aws-sdk-securityhub: update to 1.78.0
* aws-partitions: update to 1.716.0