### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-activemodel_7.0.7.bb
+++ b/recipes-rubygems/rubygems-activemodel_7.0.7.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "85837babaf8921430c474af49b9f6988"
-SRC_URI[sha256sum] = "5231fe572d7599237b6b2a4987ebf439d028754a529227630777dd3d1ad8511c"
+SRC_URI[md5sum] = "b1270709f85a5f20744b509ca9d04d9f"
+SRC_URI[sha256sum] = "0e120a270f63d64bdacd91fe244ff7ee2ade147f9b0beab9802ef5ee095f57e7"
 
 GEM_NAME = "activemodel"
 

--- a/recipes-rubygems/rubygems-activesupport_7.0.7.bb
+++ b/recipes-rubygems/rubygems-activesupport_7.0.7.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "211eaaa85b8884d6b7b1035237ef889d"
-SRC_URI[sha256sum] = "d3abba6b15d8fd7af07f3322c370f00eb8ce6715fb714436342999628c705ab2"
+SRC_URI[md5sum] = "a2471f62ffe946a38b6339a9bd8e7855"
+SRC_URI[sha256sum] = "293b492bf3808eed3bcc915f6a4599609d0664c1a306f8168f1e680bc7b6ebf3"
 
 GEM_NAME = "activesupport"
 

--- a/recipes-rubygems/rubygems-aws-partitions_1.803.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.803.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "58193f46cf8600c9dd2a9d2c41607d3d"
-SRC_URI[sha256sum] = "0e2e59ff01f69ec1b6f3bbf73d907957daf79ec2c45e1b2a0ddc08e4c0d7b8b9"
+SRC_URI[md5sum] = "113a5827e85a6ca3f08031893d1a23d7"
+SRC_URI[sha256sum] = "37b922e7b58c3e75d04c560d43c7df2e3334f911b8db011c38a5f044fdb1e947"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.67.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.67.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f42261d8f759cbc6a9d253e77eed98b9"
-SRC_URI[sha256sum] = "fd43dc478711951fae6ccbe4a98ce87d2dbd2d94cf2986d4cc9e22dfdf175dc8"
+SRC_URI[md5sum] = "76652ea8d42da5589ce128e9d1aaa5e5"
+SRC_URI[sha256sum] = "5da041eccfbb4afbe03eeca43761848ffbb4c2e80c2be18c505f42e7ec8be58b"
 
 GEM_NAME = "aws-sdk-cloudtrail"
 

--- a/recipes-rubygems/rubygems-aws-sdk-configservice_1.97.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-configservice_1.97.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "dee715efa29fe2c24a1f8b91730d9e3c"
-SRC_URI[sha256sum] = "982052b720f22261432512715b9cc446b147a27a69df1b3295e683308a91a904"
+SRC_URI[md5sum] = "8f145d90680ef9f30d7f29381a480540"
+SRC_URI[sha256sum] = "4eae7d0f7556da89e59bfb12b1929e4e37ef7716731c6eab48f991743c0c96bb"
 
 GEM_NAME = "aws-sdk-configservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.180.3.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.180.3.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "eb26fad6c3570861a72597c641da8fa1"
-SRC_URI[sha256sum] = "44b2a16492b1fea57bc9e0a9d1efbb329786d120b0dc291a8e2abc5dc3bbb3eb"
+SRC_URI[md5sum] = "fddc4c86c9155ac9e329852cda92d653"
+SRC_URI[sha256sum] = "829915d511bb018acab0905d860c1831c4a7f7e8daba1afd546225b2c9918351"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.397.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.397.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a4ccb64fbb85cc64eeb59b5fd7106545"
-SRC_URI[sha256sum] = "dff483a377db2d42e52bb3ac53240bbabc6b196e0f93bdf9bf465a3c328dac06"
+SRC_URI[md5sum] = "e94aa634bae4733249585e1702e9854c"
+SRC_URI[sha256sum] = "4da83180462673386a7f06c9e7df959bca172f4017792d941ad7ae3963c5d723"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticache_1.91.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticache_1.91.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b1514875077c2aaaf082889973588214"
-SRC_URI[sha256sum] = "d639f3173bc49ee16aea1be43dc2d37c9b765e10c2e21a8a773e5a18e9f175ca"
+SRC_URI[md5sum] = "11e845184b747fbec627021ac5300c1f"
+SRC_URI[sha256sum] = "0d08564001519fad64e8a7e97ebad06aa3373541a7418640ded2d2449adc8409"
 
 GEM_NAME = "aws-sdk-elasticache"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticloadbalancingv2_1.90.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticloadbalancingv2_1.90.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e01cd0efda688ef2ad7be6bde91fc8dc"
