### PR TITLE
pkggroup-rubygems: add rubygems-patron

### DIFF
--- a/packagegroups-rubygems/packagegroup-rubygems.bb
+++ b/packagegroups-rubygems/packagegroup-rubygems.bb
@@ -235,6 +235,7 @@ RDEPENDS:${PN} += "\
     rubygems-pastel \
     rubygems-path-expander \
     rubygems-pathutil \
+    rubygems-patron \
     rubygems-plist \
     rubygems-progress-bar \
     rubygems-proxifier \


### PR DESCRIPTION
previously missing from the list (and rightfully complained about by the linter)