### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.843.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.843.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "da126b9a56d8648771f34037e843a8a2"
-SRC_URI[sha256sum] = "597516c4e0576c6eac314c7a33bac485896cbab18181b5f05855be1461e5e40b"
+SRC_URI[md5sum] = "f61f15e68e89445561bb54c67cd4e013"
+SRC_URI[sha256sum] = "aa4524f5e5be801e7918bf0d2883ba2c606f236a6b39d938aa4a8877bf8b178a"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-codepipeline_1.64.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-codepipeline_1.64.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9dde55d237bcc553cc80967f81f25648"
-SRC_URI[sha256sum] = "73f51b769fec150b0cdd6c8830ecbe4d7ffc453610f44a93ac2809587a67d988"
+SRC_URI[md5sum] = "64485225d7582157cbb1bf05322cc200"
+SRC_URI[sha256sum] = "c508bacadb8242b2ac19a823353afa35b43bb14af1798b1f0fb6ef0ef219b563"
 
 GEM_NAME = "aws-sdk-codepipeline"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.416.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.416.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "615d883a8f85bf94b417d3cb49f70c8e"
-SRC_URI[sha256sum] = "b947ccecafa92cbdead9538e8eb0f23c0886e7932ab36f099a24edf12ac13a91"
+SRC_URI[md5sum] = "248eecb93ded50de63a29e61c7c0a56d"
+SRC_URI[sha256sum] = "a7b380a00ee7202ebcfe58d9036cf98c91e6d6d9190d9fbe92c95536aa1355e1"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eks_1.91.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eks_1.91.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "04490054d8f995c5997de8d7b4a4d2d5"
-SRC_URI[sha256sum] = "db3f97f4f6a5bb3249d0e34d46a1b9e8ee9fda12cdcfa260730691076deabb75"
+SRC_URI[md5sum] = "03cc0d5048a09525ab9560a93926b47b"
+SRC_URI[sha256sum] = "05d124ff5101f2bec46c91b49a2bce3fce34e7fa2fc75b336a68f85633db4faa"
 
 GEM_NAME = "aws-sdk-eks"
 

--- a/recipes-rubygems/rubygems-aws-sdk-emr_1.77.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-emr_1.77.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "bb799a80fc3c299593b029aecee33fe1"
-SRC_URI[sha256sum] = "d9a9c82088fc12564145ed2fe2d92f764c80c06a49a570ca2707f57f950ae2e6"
+SRC_URI[md5sum] = "fe7c9f99c8b2b3a3a0f6cfea7fe1c1fe"
+SRC_URI[sha256sum] = "23f76773bbb37f993886656ca444ee662b702eddfb719da9b6aecb8b2cdc4d19"
 
 GEM_NAME = "aws-sdk-emr"
 

--- a/recipes-rubygems/rubygems-aws-sdk-iam_1.89.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-iam_1.89.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "8f685770522e14e3e54509869911a9bb"
-SRC_URI[sha256sum] = "3dfa52caa2065fd79dc5e2d117b34f39eee94abd4ea1f943d96a531e2da7bf38"
+SRC_URI[md5sum] = "66741a0d8b194844684b5b105543528a"
+SRC_URI[sha256sum] = "3b7de13e64e413397a531a5374e032efe0b7d98aa27a885f40e0e7519d1d7d1d"
 
 GEM_NAME = "aws-sdk-iam"
 

--- a/recipes-rubygems/rubygems-aws-sdk-networkfirewall_1.36.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-networkfirewall_1.36.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9eb5eccc95f3dd75f67a40f675ea165a"
-SRC_URI[sha256sum] = "f42d6387b7472bd08b36462e7e6d3d0fe27d8ccc3cb3990059731998d398db27"
+SRC_URI[md5sum] = "a9d5fb90bfb41ba5acfa8171dffdea20"
+SRC_URI[sha256sum] = "26410d42d8166b2d7571c7d92d4d6cc5923ce1567f6614e66fdab7b1844f35f7"
 
 GEM_NAME = "aws-sdk-networkfirewall"
 

