### PR TITLE
Package update

### DIFF
--- a/lib/oeqa/runtime/cases/rubygems_rubygems_language_server_protocol.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_language_server_protocol.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_language_server_protocol(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_language_server_protocol(self):
+        self.gem_is_installed("language_server-protocol")
+
+    def test_load_language_server_protocol(self):
+        self.gem_is_loadable("language_server-protocol")
+

--- a/packagegroups-rubygems/packagegroup-rubygems.bb
+++ b/packagegroups-rubygems/packagegroup-rubygems.bb
@@ -189,6 +189,7 @@ RDEPENDS:${PN} += "\
     rubygems-kramdown \
     rubygems-kramdown-parser-gfm \
     rubygems-kwalify \
+    rubygems-language-server-protocol \
     rubygems-launchy \
     rubygems-libyajl2 \
     rubygems-license-acceptance \

--- a/recipes-rubygems/rubygems-aws-partitions_1.781.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.781.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9dd0b761ffac04d47299a1fc25244fa0"
-SRC_URI[sha256sum] = "7bdc1787575f6cf8d2de17bb85de3cf7ac73f28408a7c73f8a7bc8649a918b5e"
+SRC_URI[md5sum] = "22433c171547447f6285b4e75771a43d"
+SRC_URI[sha256sum] = "3f641eec6f386590ba38363ca45be90e5e273186d4f714d99ac5d12440862ff9"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudformation_1.82.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudformation_1.82.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "159e8c7c4ed699f9281f0c2f26caafa4"
-SRC_URI[sha256sum] = "6ae5456bad31e07ecf99ccbcf2f3f37d654fdf85ea8fe83e49c8749c526e8644"
+SRC_URI[md5sum] = "c2a4f41f26534edacc5ffe4b7df0f636"
+SRC_URI[sha256sum] = "373760e2c1cc33c04c429e746328022442dec598f1e6b1e1032f08e0d23dac81"
 
 GEM_NAME = "aws-sdk-cloudformation"
 

--- a/recipes-rubygems/rubygems-aws-sdk-configservice_1.93.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-configservice_1.93.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "fd935b5214ddb501ffba48f7eafef558"
-SRC_URI[sha256sum] = "bc164ad497fddb2939ef09242a8bb8b6835ad312a64ee3a992366f0d034905e3"
+SRC_URI[md5sum] = "e891b7997ea8c5d70500ac9a7a89a07b"
+SRC_URI[sha256sum] = "ea82088c5d70d8540a48cf96cea2113bc45f700f4de283007c510b1146cd760a"
 
 GEM_NAME = "aws-sdk-configservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-dynamodb_1.88.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-dynamodb_1.88.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6fef9c6b7dc7aa7a8a6038eb9c0a8c3e"
-SRC_URI[sha256sum] = "35fdab7a18a41a8905853eb96bb6d15768128d4aa5b3f260d79d87d95a7355a2"
+SRC_URI[md5sum] = "a3465a0521d7b5c02ba92fce682cb7f4"
+SRC_URI[sha256sum] = "8542023ebc21a6fb5da5599dfba538a9f879e8e0a5dc694c671a6081e2afdfae"
 
 GEM_NAME = "aws-sdk-dynamodb"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.386.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.386.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "8355ab1bb39e44e7697abda19de786ed"
-SRC_URI[sha256sum] = "39a0f8ee7dac3c8c79ad86028ccb352e3ca8551928aac9aad501c1d74735b86a"
+SRC_URI[md5sum] = "ac78847f6ddcb05d1d598defce726759"
+SRC_URI[sha256sum] = "3a93532735c77db9648cd1c709c53ca23d82111e2dc62425db399fa5d559c9ba"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.122.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.122.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "502121faf00fa276ab499f43ec2c9bea"
-SRC_URI[sha256sum] = "e302509f7da59e85d05741aad1c03876fda939436e2b6b098a2089ea14de28af"
+SRC_URI[md5sum] = "efa1e36d866744fe6c48ed7f75335209"
+SRC_URI[sha256sum] = "4fb4ac7c06345008abcaad13b325f959a94753b24bfb1a3d0be08359804fa6f0"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-emr_1.72.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-emr_1.72.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9b8ce26151ba06be181b0e6db0fcf93d"
-SRC_URI[sha256sum] = "0a87975e3f543ebcad75a200e858db94913a1fd000065b569596909242989fe2"
+SRC_URI[md5sum] = "1f0a9a72276051b41142d6ad5afdc600"
+SRC_URI[sha256sum] = "05bc47b4e117f58313ad327d287c9daa4ff4e461bbe6ed33b5f50b87e76ea6fe"
 
 GEM_NAME = "aws-sdk-emr"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.142.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.142.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1da0ee8939a0c6c22fed9f0dc8337f7d"
-SRC_URI[sha256sum] = "4eaf87b964b42e57a2823adff86581c651a4a9bd1baff836c7578dd032abbf19"
+SRC_URI[md5sum] = "55f9800a739fea4190421439efa38c7f"
+SRC_URI[sha256sum] = "6f182ecc6bbd000d430981bf83cc8915c27cb2ed973ee67d086062910baacca6"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-lambda_1.100.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-lambda_1.100.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d38f9f4e11450b373ee27a880901a23f"
-SRC_URI[sha256sum] = "697311af8ced629bee22f167fd10f31440eaf92148546dbb15c39405fb6ee098"
+SRC_URI[md5sum] = "ec797a653f9db064e215ee96761810b7"
+SRC_URI[sha256sum] = "4574ad0a6fbbb08b44bfccc4f5877db14af2a20f8fc550c65146bc02654a7019"
 
 GEM_NAME = "aws-sdk-lambda"
 

--- a/recipes-rubygems/rubygems-aws-sdk-mq_1.52.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-mq_1.52.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c9486657b153225205dc39177541c95a"
-SRC_URI[sha256sum] = "bbba422de61ea684b26d99e33f64c572c52051ad7a4e15d9f99db1be2a338bc3"
+SRC_URI[md5sum] = "680cc5a1d44160dcd0e5010539c646bd"
+SRC_URI[sha256sum] = "b949d955b713effd8419bc9a2610061d621fd0fda68ef0e2fda1a8c6a4c6f544"
 
 GEM_NAME = "aws-sdk-mq"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.182.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.182.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "33f734119f81115a61eaacd71fbb5666"
-SRC_URI[sha256sum] = "33acb06e70a1085164fb5b6e6bcc71be0e41666aa6dd5175f8d36efb3088e712"
+SRC_URI[md5sum] = "d5fff8649b29808729e376925216f321"
+SRC_URI[sha256sum] = "c8f154b968136e6d785ce831dfa18afc0cd5beba1f2dfd86565f2a538262d606"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-aws-sdk-redshift_1.94.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-redshift_1.94.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "05ee03e111943f55ffb75d3c87a94396"
-SRC_URI[sha256sum] = "a87d1f22cf7cee43be1bf99372921d5216fb289bd603804cef0b37915e33eeb2"
+SRC_URI[md5sum] = "0dabbd8f58762a669d478395e0c57f1d"
+SRC_URI[sha256sum] = "9cdfde03de9105463ee710da9439c951f3742a5f52f06fe7acd5bbaae6ec51a9"
 
 GEM_NAME = "aws-sdk-redshift"
 

--- a/recipes-rubygems/rubygems-aws-sdk-route53domains_1.46.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-route53domains_1.46.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "5d7fb5e03d6527d237910414c4115c4a"
-SRC_URI[sha256sum] = "f137a79b9c3ebca19e987bee7f803c541fc3a0d6b7bbdc3faab25b4436997877"
+SRC_URI[md5sum] = "154ac48d8e19642cc612998ec11702e9"
+SRC_URI[sha256sum] = "0b18634044e896df2417c1ee10b7102336be3e6400d175b455216ae2d67e50d9"
 
 GEM_NAME = "aws-sdk-route53domains"
 

--- a/recipes-rubygems/rubygems-aws-sdk-states_1.55.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-states_1.55.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "996730f7ea4df910139b5b7010842883"
-SRC_URI[sha256sum] = "0abf9ccf09c33631cc4dc0437065784df7f92209b2ced3d48fad526943dd5a4f"
+SRC_URI[md5sum] = "6b267757c3d3785a77617f7c020d6d42"
+SRC_URI[sha256sum] = "5b801ef89a73f741b2a2e2884ffc188ee1ba9cfab568c0a843135099c4d41fb7"
 
 GEM_NAME = "aws-sdk-states"
 

--- a/recipes-rubygems/rubygems-aws-sdk-transfer_1.71.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-transfer_1.71.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "efbb154e769fc5bf9142db4ee38631ae"
-SRC_URI[sha256sum] = "5d4df2444e496e7f4be8ff722d74963a6c3b88099e46b10320cd6b9d7ab16183"
+SRC_URI[md5sum] = "20e494b04856078e53de88e4a6de34e3"
+SRC_URI[sha256sum] = "63bd3c88d021195dd3f5b1535a35cf773f29c1146e4601eb57a70669e4afbf70"
 
 GEM_NAME = "aws-sdk-transfer"
 

--- a/recipes-rubygems/rubygems-faraday_2.7.7.bb
+++ b/recipes-rubygems/rubygems-faraday_2.7.7.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "bc12d52cfbf41cf241a8ce1b87cab336"
-SRC_URI[sha256sum] = "83d5f0bfa6cad31ad62d6b13743b297359236abb8540d79e266163adff8a3d23"
+SRC_URI[md5sum] = "260d9b1ef5060f5f374de7a6ccb256eb"
+SRC_URI[sha256sum] = "1ea3c705cf3546c21e1379502dfdba002a25909e7aba85bb60e7caea6d6724aa"
 
 GEM_NAME = "faraday"
 

--- a/recipes-rubygems/rubygems-googleauth_1.6.0.bb
+++ b/recipes-rubygems/rubygems-googleauth_1.6.0.bb
@@ -20,8 +20,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1063dfb404aaa6b9cded25acabcb8a3d"
-SRC_URI[sha256sum] = "3abe02832e980c29145fc4cc553ecd23ca64d90f03e884d7f2f9d89b958245d2"
+SRC_URI[md5sum] = "6ccffd3d4bd73c54c080a424dccf293e"
+SRC_URI[sha256sum] = "0de5d8c6d3c0becdec6ab454bd4ad7596d8a5dd1ee6a752f261b41cd91fc6124"
 
 GEM_NAME = "googleauth"
 

--- a/recipes-rubygems/rubygems-language-server-protocol_3.17.0.3.bb
+++ b/recipes-rubygems/rubygems-language-server-protocol_3.17.0.3.bb
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: language_server-protocol"
+DESCRIPTION = "A Language Server Protocol SDK"
+HOMEPAGE = "https://github.com/mtsmfm/language_server-protocol-ruby"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2580c2645bc754fdfb8f36610f09e7f5"
+
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "d8ab933a33865dd0a99124a6f5d1b08e"
+SRC_URI[sha256sum] = "3d5c58c02f44a20d972957a9febe386d7e7468ab3900ce6bd2b563dd910c6b3f"
+
+GEM_NAME = "language_server-protocol"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-mongo_2.19.0.bb
+++ b/recipes-rubygems/rubygems-mongo_2.19.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "77a7de914f847f634a6a9a80e2d6dd8e"
-SRC_URI[sha256sum] = "769ee6caf8675b42f24bcb13930e97ca64db87157bb51d5a3eb6ed07b167b7d1"
+SRC_URI[md5sum] = "dc249aab31ca8e512f2e2156dadf80ea"
+SRC_URI[sha256sum] = "70d990671b93994f98dc8dc8e758799255e46f9055617e4c946e371f3793dab7"
 
 GEM_NAME = "mongo"
 

--- a/recipes-rubygems/rubygems-rubocop_1.53.0.bb
+++ b/recipes-rubygems/rubygems-rubocop_1.53.0.bb
@@ -11,6 +11,7 @@ EXTRA_RDEPENDS:append = " "
 
 DEPENDS:class-native += "\
     rubygems-json-native \
+    rubygems-language-server-protocol-native \
     rubygems-parallel-native \
     rubygems-parser-native \
     rubygems-rainbow-native \
@@ -23,8 +24,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "19baa238663a90ae05264ad8c8517fa4"
-SRC_URI[sha256sum] = "908718035c4771f414280412be0d9168a7abd310da1ab859a50d41bece0dac2f"
+SRC_URI[md5sum] = "c11fdea9e1bc285b921af2a4c05a7dac"
+SRC_URI[sha256sum] = "01e56decdd30c12163c3ec5784ee6f579e61c939c04edb64d2f74c131272f72c"
 
 GEM_NAME = "rubocop"
 
@@ -34,6 +35,7 @@ inherit pkgconfig
 
 RDEPENDS:${PN}:class-target += "\
     rubygems-json \
+    rubygems-language-server-protocol \
     rubygems-parallel \
     rubygems-parser \
     rubygems-rainbow \

--- a/recipes-rubygems/rubygems-train-core_3.10.8.bb
+++ b/recipes-rubygems/rubygems-train-core_3.10.8.bb
@@ -20,8 +20,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "948a7306d3bc0907273c7a71fd1c56c8"
-SRC_URI[sha256sum] = "2cc99d0348056d53338335b52610251be6c1782c4e0263866df9e45b0bec1eb8"
+SRC_URI[md5sum] = "62e9d36f3ec44d6c0e99846d43cba914"
+SRC_URI[sha256sum] = "8493da02015fbe9b11840d22ba879ef18a0aa2633cb0c04eac3f07dd9b87223b"
 
 GEM_NAME = "train-core"
 

--- a/recipes-rubygems/rubygems-train_3.10.8.bb
+++ b/recipes-rubygems/rubygems-train_3.10.8.bb
@@ -26,8 +26,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "3585471264d3f0c261fa775d32e0de36"
-SRC_URI[sha256sum] = "5e6a3434cb309d7265a6bd3b58fa8d5df478cb7d9fde1c1947708c7d61df3d12"
+SRC_URI[md5sum] = "52f86e88ac183c5ead8d03ab77678766"
+SRC_URI[sha256sum] = "51a87a7d8e9c5d557e74b1f4754f637e7a08da7758192502aca2a86f54e8e267"
 
 GEM_NAME = "train"
 


### PR DESCRIPTION
* faraday: update to 2.7.7
* train-core: update to 3.10.8
* train: update to 3.10.8
* aws-sdk-emr: update to 1.72.0
* aws-sdk-transfer: update to 1.71.0
* aws-sdk-mq: update to 1.52.0
* aws-sdk-redshift: update to 1.94.0
* aws-sdk-glue: update to 1.142.0
* aws-sdk-ecs: update to 1.122.0
* aws-partitions: update to 1.781.0
* aws-sdk-configservice: update to 1.93.0
* rubocop: update to 1.53.0
* aws-sdk-states: update to 1.55.0
* aws-sdk-dynamodb: update to 1.88.0
* aws-sdk-cloudformation: update to 1.82.0
* aws-sdk-lambda: update to 1.100.0
* mongo: update to 2.19.0
* aws-sdk-route53domains: update to 1.46.0
* aws-sdk-rds: update to 1.182.0
* aws-sdk-ec2: update to 1.386.0