### PR TITLE
Package update

### DIFF
--- a/.pkgupdateskip
+++ b/.pkgupdateskip
@@ -2,7 +2,7 @@ chef-config;>18.1.0
 chef-utils;>18.1.0
 chef;>18.1.0
 concurrent-ruby;~=1.1
-highline;>3.0.0
+highline;>=3.0.0
 inspec-bin;>6.0.0
 inspec-core;>6.0.0
 inspec;>6.0.0

--- a/recipes-rubygems/rubygems-aws-partitions_1.880.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.880.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a0b10da64c64c04bbe5b5383c40f3758"
-SRC_URI[sha256sum] = "9552ed7bbd3700ed1eeb0121c160ceaf64fa5dbaff5a1ff5fe6fd8481ecd9cfd"
+SRC_URI[md5sum] = "22fbae5152ba2d40aaa900dbd06d8851"
+SRC_URI[sha256sum] = "81387f2dfab3a950e067fa058535ddceccfc717b1a9416c6867d94cb63320ea5"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.86.1.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.86.1.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "5f4c52d14ff580144265c387c2013e92"
-SRC_URI[sha256sum] = "2668f03e31156a572e589aa7d94d7b0e84ed17d5238ef6d565c15c8affd9b9bb"
+SRC_URI[md5sum] = "652dab5449c988a59dd2774a732cf7c1"
+SRC_URI[sha256sum] = "62f1cac3917d885e9a3c7b7f01e4f3afa995a53e3de2de10a1353ca291e7bf3c"
 
 GEM_NAME = "aws-sdk-cloudfront"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.77.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.77.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f5c64ce5956573bfa56059451361deaf"
-SRC_URI[sha256sum] = "83f5efff84c070699ac102541a32b9c0070071ede013fecb50ba1fc730f54841"
+SRC_URI[md5sum] = "ed3463707f1b635937bf22fedbba0f0e"
+SRC_URI[sha256sum] = "efffcb86297f90b22511b4d0beffe5815f2280b1751b6cce37bfc3a88ace838b"
 
 GEM_NAME = "aws-sdk-cloudwatchlogs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.190.2.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.190.2.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "2ec68f10a9e203ac5b58ad604fb56ea2"
-SRC_URI[sha256sum] = "b02aa7981f955c6021405c89b66e99061b99e2edc4f5b48c0f3dc742dd53daaa"
+SRC_URI[md5sum] = "b1364f38397fc53316c660a3eb96b426"
+SRC_URI[sha256sum] = "5d97bd8ebfff08b51c38e37dace3d919fa7c708696da01b1d343f2bbaf472e7d"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.433.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.433.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "03e8767b87454116889eaa68cda53daa"
-SRC_URI[sha256sum] = "5d52504196a21ee66af9711ec4869d9736dc00a72c30b6f7376eeea8cc238f12"
+SRC_URI[md5sum] = "3ed9b57a4916896b3cf789fcbdf4baeb"
+SRC_URI[sha256sum] = "4147eeab62d8ccfc35bf860d62aa8059890ffe11e302278aa85f2b2d39abc84f"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.137.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.137.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9ba38759d356cddafe7c8ff78d3bbba3"
-SRC_URI[sha256sum] = "16c685ff0bb871c438734c03622b3b132ffa25dceb48876586af390b3f8250ff"
+SRC_URI[md5sum] = "3631e9605d53da31db5edf69c9876654"
+SRC_URI[sha256sum] = "9a3ff65746529d936b53c2a46a1ff83ba21e6675c9162450b5d5aab33d084bb0"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eventbridge_1.56.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eventbridge_1.56.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "829a43e53d95e22b150d474404929dbf"
-SRC_URI[sha256sum] = "3122ab859b123b40ff5a9fe31f09019b45c9058f3948afcdf3674a23032ab419"
+SRC_URI[md5sum] = "da43f0e42648f601f6ca4fde8967665d"
+SRC_URI[sha256sum] = "2da407e07381540010c82dc6d309c64b13b9e74cee48f65488667a6e5a6cf995"
 
 GEM_NAME = "aws-sdk-eventbridge"
 