--- a/recipes-rubygems/rubygems-aws-sdk-networkmanager_1.38.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-networkmanager_1.38.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f27483b63262dca8fc33782c002974ce"
-SRC_URI[sha256sum] = "839594e5f4d81981763f805cc27e9dbbc6fa0dd5692d1d0a7dabe7024ee282b0"
+SRC_URI[md5sum] = "91444f63db5ffdf826272ed510912e37"
+SRC_URI[sha256sum] = "85e34cfaaf2ccce2b052a640aab2679701d759cc3d669312b7354eef0cc440e7"
 
 GEM_NAME = "aws-sdk-networkmanager"
 

--- a/recipes-rubygems/rubygems-aws-sdk-redshift_1.101.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-redshift_1.101.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "60be3966ad4ebd734e25e03ddaff0fc4"
-SRC_URI[sha256sum] = "c6a6ae32f8f4a63dc0167a2bc4da081fe418ac4e9cb3e1231f0f66c0ef4d28c0"
+SRC_URI[md5sum] = "164fd3cd22bafbe0cd3bd75187aa4d6a"
+SRC_URI[sha256sum] = "dbdc686213c30720142b365c41454c3df5597851b1c0175a4fc28f621cec364f"
 
 GEM_NAME = "aws-sdk-redshift"
 

--- a/recipes-rubygems/rubygems-aws-sdk-sns_1.68.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-sns_1.68.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "3ffb73e4099e11a9161967cf54b6ab87"
-SRC_URI[sha256sum] = "c9bc783530de76252712af797e09279be1b04c121e46e9054779de8cf37f8562"
+SRC_URI[md5sum] = "eda1340bf052132310d5a6a9aeaec0db"
+SRC_URI[sha256sum] = "cb0b1366d87cb1a1989779f0b08342be873ee4ccbe3ff37cca79f059fb70c96d"
 
 GEM_NAME = "aws-sdk-sns"
 

--- a/recipes-rubygems/rubygems-aws-sdk-transfer_1.83.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-transfer_1.83.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6a500a82464b67ab67399dad627cdb90"
-SRC_URI[sha256sum] = "12ea1ef524d426e3ebdba5978bef8a0ff0a546a9b55348941c4ec54ea7534c86"
+SRC_URI[md5sum] = "a697a9116debfd201d5b27c7486cd639"
+SRC_URI[sha256sum] = "69a11f5388669f807c3185f47bebe0a62fe2d463b016996a5f9b8fff1535e690"
 
 GEM_NAME = "aws-sdk-transfer"
 

--- a/recipes-rubygems/rubygems-aws-sigv4_1.6.1.bb
+++ b/recipes-rubygems/rubygems-aws-sigv4_1.6.1.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a5a45f14886bbdcff038262a80dc4c75"
-SRC_URI[sha256sum] = "ca9e6a15cd424f1f32b524b9760995331459bc22e67d3daad4fcf0c0084b087d"
+SRC_URI[md5sum] = "d8916e5d46f785b1f5a0034a7a61bb73"
+SRC_URI[sha256sum] = "1c158f74d7daa882459bd5a686bccc25041af127a6b791911f2233e7673df1f3"
 
 GEM_NAME = "aws-sigv4"
 

--- a/recipes-rubygems/rubygems-google-apis-core_0.11.2.bb
+++ b/recipes-rubygems/rubygems-google-apis-core_0.11.2.bb
@@ -22,8 +22,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "5fa94c3424e2e56f88aef9dd4ff50781"
-SRC_URI[sha256sum] = "917611234f38276524801058b8a56cdf496ff061b07295ef93cd5b8abd3b97fc"
+SRC_URI[md5sum] = "e41802096e7ee852f91621f171b20769"
+SRC_URI[sha256sum] = "ed2e4d4a2e0e241b6d5b545bfb2d7069ca8be1c6766c605a09134a9f99379eb2"
 
 GEM_NAME = "google-apis-core"
 