-SRC_URI[sha256sum] = "14c917a5a022dac7c9fb54128de673f3e83e5c2670bd71ff638894b56101013d"
+SRC_URI[md5sum] = "2793b7bae6b4fdd920d687c99c670462"
+SRC_URI[sha256sum] = "995da208ee63f6e621e631872e3dfbae1c55911b60d533bfd228585d6f45c06b"
 
 GEM_NAME = "aws-sdk-elasticloadbalancingv2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-guardduty_1.77.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-guardduty_1.77.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "4fa0350cf1e53153d2a2848ba6b61474"
-SRC_URI[sha256sum] = "1a451eaa865847f0c7688176ff72778ac381234d5ec0e192c7519555ea7dad67"
+SRC_URI[md5sum] = "adea89565950e861220fd1bdbf142b9e"
+SRC_URI[sha256sum] = "62aeb94bf806143286526e593219dbdafece5999d0883db91ca9e6ccabb79fbb"
 
 GEM_NAME = "aws-sdk-guardduty"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.132.1.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.132.1.bb
@@ -17,8 +17,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7ba8cf7c51c06f1b59f10bb4ecab3eb1"
-SRC_URI[sha256sum] = "eec42306e6df54bacf5045a366c69acac8b02834b745b9562a90708838204b32"
+SRC_URI[md5sum] = "1f0afee627b8e5fb32b1264a248ea760"
+SRC_URI[sha256sum] = "cac01fbba5d717907b8df7b4e482447678c8392c7a4707ba09956d10e3549145"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-aws-sdk-secretsmanager_1.82.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-secretsmanager_1.82.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "479fc55e44c05aea3fd4a122974ee528"
-SRC_URI[sha256sum] = "44fde96e2d6383c8993dcc8cf599a6edb6a22dae18bc57d7c08a32f149e623b9"
+SRC_URI[md5sum] = "9015f516dcfa80b776e7c4a30bf17a78"
+SRC_URI[sha256sum] = "69b212c0d290a450c25957ae94366efda815d2082e8e530db76331fb55a89d27"
 
 GEM_NAME = "aws-sdk-secretsmanager"
 

--- a/recipes-rubygems/rubygems-aws-sdk-servicecatalog_1.86.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-servicecatalog_1.86.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "be43cbb477492c8f8b994523c7032c08"
-SRC_URI[sha256sum] = "3423dbe4f5ec2a6d44abb04590f008a87ad222138cad6188caf07b691786638e"
+SRC_URI[md5sum] = "53b338d5a08a264dbe74f1f40dd71ede"
+SRC_URI[sha256sum] = "03e5a03410e726d8272727bedd0f38c0226490a0ea36e8b956a265c13c3d04b4"
 
 GEM_NAME = "aws-sdk-servicecatalog"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ses_1.55.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ses_1.55.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7550a0cba33f7ee9900209af076f32b8"
-SRC_URI[sha256sum] = "606e820257c0961ccb552fd3d6f3c4f5169aaceaf62c3f01398623d3dca0696d"
+SRC_URI[md5sum] = "01339ee514f2bac100306a2beda93d4a"
+SRC_URI[sha256sum] = "4f69b92880dbb7638e4910f4d3d1b70eb43e6881f3dfaa578025f6364c975311"
 
 GEM_NAME = "aws-sdk-ses"
 