--- a/recipes-rubygems/rubygems-aws-sdk-route53_1.85.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-route53_1.85.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c19ec3d9f304d869200481c705d51e9e"
-SRC_URI[sha256sum] = "48b43d1db66110d68b34cf654ede6ab192f819a51e0db31a0104803bd98ed1d0"
+SRC_URI[md5sum] = "d6095a2be62a20d547b949fbde14a95f"
+SRC_URI[sha256sum] = "02eb282c8f1d910beaea54d77212442bb316126ff45ec1ff3cd45815bffaac74"
 
 GEM_NAME = "aws-sdk-route53"
 

--- a/recipes-rubygems/rubygems-aws-sdk-route53resolver_1.53.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-route53resolver_1.53.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a4eda127bca96e4450c184ef231ad44a"
-SRC_URI[sha256sum] = "a454f9552134b12189b93e913021547751a96dbfe43417820a3d6566bc19d055"
+SRC_URI[md5sum] = "5d54c0fff58c9705a35366ada67e868e"
+SRC_URI[sha256sum] = "cfb676baa7ec3c9c6d6dcc7a06007aeb520424f91e78c79a83970fc0fe763e62"
 
 GEM_NAME = "aws-sdk-route53resolver"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3control_1.76.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3control_1.76.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "40996d2ce46da52f7d095b2d6d5fe461"
-SRC_URI[sha256sum] = "41c774c9a8981443a3ad032901e70fae2cd44416d3fb5ff6943e5f2d4ff59594"
+SRC_URI[md5sum] = "5aa448a569210736d45b38014697a78c"
+SRC_URI[sha256sum] = "49982d1684c96813cad05884734abadb0022c727845d29fb8baee4aefe0ff62f"
 
 GEM_NAME = "aws-sdk-s3control"
 

--- a/recipes-rubygems/rubygems-aws-sdk-secretsmanager_1.89.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-secretsmanager_1.89.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "cc3f3b33a82700832913ee9c36bc270f"
-SRC_URI[sha256sum] = "0b686a21a0deb55573bbf521f732f2c5a9865736b96cc0e0df03db4520d8f06a"
+SRC_URI[md5sum] = "39fec295a6230a82c1d8f587a00e6f59"
+SRC_URI[sha256sum] = "57f47e0e2625ce974423d0e1b5fde4528a247265c42098b3538f977b6d68974d"
 
 GEM_NAME = "aws-sdk-secretsmanager"
 

--- a/recipes-rubygems/rubygems-aws-sdk-transfer_1.87.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-transfer_1.87.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "dce94f9fa0497dadf58a9f690674ea0d"
-SRC_URI[sha256sum] = "97a4e453c265ed37cfefa35a653b497b345cfaaccdba0aaa237557cd6257bb99"
+SRC_URI[md5sum] = "d1bf5bb55117dc739cb109dbcba815a9"
+SRC_URI[sha256sum] = "47b6fa8b4251eeab6f71333781a11861e5bbb94e7ee3d4ecf90e8bbf3739af39"
 
 GEM_NAME = "aws-sdk-transfer"
 

--- a/recipes-rubygems/rubygems-domain-name_0.6.20240107.bb
+++ b/recipes-rubygems/rubygems-domain-name_0.6.20240107.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "69d5ea358e9f997b8b144933e11fd9c0"
-SRC_URI[sha256sum] = "5127a1521ecca79d54accefc393f6d19db8600c6224416004414f7eaa28aecbe"
+SRC_URI[md5sum] = "c5703bfdafdb270349ba444f7df49e2b"
+SRC_URI[sha256sum] = "5f693b2215708476517479bf2b3802e49068ad82167bcd2286f899536a17d933"
 
 GEM_NAME = "domain_name"
 

--- a/recipes-rubygems/rubygems-faraday-net-http_3.1.0.bb
+++ b/recipes-rubygems/rubygems-faraday-net-http_3.1.0.bb
@@ -9,15 +9,23 @@ LIC_FILES_CHKSUM = "file://LICENSE.md;md5=20830660ee48a0c845a62aad77c18f4a"
 EXTRA_DEPENDS:append = " "
 EXTRA_RDEPENDS:append = " "
 
