### PR TITLE
Package update

### DIFF
--- a/lib/oeqa/runtime/cases/rubygems_rubygems_sys_filesystem.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_sys_filesystem.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_sys_filesystem(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_sys_filesystem(self):
+        self.gem_is_installed("sys-filesystem")
+
+    def test_load_sys_filesystem(self):
+        self.gem_is_loadable("sys-filesystem")
+

--- a/packagegroups-rubygems/packagegroup-rubygems.bb
+++ b/packagegroups-rubygems/packagegroup-rubygems.bb
@@ -291,6 +291,7 @@ RDEPENDS:${PN} += "\
     rubygems-sslshake \
     rubygems-strings \
     rubygems-strings-ansi \
+    rubygems-sys-filesystem \
     rubygems-syslog-logger \
     rubygems-systemu \
     rubygems-terminal-table \

--- a/recipes-rubygems/rubygems-activemodel_7.0.7.2.bb
+++ b/recipes-rubygems/rubygems-activemodel_7.0.7.2.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b1270709f85a5f20744b509ca9d04d9f"
-SRC_URI[sha256sum] = "0e120a270f63d64bdacd91fe244ff7ee2ade147f9b0beab9802ef5ee095f57e7"
+SRC_URI[md5sum] = "2d85a0cf4616434559ce1f238fdea3db"
+SRC_URI[sha256sum] = "45ba827986065ac273b59cb3b6c9ab3da412beca5d465f1acf7a51fb5bc032b3"
 
 GEM_NAME = "activemodel"
 

--- a/recipes-rubygems/rubygems-activesupport_7.0.7.2.bb
+++ b/recipes-rubygems/rubygems-activesupport_7.0.7.2.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a2471f62ffe946a38b6339a9bd8e7855"
-SRC_URI[sha256sum] = "293b492bf3808eed3bcc915f6a4599609d0664c1a306f8168f1e680bc7b6ebf3"
+SRC_URI[md5sum] = "9dbcca819e3cdd4b00e97c6fb123b3a6"
+SRC_URI[sha256sum] = "62e01393689c8514a65e2cf8be6f4781d1e6c7d9adc25b1056902d8abd659fee"
 
 GEM_NAME = "activesupport"
 

--- a/recipes-rubygems/rubygems-aws-partitions_1.812.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.812.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "10546f93f5a7791e52f1518d58a79ff9"
-SRC_URI[sha256sum] = "97ea286ab2ca2b6541213990f8399e0ca878415ff6f1e67eebd0a871aaedf4ed"
+SRC_URI[md5sum] = "9cc1796ebc4268202c8c5c6a0a23c2fc"
+SRC_URI[sha256sum] = "35d26a5456187358b3bf129833382890b4c99eb3fd5464eec4e6371b5f3b64f2"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-apigateway_1.87.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-apigateway_1.87.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e5921f466993700b0b78e07252d40233"
-SRC_URI[sha256sum] = "9f9f5be90feb3fc5909c8f10fab156edad8883d90f91512cd71cace3e057d4b2"
+SRC_URI[md5sum] = "ef39df8656aada3ad74d265b9eac9a32"
+SRC_URI[sha256sum] = "07204d62e2409cafea1254bf4bb9a18f79f5be97302af6aff042c7e4b8111113"
 
 GEM_NAME = "aws-sdk-apigateway"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.68.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.68.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "76652ea8d42da5589ce128e9d1aaa5e5"
-SRC_URI[sha256sum] = "5da041eccfbb4afbe03eeca43761848ffbb4c2e80c2be18c505f42e7ec8be58b"
+SRC_URI[md5sum] = "d1be4241334f1ef66324e895ea12f4c4"
+SRC_URI[sha256sum] = "a0dc1db5a432adecf08d06870c221585ee1d937a9490972b3a97972d0f72a338"
 
 GEM_NAME = "aws-sdk-cloudtrail"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatch_1.80.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatch_1.80.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "71539eceb8dd30235ee049ad41eb76b8"
-SRC_URI[sha256sum] = "29c49496f9d97e369462423de3016263e9f866207c05ffa57fba632349ecc9b4"
+SRC_URI[md5sum] = "e8ca826a4c7cd05fb452242680d95ff5"
+SRC_URI[sha256sum] = "d9856d545041a0a91795135d88f7501e3e5dd9e688048789f41660dc1ef5d990"
 
 GEM_NAME = "aws-sdk-cloudwatch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.181.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.181.0.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "fddc4c86c9155ac9e329852cda92d653"
-SRC_URI[sha256sum] = "829915d511bb018acab0905d860c1831c4a7f7e8daba1afd546225b2c9918351"
+SRC_URI[md5sum] = "8d72b0246c714ade8b809d227baf657b"
+SRC_URI[sha256sum] = "711cdf9483e48c63cd16b063b5f55d7ea23c4c432ce6123b287c356a1c4b5c76"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.402.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.402.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6d03f8555afdddc61076adbe6ea110e7"
-SRC_URI[sha256sum] = "16a8605c7dd58c4527dccde97eae51835f19af3c8fd0ad07cac527fc306d4f50"
+SRC_URI[md5sum] = "001e928227cae4fd1688e88b3329ca4f"
+SRC_URI[sha256sum] = "6c8c3dd98e1308e87b6df92f0904c2d742eee09dbc389085ec4d34052a5a85ce"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.155.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.155.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "33343f44d9ede74c840320d376459002"
-SRC_URI[sha256sum] = "6152a76d9982f24c4c4551c5766613565c6be1b874f0ff9fdca9710cff2eb2af"
+SRC_URI[md5sum] = "58ef47a20181dc7a5ee2ff5333ab0c9f"
+SRC_URI[sha256sum] = "9ea1707431d9abb4fd034067aee3f2a3420bd7342616a6c6925f9833503edb97"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.192.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.192.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "fc9af49ffb9d29b279f3fe5c705348e0"
-SRC_URI[sha256sum] = "7f4ccd1cc871ee61e0478b2868bcf5afab248796bbde253daca1aae0254f9bff"
+SRC_URI[md5sum] = "2f2bf67f051fc87a896da2de43d70efb"
+SRC_URI[sha256sum] = "8323db9bb5791eb0c87572a39e2f926909609588a6ca4e9fe3c59fa1c57ea4d8"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-aws-sdk-route53domains_1.51.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-route53domains_1.51.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7de1c1d32cdc1ae04d6b9bb7daae9f64"
-SRC_URI[sha256sum] = "195824f16a75e548233895c8098f480010eb3207278f736d0c6a1dee415e4b37"
+SRC_URI[md5sum] = "d33d802af1e8a0ec4abc87a1f2535c63"
+SRC_URI[sha256sum] = "edc4af48a15198542fc97d53b8e590dbf3c99e19360e59ac52f16d7aaa346705"
 
 GEM_NAME = "aws-sdk-route53domains"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.134.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.134.0.bb
@@ -17,8 +17,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1f0afee627b8e5fb32b1264a248ea760"
-SRC_URI[sha256sum] = "cac01fbba5d717907b8df7b4e482447678c8392c7a4707ba09956d10e3549145"
+SRC_URI[md5sum] = "ac6911de90293424907c04f036bbf571"
+SRC_URI[sha256sum] = "25135ec8af8b44c5221f50241810d3ae60bad0f52bfd618ab31d18ad52117fb9"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3control_1.69.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3control_1.69.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c401694f7dc9b3d55a7fc1295c210b7c"
-SRC_URI[sha256sum] = "321ab2928eaacf138922019369fe96b03b4fad9348e7a646c311f00aec949308"
+SRC_URI[md5sum] = "1bb78341cecedd6e4a99a8b80d4f9645"
+SRC_URI[sha256sum] = "3d612b061faf50cf78b807d6dc2e935a137e53e7ceb75622542f38218cd78f3b"
 
 GEM_NAME = "aws-sdk-s3control"
 

--- a/recipes-rubygems/rubygems-excon_0.102.0.bb
+++ b/recipes-rubygems/rubygems-excon_0.102.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9819f1e54e14d5e1274aa2404fe72993"
-SRC_URI[sha256sum] = "c7a084b4ff6bd67c2e2734dc323a2c3899ac031df36a5a258cbaf779d7c32623"
+SRC_URI[md5sum] = "6580a63d5f060d2c089d4642766a4285"
+SRC_URI[sha256sum] = "8f68ccbdc1f8ede6ec76fc4361fd188047138d9e2dc51e7f3d7ca7df94f77355"
 
 GEM_NAME = "excon"
 

--- a/recipes-rubygems/rubygems-facter_4.4.3.bb
+++ b/recipes-rubygems/rubygems-facter_4.4.3.bb
@@ -11,13 +11,14 @@ EXTRA_RDEPENDS:append = " "
 
 DEPENDS:class-native += "\
     rubygems-hocon-native \
+    rubygems-sys-filesystem-native \
     rubygems-thor-native \
 "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b508db263dbcf4511a4e1d59d9366b88"
-SRC_URI[sha256sum] = "a31953eb12295c16981c84ff422be35ff2bb7e59c2ec848a729f4a5698211d71"
+SRC_URI[md5sum] = "36d246c260ea6d48c0d49ae6c223b547"
+SRC_URI[sha256sum] = "32d2dcada49322cbfa2850393fd86d52bf35828edb7306fc5e4f7f2b410811e0"
 
 GEM_NAME = "facter"
 
@@ -27,6 +28,7 @@ inherit pkgconfig
 
 RDEPENDS:${PN}:class-target += "\
     rubygems-hocon \
+    rubygems-sys-filesystem \
     rubygems-thor \
 "
 

--- a/recipes-rubygems/rubygems-mime-types_3.5.1.bb
+++ b/recipes-rubygems/rubygems-mime-types_3.5.1.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6abf702cc0a5606117573910a507f505"
-SRC_URI[sha256sum] = "5d9c39f04074b5b545aea4f6fa853160daf30070c6fd8c9fbb999779afb725e9"
+SRC_URI[md5sum] = "4754d798c156458440a645f7a31a3ec2"
+SRC_URI[sha256sum] = "85d772fb6cf21f999ac8085998192fb9dd5d16e86ec4c69c5e79ac3003420d61"
 
 GEM_NAME = "mime-types"
 

--- a/recipes-rubygems/rubygems-puppet_8.2.0.bb
+++ b/recipes-rubygems/rubygems-puppet_8.2.0.bb
@@ -23,8 +23,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "cadd2fa5c0920a677f47f3b745d98f59"
-SRC_URI[sha256sum] = "f8d695a3ed3ee92a8693c7b37f85d0bd45c8a6c6c1cb5c8eb0349340f934d60e"
+SRC_URI[md5sum] = "dd20e1ade0dc94c6740c98221101b74a"
+SRC_URI[sha256sum] = "e04405122a9279f32bdba0a9e84f0ade6f8c9e7cac2081d2b92a14db0e1e0be0"
 
 GEM_NAME = "puppet"
 

--- a/recipes-rubygems/rubygems-rubocop_1.56.1.bb
+++ b/recipes-rubygems/rubygems-rubocop_1.56.1.bb
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 SUMMARY = "RubyGem: rubocop"
-DESCRIPTION = "RuboCop is a Ruby code style checking and code formatting tool.    It aims to enforce the community-driven Ruby Style Guide."
+DESCRIPTION = "RuboCop is a Ruby code style checking and code formatting tool.It aims to enforce the community-driven Ruby Style Guide."
 HOMEPAGE = "https://rubocop.org/"
 
 LICENSE = "MIT"
@@ -25,8 +25,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d5671f61dbb48c37b47bbf6c667d5428"
-SRC_URI[sha256sum] = "96152bc00f2bd09df20a48133cb2b5c34267414d665f424d7cc127470c1fe2c5"
+SRC_URI[md5sum] = "47eb00c778be5ed2875317772038ccd8"
+SRC_URI[sha256sum] = "50552e8f455f162bde074f26f607320357b587860778bc7a68097ee68b05add8"
 
 GEM_NAME = "rubocop"
 

--- a/recipes-rubygems/rubygems-sys-filesystem_1.4.3.bb
+++ b/recipes-rubygems/rubygems-sys-filesystem_1.4.3.bb
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: sys-filesystem"
+DESCRIPTION = "The sys-filesystem library provides a cross-platform interface for    gathering filesystem information, such as disk space and mount point data."
+HOMEPAGE = "https://github.com/djberg96/sys-filesystem"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2ee41112a44fe7014dce33e26468ba93"
+
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+DEPENDS:class-native += "\
+    rubygems-ffi-native \
+"
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "4c777b6ce146df4f7dd311d5250b7232"
+SRC_URI[sha256sum] = "390919de89822ad6d3ba3daf694d720be9d83ed95cdf7adf54d4573c98b17421"
+
+GEM_NAME = "sys-filesystem"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS:${PN}:class-target += "\
+    rubygems-ffi \
+"
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
* aws-sdk-core: update to 3.181.0
* excon: update to 0.102.0
* activesupport: update to 7.0.7.2
* aws-sdk-s3: update to 1.134.0
* aws-sdk-cloudwatch: update to 1.80.0
* facter: update to 4.4.3
* mime-types: update to 3.5.1
* aws-sdk-ec2: update to 1.402.0
* aws-sdk-s3control: update to 1.69.0
* rubocop: update to 1.56.1
* aws-sdk-route53domains: update to 1.51.0
* aws-sdk-cloudtrail: update to 1.68.0
* aws-sdk-glue: update to 1.155.0
* aws-sdk-rds: update to 1.192.0
* aws-sdk-apigateway: update to 1.87.0
* puppet: update to 8.2.0
* activemodel: update to 7.0.7.2