--- a/recipes-rubygems/rubygems-aws-sdk-transfer_1.77.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-transfer_1.77.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "0ae2d24ee90c86105710e655f36bf48c"
-SRC_URI[sha256sum] = "32f14b685229c245b557747fd7a2d8fe8364f7b360c233eaee52bbcb04906dc6"
+SRC_URI[md5sum] = "e077062d67a9c7933512deee330db450"
+SRC_URI[sha256sum] = "e818670c07566a075183f32f9555eae944820f4de5e5c1fb634f3beb19e52a90"
 
 GEM_NAME = "aws-sdk-transfer"
 

--- a/recipes-rubygems/rubygems-nokogiri_1.15.4.bb
+++ b/recipes-rubygems/rubygems-nokogiri_1.15.4.bb
@@ -24,8 +24,8 @@ GEM_INSTALL_FLAGS:append = " \
     --use-system-libraries \
 "
 
-SRC_URI[md5sum] = "cbdfcebb204bb824ab6b68ddf9fb9ebe"
-SRC_URI[sha256sum] = "876631295a85315dac37e7a71386d62d9eb452a891083cfe7505cca4805088cb"
+SRC_URI[md5sum] = "3f4c7fb57912e55022201a0eb44c996c"
+SRC_URI[sha256sum] = "e4a801e5ef643cc0036f0a7e93433d18818b31d48c9c287596b68e92c0173c4d"
 
 GEM_NAME = "nokogiri"
 

--- a/recipes-rubygems/rubygems-puppet-resource-api_1.9.0.bb
+++ b/recipes-rubygems/rubygems-puppet-resource-api_1.9.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a3b62c1b68eda7a1c63f4f2ee5cd0efe"
-SRC_URI[sha256sum] = "9b1b1c09bff2fe1c4d61e3d17b04f2aaf5abb879a48272c85f4654d8a3fddd8c"
+SRC_URI[md5sum] = "34a4d89f3241421aae2eb95e0af73cee"
+SRC_URI[sha256sum] = "4b82e77fad1d3810f3a84ad727aa9fd7c4e8b1179bacc034e9071c0a8f2ebe67"
 
 GEM_NAME = "puppet-resource_api"
 

--- a/recipes-rubygems/rubygems-rubocop_1.56.0.bb
+++ b/recipes-rubygems/rubygems-rubocop_1.56.0.bb
@@ -10,6 +10,7 @@ EXTRA_DEPENDS:append = " "
 EXTRA_RDEPENDS:append = " "
 
 DEPENDS:class-native += "\
+    rubygems-base64-native \
     rubygems-json-native \
     rubygems-language-server-protocol-native \
     rubygems-parallel-native \
@@ -24,8 +25,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "89beb8fd02976f66bdf83686bd6fab5f"
-SRC_URI[sha256sum] = "35e7ab338bcfd883122a3cb828b33aaa32c6759ab423ed872e10198c152e3769"
+SRC_URI[md5sum] = "d5671f61dbb48c37b47bbf6c667d5428"
+SRC_URI[sha256sum] = "96152bc00f2bd09df20a48133cb2b5c34267414d665f424d7cc127470c1fe2c5"
 
 GEM_NAME = "rubocop"
 
@@ -34,6 +35,7 @@ inherit rubygentest
 inherit pkgconfig
 
 RDEPENDS:${PN}:class-target += "\
+    rubygems-base64 \
     rubygems-json \
     rubygems-language-server-protocol \
     rubygems-parallel \


### PR DESCRIPTION
* aws-sdk-core: update to 3.180.3
* activesupport: update to 7.0.7
* aws-sdk-secretsmanager: update to 1.82.0
* aws-sdk-s3: update to 1.132.1
* aws-sdk-guardduty: update to 1.77.0
* aws-sdk-configservice: update to 1.97.0
* nokogiri: update to 1.15.4
* rubocop: update to 1.56.0
* aws-sdk-elasticloadbalancingv2: update to 1.90.0
* puppet-resource_api: update to 1.9.0
* aws-sdk-ec2: update to 1.397.0
* aws-sdk-elasticache: update to 1.91.0
* aws-sdk-servicecatalog: update to 1.86.0
* aws-sdk-cloudtrail: update to 1.67.0
* aws-sdk-transfer: update to 1.77.0
* aws-sdk-ses: update to 1.55.0
* activemodel: update to 7.0.7