+DEPENDS:class-native += "\
+    rubygems-net-http-native \
+"
+
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "fe2ee661420646b1e1e30b5e6bfde96d"
-SRC_URI[sha256sum] = "6882929abed8094e1ee30344a3369e856fe34530044630d1f652bf70ebd87e8d"
+SRC_URI[md5sum] = "6fe5aae7b80b61ae48027a03d6757d31"
+SRC_URI[sha256sum] = "1627be414960d0131691190ff524506ba6607402a50fb6eccda9e64ca60f859f"
 
 GEM_NAME = "faraday-net_http"
 
 inherit rubygems
 inherit rubygentest
 inherit pkgconfig
+
+RDEPENDS:${PN}:class-target += "\
+    rubygems-net-http \
+"
 
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-faraday_2.9.0.bb
+++ b/recipes-rubygems/rubygems-faraday_2.9.0.bb
@@ -10,15 +10,13 @@ EXTRA_DEPENDS:append = " "
 EXTRA_RDEPENDS:append = " "
 
 DEPENDS:class-native += "\
-    rubygems-base64-native \
     rubygems-faraday-net-http-native \
-    rubygems-ruby2-keywords-native \
 "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7bf67c739b3b7f02ecf3b163ffff64cb"
-SRC_URI[sha256sum] = "a823dc6e1f5deaf6f91c8c1c02f37393f2339b39d811d9de33cef59d7d2ee4a6"
+SRC_URI[md5sum] = "bcce8e7ec967f7f257196016a1b81235"
+SRC_URI[sha256sum] = "1aa114507006eed6779a726b932d5cc12f5f6053984a19a3403539306b0e0be3"
 
 GEM_NAME = "faraday"
 
@@ -27,9 +25,7 @@ inherit rubygentest
 inherit pkgconfig
 
 RDEPENDS:${PN}:class-target += "\
-    rubygems-base64 \
     rubygems-faraday-net-http \
-    rubygems-ruby2-keywords \
 "
 
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-parser_3.3.0.3.bb
+++ b/recipes-rubygems/rubygems-parser_3.3.0.3.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c1297a0b5977ddf95eb3d97ed23a9bf2"
-SRC_URI[sha256sum] = "8ba7fa149ae1b268bae3e5aaf5b5345e16bd553406e1562c483fe9bed6ed00ad"
+SRC_URI[md5sum] = "32a9cd79efed3ddcf869c01c0d3ba0dc"
+SRC_URI[sha256sum] = "4600edc3c6ea73347ec8fc2a95d6f4b69797625cb22f055a2c4c5d22afd7a330"
 
 GEM_NAME = "parser"
 

--- a/recipes-rubygems/rubygems-regexp-parser_2.9.0.bb
+++ b/recipes-rubygems/rubygems-regexp-parser_2.9.0.bb
@@ -4,15 +4,15 @@ DESCRIPTION = "A library for tokenizing, lexing, and parsing Ruby regular expres
 HOMEPAGE = "https://github.com/ammar/regexp_parser"
 
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=ab6e6852046ddac1a232486a7deee31b"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=70dd94107d72a26732c98b5ce86c90f2"
 
 EXTRA_DEPENDS:append = " "
 EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f739f1af4903c92e882ef79e86e373b7"
-SRC_URI[sha256sum] = "953277d2268bfb2f03275f36222ba9b36342f744a886cb7c8eefa8b985842ff7"
+SRC_URI[md5sum] = "a22ca8a4f8e1dd11be0a66e65f59ca78"
+SRC_URI[sha256sum] = "81a00ba141cec0d4b4bf58cb80cd9193e5180836d3fa6ef623f7886d3ba8bdd9"
 
 GEM_NAME = "regexp_parser"
 


### PR DESCRIPTION
* aws-sdk-core: update to 3.190.2
* faraday: update to 2.9.0
* parser: update to 3.3.0.3
* aws-sdk-secretsmanager: update to 1.89.0
* aws-sdk-route53: update to 1.85.0
* aws-sdk-transfer: update to 1.87.0
* aws-sdk-eventbridge: update to 1.56.0
* aws-sdk-cloudfront: update to 1.86.1
* aws-sdk-ecs: update to 1.137.0
* aws-sdk-route53resolver: update to 1.53.0
* aws-sdk-cloudwatchlogs: update to 1.77.0
* highline: update to 3.0.0
* domain_name: update to 0.6.20240107
* aws-sdk-ec2: update to 1.433.0
* regexp_parser: update to 2.9.0
* aws-sdk-s3control: update to 1.76.0