### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-addressable_2.8.4.bb
+++ b/recipes-rubygems/rubygems-addressable_2.8.4.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a3ccb48d0c08f83709f04a8374d88d4c"
-SRC_URI[sha256sum] = "e3eebf83efd3da4a6b0895efb436e1b8d73d8a6c0dc165b823a97f5aaedcc4b1"
+SRC_URI[md5sum] = "5c7357e0d9caef708e2cc5bfe9e74670"
+SRC_URI[sha256sum] = "40a88af5285625b7fb14070e550e667d5b0cc91f748068701b4d897cacda4897"
 
 GEM_NAME = "addressable"
 

--- a/recipes-rubygems/rubygems-aws-partitions_1.748.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.748.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a31b655b97758312ed0953cf07888a76"
-SRC_URI[sha256sum] = "92522c74bf5c72c13e2c4818bce94bfdbff748311de720d4e0d699c2063a6ea3"
+SRC_URI[md5sum] = "3fa0432b950902ac19a63c8486615262"
+SRC_URI[sha256sum] = "f181a05fa33866e39fd85324fa502eba2b95b0e0116f22fcfbf42abe5937f18a"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecrpublic_1.16.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecrpublic_1.16.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "cd754989dba692727b3a7802c388dbaa"
-SRC_URI[sha256sum] = "31d80628675e64c5472012031172e2cca79a281b40196ba4fa4ce2f46982f4e6"
+SRC_URI[md5sum] = "1f39a7df2f1dc16b1c1d17c8f7fd120e"
+SRC_URI[sha256sum] = "acac48a5793472741360bc58df8aa1e62d10bdc7cf2d4b9303767cc12c1f3f96"
 
 GEM_NAME = "aws-sdk-ecrpublic"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.114.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.114.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f589dec330fe62e1817df2504ad74616"
-SRC_URI[sha256sum] = "653136e7f1a737c075dc05b013db00167b8a912e39a4c182b00af9da78204c6a"
+SRC_URI[md5sum] = "8714c40b8f8d210ea8154790eac46e17"
+SRC_URI[sha256sum] = "fe757f59c09ebdf072dc7f127f2e1b84102bf5774c7b5ebfe326f361bc137fde"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eventbridge_1.43.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eventbridge_1.43.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d2df14168bd257f51a142f46d366cbdf"
-SRC_URI[sha256sum] = "f8068d05cff4ddbc8fcacde752f60282cd7e03cf11d4f8d927c2494939a223f0"
+SRC_URI[md5sum] = "32727744d6c0c9ffd18d15bd49410a5a"
+SRC_URI[sha256sum] = "3ca29f0fd6061fd1908fb2e6002070b0bc40f5191b444307ac43211fbc9b7154"
 
 GEM_NAME = "aws-sdk-eventbridge"
 

--- a/recipes-rubygems/rubygems-aws-sdk-lambda_1.94.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-lambda_1.94.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "83cd2f635fa20cb4b49239cef51bd9b1"
-SRC_URI[sha256sum] = "808fc212317afa220787469429c4ae419871795a467ebf44350977877215bb66"
+SRC_URI[md5sum] = "0222b5a10493a8032ca2c2a5eea8c380"
+SRC_URI[sha256sum] = "59a37072fc798862c0ce86cab3d37064f9d218ce6afad372c8c20b9ad7931247"
 
 GEM_NAME = "aws-sdk-lambda"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.176.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.176.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1a516f2414bf741a24b000dcdde59fb8"
-SRC_URI[sha256sum] = "5da5913e7ea82e51a497363e63390d7ab42b3407298c8fd683e1d3b0ff21a042"
+SRC_URI[md5sum] = "72a30320996a28a3cb292482bd5b6669"
+SRC_URI[sha256sum] = "48fef973bbf94cb47618bb11ee5c62a28301adebcfc8b5d4055d95f60e8d5996"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-googleauth_1.5.2.bb
+++ b/recipes-rubygems/rubygems-googleauth_1.5.2.bb
@@ -20,8 +20,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9c34d6e819ea2a2d78f5960576035bdf"
-SRC_URI[sha256sum] = "d1b06ff4ad2a044b0f2237da949e2f2f1db13ff936e7c3a3050cbb192cac4bfd"
+SRC_URI[md5sum] = "1063dfb404aaa6b9cded25acabcb8a3d"
+SRC_URI[sha256sum] = "3abe02832e980c29145fc4cc553ecd23ca64d90f03e884d7f2f9d89b958245d2"
 
 GEM_NAME = "googleauth"
 

