### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.791.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.791.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a0bdae4c1a8b74e1fda1da00077e0f6b"
-SRC_URI[sha256sum] = "150621a898b53e018b18a5b239949ca617af2202c8774b5d0b88cbcc9fcf3cc6"
+SRC_URI[md5sum] = "22f87ac3df33e3dbf292f386d90fcf17"
+SRC_URI[sha256sum] = "e98a634d683f342b48f2c25bb93b55bd1e9a6b3bc3f34baae06e4ede4c18481c"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudformation_1.86.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudformation_1.86.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b6bdf684354faaa5bdc36e8437d932a8"
-SRC_URI[sha256sum] = "05ac2d86ad727d15ff94f78e7d0b9f5af08f6af6ddbe4a749b9fa355a5b1c533"
+SRC_URI[md5sum] = "032de3a2414f1158fd8a9da43cb06b0a"
+SRC_URI[sha256sum] = "19ec984b2d931417f4faa6a2e8fac4fc9fbdd762c8ae0bdef212a8ce631fb673"
 
 GEM_NAME = "aws-sdk-cloudformation"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.392.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.392.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f10e0710248fc94f2473a172219f7fe7"
-SRC_URI[sha256sum] = "d505ab7f6a338321a6df7286ccb6a2d44eb319f1b9bac83d9f4c437044781f13"
+SRC_URI[md5sum] = "517da0fcecb1c6833d2f1de4698a0aa1"
+SRC_URI[sha256sum] = "b6588031ff6e33cd0784f19b5548ed8d152a413e88c0cea8322ff621ec036b97"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticsearchservice_1.76.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticsearchservice_1.76.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "56e574116f9f5c2fec211f1df03a33d7"
-SRC_URI[sha256sum] = "4cc939cd96db1c359db0433588a88a7f8180c4fb74b45e36fb0ad0364c3b98a7"
+SRC_URI[md5sum] = "e8ba30da8898f056e22cf39c62048b9d"
+SRC_URI[sha256sum] = "934c29f928de89b81747c34f3f57ba05a8c5d21acebf779a1cfd347314a576d8"
 
 GEM_NAME = "aws-sdk-elasticsearchservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.150.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.150.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "235bd9b6ad78f410963d302225c3da50"
-SRC_URI[sha256sum] = "ecefe1d1d2953e517c5564d67684cba3c7715f4ad5a80ccf17ad6395b5654072"
+SRC_URI[md5sum] = "11af51d11a32dac58101694d00c551eb"
+SRC_URI[sha256sum] = "3e1d60c2ec4fe9a33edbbbe4622d821f90567d8df32839e7567ef24ce5aec745"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ram_1.49.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ram_1.49.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6cedb8f21d0261b64fb99caf3163d85b"
-SRC_URI[sha256sum] = "aa34c0d7f1eeaf8324dab189b097024d1bb98c79025302dfe29610f615eba63f"
+SRC_URI[md5sum] = "4e63d7e325a8eff084b1a44991c47662"
+SRC_URI[sha256sum] = "92e972961432061922d30671cf99c6d674c312975a4d5d0961c7687b0a3dce98"
 
 GEM_NAME = "aws-sdk-ram"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.186.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.186.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7874928c3168334448c91ec67d36127b"
-SRC_URI[sha256sum] = "a975d6cc20fe0925609aa4c0cc8f8a18202ce506f8c618ae96daf07e8c3d58f8"
+SRC_URI[md5sum] = "e1a283929a7ec501a5268cf19c42db05"
+SRC_URI[sha256sum] = "dc705439924a46e93adbf118187ef545c83111e72bbb274d873da46af123e6f9"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-aws-sdk-route53resolver_1.47.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-route53resolver_1.47.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "5286b22b962b38709abd9a540907bc9e"
-SRC_URI[sha256sum] = "14e1f8cb98ea89be19ef71f7bb32ca14c1c467d2caacb13bd526e29a47dafff3"
+SRC_URI[md5sum] = "4f3d725a444037af087a902f2e7a44e6"
+SRC_URI[sha256sum] = "3711a70b95b3346b02081be2e0f4a04580fa1fd8fb82e1b97cd4cdcfa4a60c85"
 
 GEM_NAME = "aws-sdk-route53resolver"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.131.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.131.0.bb
@@ -17,8 +17,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d25211225aa8cf093449e2eda9581ea8"
-SRC_URI[sha256sum] = "80ac391ede15dcc62f1ada2fec12719a22148cf64ef76e5ec929558bb936c72a"
+SRC_URI[md5sum] = "1df01bb091ba02f117c99c2ece296e54"
+SRC_URI[sha256sum] = "cc3c77e88a1a9be38b23eca3930406aaa264a50373db414a9439416a76a8a5a0"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-dry-configurable_1.1.0.bb
+++ b/recipes-rubygems/rubygems-dry-configurable_1.1.0.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "A mixin to add configuration functionality to your classes"
 HOMEPAGE = "https://dry-rb.org/gems/dry-configurable"
 
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=94642341bb0f18ae40ee66ef498a2777"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b14b1929847ba471f3f59da600744315"
 
 EXTRA_DEPENDS:append = " "
 EXTRA_RDEPENDS:append = " "
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "86d2078596a5b65a2b566fca59821dc6"
-SRC_URI[sha256sum] = "4c876f2ff35c0e8bc54efc24a5a93972e1907a1221fccdfb528adc9fc2eb5af1"
+SRC_URI[md5sum] = "598bfc68bcf42c28ba06bd94d800f4b8"
+SRC_URI[sha256sum] = "dd7449cfcde4b1b99ff7ef6da87df273128f19a58c2d97fb6405f97cb22fb7da"
 
 GEM_NAME = "dry-configurable"
 