--- a/recipes-rubygems/rubygems-mini-portile2_2.8.5.bb
+++ b/recipes-rubygems/rubygems-mini-portile2_2.8.5.bb
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 SUMMARY = "RubyGem: mini_portile2"
-DESCRIPTION = "Simplistic port-like solution for developers"
+DESCRIPTION = "Simple autoconf and cmake builder for developers"
 HOMEPAGE = "https://github.com/flavorjones/mini_portile"
 
 LICENSE = "MIT"
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "519d07cf615aeaf352fb5c30dd26c370"
-SRC_URI[sha256sum] = "180bc4193701bbeb9b6c02df5a6b8185bff7f32abd466dd97d6532d36e45b20a"
+SRC_URI[md5sum] = "0d8a4ba2e286b8f36b869997af6f3ecf"
+SRC_URI[sha256sum] = "7a37db8ae758086c3c3ac3a59c036704d331e965d5e106635e4a42d6e66089ce"
 
 GEM_NAME = "mini_portile2"
 

--- a/recipes-rubygems/rubygems-rouge_4.2.0.bb
+++ b/recipes-rubygems/rubygems-rouge_4.2.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "2e82310b160438960269f3a8c8ea223a"
-SRC_URI[sha256sum] = "9c8663db26e05e52b3b0286daacae73ebb361c1bd31d7febd8c57087faa0b9a5"
+SRC_URI[md5sum] = "f6a589c883d660ac6a6ce2e35aae2cbf"
+SRC_URI[sha256sum] = "60dd666b3a223467dc72f5b7384764dfd7ad4e50b0df9eff072be58123506eba"
 
 GEM_NAME = "rouge"
 

--- a/recipes-rubygems/rubygems-rubocop-ast_1.30.0.bb
+++ b/recipes-rubygems/rubygems-rubocop-ast_1.30.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6bb0c153c93e8d4f121dfc79a1ac38fa"
-SRC_URI[sha256sum] = "d1da2ab279a074baefc81758ac430c5768a8da8c7438dd4e5819ce5984d00ba1"
+SRC_URI[md5sum] = "b8a52f2585b1f16e20525eb4830bdaa4"
+SRC_URI[sha256sum] = "faad6452b1018fee0dd9e21a44445908e94ee2a4435932a9dae0e0740b6349b3"
 
 GEM_NAME = "rubocop-ast"
 

--- a/recipes-rubygems/rubygems-rubocop_1.57.2.bb
+++ b/recipes-rubygems/rubygems-rubocop_1.57.2.bb
@@ -10,7 +10,6 @@ EXTRA_DEPENDS:append = " "
 EXTRA_RDEPENDS:append = " "
 
 DEPENDS:class-native += "\
-    rubygems-base64-native \
     rubygems-json-native \
     rubygems-language-server-protocol-native \
     rubygems-parallel-native \
@@ -25,8 +24,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a336b6119086e1aa1aa5570f64747a77"
-SRC_URI[sha256sum] = "815449c1918f8acfd000cd52e2e20283e20540fac8d81c10e8d76df312dbfdc7"
+SRC_URI[md5sum] = "d3ab5e5660b5fe23e7287309d9395f35"
+SRC_URI[sha256sum] = "8f679dfe42d7821dc61dafb17d14b1294343157a197b9f8a23720ca17fb9161b"
 
 GEM_NAME = "rubocop"
 
@@ -35,7 +34,6 @@ inherit rubygentest
 inherit pkgconfig
 
 RDEPENDS:${PN}:class-target += "\
-    rubygems-base64 \
     rubygems-json \
     rubygems-language-server-protocol \
     rubygems-parallel \


### PR DESCRIPTION
* aws-sigv4: update to 1.6.1
* google-apis-core: update to 0.11.2
* aws-sdk-sns: update to 1.68.0
* rubocop: update to 1.57.2
* aws-sdk-networkfirewall: update to 1.36.0
* rouge: update to 4.2.0
* aws-sdk-codepipeline: update to 1.64.0
* mini_portile2: update to 2.8.5
* aws-sdk-redshift: update to 1.101.0
* aws-sdk-networkmanager: update to 1.38.0
* aws-sdk-emr: update to 1.77.0
* aws-sdk-transfer: update to 1.83.0
* aws-sdk-iam: update to 1.89.0
* aws-partitions: update to 1.843.0
* aws-sdk-eks: update to 1.91.0
* aws-sdk-ec2: update to 1.416.0