--- a/recipes-rubygems/rubygems-nokogiri_1.14.3.bb
+++ b/recipes-rubygems/rubygems-nokogiri_1.14.3.bb
@@ -24,8 +24,8 @@ GEM_INSTALL_FLAGS:append = " \
     --use-system-libraries \
 "
 
-SRC_URI[md5sum] = "26e975dd1d34eae530525ec926a044bb"
-SRC_URI[sha256sum] = "c765a74aac6cf430a710bb0b6038b8ee11f177393cd6ae8dadc7a44a6e2658b6"
+SRC_URI[md5sum] = "0eedfc2aaa845451013966c221199dc0"
+SRC_URI[sha256sum] = "3b1cee0eb8879e9e25b6dd431be597ca68f20283b0d4f4ca986521fad107dc3a"
 
 GEM_NAME = "nokogiri"
 

--- a/recipes-rubygems/rubygems-rubocop_1.50.1.bb
+++ b/recipes-rubygems/rubygems-rubocop_1.50.1.bb
@@ -23,8 +23,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a1f75166367ead93211c2b4213437c3c"
-SRC_URI[sha256sum] = "d4c09409555ae24bca5b80cce20954544b057c1e7ec89c361f676aaba4b705b6"
+SRC_URI[md5sum] = "a4fe204a062421f53a7098bd5ec68e76"
+SRC_URI[sha256sum] = "acfcbf5a410f7afe00d42fa696e752646057731396411d5066078ec26b909242"
 
 GEM_NAME = "rubocop"
 

--- a/recipes-rubygems/rubygems-semantic-puppet_1.1.0.bb
+++ b/recipes-rubygems/rubygems-semantic-puppet_1.1.0.bb
@@ -6,8 +6,13 @@ HOMEPAGE = "https://github.com/puppetlabs/semantic_puppet"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=8737b067d16e724769a2968ed8d6373f"
 
-SRC_URI[md5sum] = "bf36de9dffe6bc035a862bf0c3dc034b"
-SRC_URI[sha256sum] = "5d8380bf733c1552ef77e06a7c44a6d5b48def7d390ecf3bd71cad477f5ce13d"
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "0042f4e83fbf7435f4425070d81efd9e"
+SRC_URI[sha256sum] = "52d108d08e1a5d95c00343cb3a4936fb1deecff2be612ec39c9cb66be5a8b859"
 
 GEM_NAME = "semantic_puppet"
 

--- a/recipes-rubygems/rubygems-yard_0.9.34.bb
+++ b/recipes-rubygems/rubygems-yard_0.9.34.bb
@@ -9,23 +9,15 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b6f9769ae84eb7b621febf5cc8c5c62"
 EXTRA_DEPENDS:append = " "
 EXTRA_RDEPENDS:append = " "
 
-DEPENDS:class-native += "\
-    rubygems-webrick-native \
-"
-
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d5ac32134ef09cb6194a0371b863c7c1"
-SRC_URI[sha256sum] = "d31b7e3172405165212e0c8db5b3b57865f0831f1bc33bdda5d0709e1e72315c"
+SRC_URI[md5sum] = "9c8530eaaf9acf6fd32ee4b51119e46a"
+SRC_URI[sha256sum] = "5a8e04114d7f15f77814973ea56b7c38282126fb2930eb82851ffed0b9cd7e04"
 
 GEM_NAME = "yard"
 
 inherit rubygems
 inherit rubygentest
 inherit pkgconfig
-
-RDEPENDS:${PN}:class-target += "\
-    rubygems-webrick \
-"
 
 BBCLASSEXTEND = "native"


### PR DESCRIPTION
* addressable: update to 2.8.4
* googleauth: update to 1.5.2
* nokogiri: update to 1.14.3
* aws-sdk-ecrpublic: update to 1.16.0
* semantic_puppet: update to 1.1.0
* aws-sdk-lambda: update to 1.94.0
* aws-partitions: update to 1.748.0
* aws-sdk-ecs: update to 1.114.0
* aws-sdk-eventbridge: update to 1.43.0
* aws-sdk-rds: update to 1.176.0
* rubocop: update to 1.50.1
* yard: update to 0.9.34