### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-addressable_2.8.3.bb
+++ b/recipes-rubygems/rubygems-addressable_2.8.3.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "64cb545a6ddcfc93c68fe53ac594c5f7"
-SRC_URI[sha256sum] = "bc724a176ef02118c8a3ed6b5c04c39cf59209607ffcce77b91d0261dbadedfa"
+SRC_URI[md5sum] = "a3ccb48d0c08f83709f04a8374d88d4c"
+SRC_URI[sha256sum] = "e3eebf83efd3da4a6b0895efb436e1b8d73d8a6c0dc165b823a97f5aaedcc4b1"
 
 GEM_NAME = "addressable"
 

--- a/recipes-rubygems/rubygems-aws-partitions_1.743.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.743.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7c47b7318b23a89014a8908249719f2a"
-SRC_URI[sha256sum] = "051b99b9d4f8d6c5a970559bc8870c7499b3bd9b2eaaf7c539bf86c4fdd42d8b"
+SRC_URI[md5sum] = "a31b655b97758312ed0953cf07888a76"
+SRC_URI[sha256sum] = "92522c74bf5c72c13e2c4818bce94bfdbff748311de720d4e0d699c2063a6ea3"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-autoscaling_1.89.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-autoscaling_1.89.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a7748ab87736ef119d29062f624e6e4b"
-SRC_URI[sha256sum] = "7fa1df4e937424bec46cae69a7395ed1a3b067de35cceacb684db449e82fdbb7"
+SRC_URI[md5sum] = "900c9ce3ed82e6c5db2751c11d74e727"
+SRC_URI[sha256sum] = "7a32fe0f1270ba275028d7cb79622c84d59abbe546ff2f0e87ce45b699641617"
 
 GEM_NAME = "aws-sdk-autoscaling"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudformation_1.77.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudformation_1.77.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1c584dce389bc43a42a3b96c5eae3543"
-SRC_URI[sha256sum] = "a9ce65511daa71c58bc2e347bc13a146b032fcb6a81db24da1b14b191dc8388a"
+SRC_URI[md5sum] = "9945393d5f9e3a52c14d6d73833aeecc"
+SRC_URI[sha256sum] = "9f5543e0c62fdec0f9cc2570899b17406e7ccc199db25db521d22606f3d46498"
 
 GEM_NAME = "aws-sdk-cloudformation"
 

--- a/recipes-rubygems/rubygems-aws-sdk-configservice_1.89.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-configservice_1.89.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "760d9d3c7693cb93b34de294f506ab37"
-SRC_URI[sha256sum] = "7d70096b82389749387808eed000459c480853c37fad0cffba58c1acac50e09e"
+SRC_URI[md5sum] = "a53d23b9646fcea6fea9119f1829e364"
+SRC_URI[sha256sum] = "8ac7693a549b87a99da9694428d043d79e15f82e0af3512f451a7fecc43c7e52"
 
 GEM_NAME = "aws-sdk-configservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.375.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.375.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b576324814db7264e2a391821aa808ae"
-SRC_URI[sha256sum] = "0b226fac184814d19c1b051c80a8e4aa97a523f847d589f560d0a925f04b4c37"
+SRC_URI[md5sum] = "951e716a52724777cbe0a831fffbba02"
+SRC_URI[sha256sum] = "1bdb79e257d2353885136c4317c8575ce82bc43a02f22a541bd906f4be3c46fe"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.112.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.112.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9117ca91b9353b0305bca2f38a350398"
-SRC_URI[sha256sum] = "5033bdc126a2cbb39ee55110420fb7cf9f6e1900f69421fdadc5f9c65e78b8a2"
+SRC_URI[md5sum] = "f589dec330fe62e1817df2504ad74616"
+SRC_URI[sha256sum] = "653136e7f1a737c075dc05b013db00167b8a912e39a4c182b00af9da78204c6a"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.134.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.134.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1cc6125174ea78fb34165cba456cd2d2"
-SRC_URI[sha256sum] = "ed29d33fbe77e838266a6970a18b8bba2a2c802a83a985f273ba5060b5a08423"
+SRC_URI[md5sum] = "b4ac3a506ecb31ab9caf666496b5484a"
+SRC_URI[sha256sum] = "454a2608f5e2a9d7c6456a6c6a2ac7e3d18c8abe35ee59f5021d491c2cc522ca"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-lambda_1.93.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-lambda_1.93.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "4847fcda4b66632384f63f33545aa6d8"
-SRC_URI[sha256sum] = "dc9adc9314840c43346b9b61e293ae96f15d531cf1b19ec764947eefc7042e96"
+SRC_URI[md5sum] = "83cd2f635fa20cb4b49239cef51bd9b1"
+SRC_URI[sha256sum] = "808fc212317afa220787469429c4ae419871795a467ebf44350977877215bb66"
 
 GEM_NAME = "aws-sdk-lambda"
 