--- a/recipes-rubygems/rubygems-flay_2.13.1.bb
+++ b/recipes-rubygems/rubygems-flay_2.13.1.bb
@@ -20,8 +20,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "5a5449d043b26dc25c2ee9e25d906677"
-SRC_URI[sha256sum] = "6baa1a93c5a8cb20ec99376f55c0f1aa00b7e97a3e673cb80d029be52d755486"
+SRC_URI[md5sum] = "9af7cac9d9ecf0a7785f32cb79bf8d94"
+SRC_URI[sha256sum] = "dfe0bd800e4c331fb5a65ae6cc316137eb2e774a022d532c547fb7564ce1d73a"
 
 GEM_NAME = "flay"
 

--- a/recipes-rubygems/rubygems-flog_4.7.0.bb
+++ b/recipes-rubygems/rubygems-flog_4.7.0.bb
@@ -19,8 +19,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "fa1c44e88c5d7d62a4655abf0cba0172"
-SRC_URI[sha256sum] = "edf919b06d7aa5a7de3790e2b24e4a983f843a43e3463a980334685bcf24a99f"
+SRC_URI[md5sum] = "aef19441d585309eb18b5c3d97ebdccd"
+SRC_URI[sha256sum] = "b2a31e568958e4c0ad39f0cbdf29e1f8aa4908b0d5f592701ae1eece1926d546"
 
 GEM_NAME = "flog"
 

--- a/recipes-rubygems/rubygems-google-apis-core_0.11.1.bb
+++ b/recipes-rubygems/rubygems-google-apis-core_0.11.1.bb
@@ -22,8 +22,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6cee8664442fdb4af3bbaa20066687c6"
-SRC_URI[sha256sum] = "4e2048b8d00ffd94b580d68b66876884e9e6af84eac174a82bf9c4a74a9d9fa0"
+SRC_URI[md5sum] = "5fa94c3424e2e56f88aef9dd4ff50781"
+SRC_URI[sha256sum] = "917611234f38276524801058b8a56cdf496ff061b07295ef93cd5b8abd3b97fc"
 
 GEM_NAME = "google-apis-core"
 

--- a/recipes-rubygems/rubygems-googleauth_1.7.0.bb
+++ b/recipes-rubygems/rubygems-googleauth_1.7.0.bb
@@ -20,8 +20,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6ccffd3d4bd73c54c080a424dccf293e"
-SRC_URI[sha256sum] = "0de5d8c6d3c0becdec6ab454bd4ad7596d8a5dd1ee6a752f261b41cd91fc6124"
+SRC_URI[md5sum] = "46ae6761fa8a7ed3dd9b2eacb7be3da5"
+SRC_URI[sha256sum] = "4f7528361a3c11185acd074cb875606005098a1b2f119c38a0676025f7213340"
 
 GEM_NAME = "googleauth"
 

--- a/recipes-rubygems/rubygems-mini-portile2_2.8.4.bb
+++ b/recipes-rubygems/rubygems-mini-portile2_2.8.4.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a65078f35282e002d2ac45f0f6b65d41"
-SRC_URI[sha256sum] = "46b2d244cc6ff01a89bf61274690c09fdbdca47a84ae9eac39039e81231aee7c"
+SRC_URI[md5sum] = "519d07cf615aeaf352fb5c30dd26c370"
+SRC_URI[sha256sum] = "180bc4193701bbeb9b6c02df5a6b8185bff7f32abd466dd97d6532d36e45b20a"
 
 GEM_NAME = "mini_portile2"
 

--- a/recipes-rubygems/rubygems-puppet-resource-api_1.8.18.bb
+++ b/recipes-rubygems/rubygems-puppet-resource-api_1.8.18.bb
@@ -6,12 +6,17 @@ HOMEPAGE = "https://github.com/puppetlabs/puppet-resource_api"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
 
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
 DEPENDS:class-native += "\
     rubygems-hocon-native \
 "
 
-SRC_URI[md5sum] = "aee660a8398fc1c4dff2154eeb8b5975"
-SRC_URI[sha256sum] = "920e4fe74983cdfd20ce6b38f302bafbad653956aaf89cd9058d839eb3b590b5"
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "a3b62c1b68eda7a1c63f4f2ee5cd0efe"
+SRC_URI[sha256sum] = "9b1b1c09bff2fe1c4d61e3d17b04f2aaf5abb879a48272c85f4654d8a3fddd8c"
 
 GEM_NAME = "puppet-resource_api"
 


### PR DESCRIPTION
* google-apis-core: update to 0.11.1
* aws-sdk-s3: update to 1.131.0
* aws-sdk-ec2: update to 1.392.0
* aws-partitions: update to 1.791.0
* aws-sdk-glue: update to 1.150.0
* dry-configurable: update to 1.1.0
* aws-sdk-route53resolver: update to 1.47.0
* mini_portile2: update to 2.8.4
* aws-sdk-cloudformation: update to 1.86.0
* aws-sdk-ram: update to 1.49.0
* aws-sdk-elasticsearchservice: update to 1.76.0
* flog: update to 4.7.0
* puppet-resource_api: update to 1.8.18
* aws-sdk-rds: update to 1.186.0
* flay: update to 2.13.1