--- a/recipes-rubygems/rubygems-aws-sdk-networkfirewall_1.26.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-networkfirewall_1.26.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "8f693c724bb24dabb75e361695f43989"
-SRC_URI[sha256sum] = "b5751c045716ef62f1bdac4034b74ebae8c91a0c6eeca11f4b039457727a53bd"
+SRC_URI[md5sum] = "3958a829f6faee559f6957d9502d8f71"
+SRC_URI[sha256sum] = "d75713052e8d13c3f9c5f4af0c5aab97b2197bc0be11cae2b47b038c982627aa"
 
 GEM_NAME = "aws-sdk-networkfirewall"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.175.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.175.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f69d0e16d712f96f4e08fffee16f799c"
-SRC_URI[sha256sum] = "976881ac8dfd488dac125eed511cf2c1f27cfe64d287216bf2b52549ee3af4ce"
+SRC_URI[md5sum] = "1a516f2414bf741a24b000dcdde59fb8"
+SRC_URI[sha256sum] = "5da5913e7ea82e51a497363e63390d7ab42b3407298c8fd683e1d3b0ff21a042"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.120.1.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.120.1.bb
@@ -17,8 +17,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "258f73cb57532d63f5e942704faf63f1"
-SRC_URI[sha256sum] = "e3c3f65b5609831f6865ec68576704f9934150aecc43c62ce78ef8d86b4103b4"
+SRC_URI[md5sum] = "c6616d35cf2dfba1e78ead1c6d9088f9"
+SRC_URI[sha256sum] = "23212ce52e56ba368c674e6c2fda134139a539d47bc3a0d81562e793ea6f57d5"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-aws-sdk-servicecatalog_1.79.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-servicecatalog_1.79.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b1e4b038d216902f07760c209259530b"
-SRC_URI[sha256sum] = "fdb4c98008af89cb2b3a98a561f8f1b407e9895cb6b18bde09b8912c557c16c4"
+SRC_URI[md5sum] = "cd2fa3eeb394a19363105a27ce96d833"
+SRC_URI[sha256sum] = "7e03d73dd2957ae09def818aa37811a36bd2abb2a00e623dff461c44034ab7da"
 
 GEM_NAME = "aws-sdk-servicecatalog"
 

--- a/recipes-rubygems/rubygems-facter_4.3.1.bb
+++ b/recipes-rubygems/rubygems-facter_4.3.1.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "aef369eddbda0a53790b07ceea30449e"
-SRC_URI[sha256sum] = "d24597d0fdc6a9219cb16f57f71512cd97219611775e24868bd30975b06cad2c"
+SRC_URI[md5sum] = "29977f8e6790ee24bd5eb63df888d0ca"
+SRC_URI[sha256sum] = "25223765648b3d75ff917b294ba8142bab1bba2ed307cd63acb6d77491265879"
 
 GEM_NAME = "facter"
 

--- a/recipes-rubygems/rubygems-puppet_7.24.0.bb
+++ b/recipes-rubygems/rubygems-puppet_7.24.0.bb
@@ -24,8 +24,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "65b9908ba642ae2c383f17f3180af321"
-SRC_URI[sha256sum] = "0af85280e1b2500510253307d3f80b4b9f17815b2f9bb3cc88261c6e8ec2654b"
+SRC_URI[md5sum] = "3e996d5ceb0af826c95484494ad8a9a4"
+SRC_URI[sha256sum] = "cc106f34fe1f351c593fc9ba8e3c6dc13dd594c5f0a0bf52f1820be206285722"
 
 GEM_NAME = "puppet"
 

--- a/recipes-rubygems/rubygems-rubocop_1.49.0.bb
+++ b/recipes-rubygems/rubygems-rubocop_1.49.0.bb
@@ -23,8 +23,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e7b5bda387ddedf79f3da367f7e877ce"
-SRC_URI[sha256sum] = "18cf7216ba8febb2f8a2a5978f36c54cfdf0de4427cb190a20fd0ee38ccdbee8"
+SRC_URI[md5sum] = "a1f75166367ead93211c2b4213437c3c"
+SRC_URI[sha256sum] = "d4c09409555ae24bca5b80cce20954544b057c1e7ec89c361f676aaba4b705b6"
 
 GEM_NAME = "rubocop"
 


### PR DESCRIPTION
* addressable: update to 2.8.3
* aws-sdk-s3: update to 1.120.1
* aws-sdk-autoscaling: update to 1.89.0
* rubocop: update to 1.49.0
* aws-sdk-lambda: update to 1.93.0
* aws-sdk-networkfirewall: update to 1.26.0
* aws-partitions: update to 1.743.0
* puppet: update to 7.24.0
* aws-sdk-glue: update to 1.134.0
* aws-sdk-rds: update to 1.175.0
* aws-sdk-ec2: update to 1.375.0
* aws-sdk-cloudformation: update to 1.77.0
* aws-sdk-configservice: update to 1.89.0
* aws-sdk-ecs: update to 1.112.0
* aws-sdk-servicecatalog: update to 1.79.0