### PR TITLE
Package update

### DIFF
--- a/.pkgupdateskip
+++ b/.pkgupdateskip
@@ -8,9 +8,9 @@ inspec-core;>6.0.0
 inspec;>6.0.0
 jekyll-sass-converter;>2.3.0
 jekyll;>=4.3.1
-rspec-core;~=3.12
-rspec-expectations;~=3.12
-rspec-mocks;~=3.12
-rspec-support;~=3.12
-rspec;~=3.12.0
+rspec-core;>=3.12.0
+rspec-expectations;>=3.12.0
+rspec-mocks;>=3.12.0
+rspec-support;>=3.12.0
+rspec;>=3.12.0
 ruby_parser;>3.20.3

--- a/recipes-rubygems/rubygems-aws-partitions_1.889.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.889.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "0766856c87b28bceb1a6bbb50d768b2c"
-SRC_URI[sha256sum] = "f451bcde8cf105f2cfef0d074d0a6658109b403206c48afd41ab2b1d1f9b2c0e"
+SRC_URI[md5sum] = "cfac706bba2ddc546960c038cf77e6dd"
+SRC_URI[sha256sum] = "45c2e6070eddeb127d91eab686c9b152ab048db6d925b4c48c8b7312baefa8bc"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-batch_1.81.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-batch_1.81.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1c42ac1b7d3be1eaf8b8c00128c50491"
-SRC_URI[sha256sum] = "69b4f05ac38f276aa88da4b3a7c7546f3e428bea0962d94569d1060ef95da4d3"
+SRC_URI[md5sum] = "147691532df5703ed61852b3d0465911"
+SRC_URI[sha256sum] = "20cc27b6ef1aebb1ef136ed509c902b7f9fbb26ef8c21555790964e30e9d42e0"
 
 GEM_NAME = "aws-sdk-batch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.79.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.79.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b8927f8d756007bf5fe6b17b9fd19d3c"
-SRC_URI[sha256sum] = "6b6b3364475b8a68df5e60fc9f31ed40f48387b77bd2cb764dc4fa0dc5490f6d"
+SRC_URI[md5sum] = "816ad2c68b8413a308202c72c69e4de2"
+SRC_URI[sha256sum] = "0dcdd8d8ea84eb27450491252a30a4db215fbd6c7845054e705065a61d7eada3"
 
 GEM_NAME = "aws-sdk-cloudwatchlogs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-codepipeline_1.69.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-codepipeline_1.69.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "4b72fcd8f8ed15becd3c197d33669086"
-SRC_URI[sha256sum] = "c1766869d9c4a5e1d5eb5f3316ab65364320adcbe85bc2402abb1b31907e18a6"
+SRC_URI[md5sum] = "b48d475c859010980652a3cbefe1bcd3"
+SRC_URI[sha256sum] = "19672d1ba27c7f9b74f82541b99266770119dcd20940e898f0dee7e32ac8c24f"
 
 GEM_NAME = "aws-sdk-codepipeline"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.191.1.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.191.1.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b0adbea49e0189254ca87544c2c58465"
-SRC_URI[sha256sum] = "de1dfbd22c0e16602f52b14cf0beadcebb329f345e1f01cf2dc3fcc089fa7bab"
+SRC_URI[md5sum] = "f5c828bdae7fcb03535516c7074d2a01"
+SRC_URI[sha256sum] = "f8608fc0569cbe4c6be07f4d4978b5f537ab990faeb501fc4532888f0e02c83b"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.142.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.142.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1f614bb5270f38165b4dc5f5b74ebd42"
-SRC_URI[sha256sum] = "dbfe6403051508b0830204fc9cffd69a5ddd6b6bc0b67e47616a785ef94c865e"
+SRC_URI[md5sum] = "9e884f07047149e0e93c3103bfefbac3"
+SRC_URI[sha256sum] = "0b62107620df9a033c842891a4b517bfb02f29d58df955a75a97b41a09687417"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticsearchservice_1.82.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticsearchservice_1.82.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f1d85d1fd51adde1c41837775e486fb8"
-SRC_URI[sha256sum] = "c3c4421ddb426307859f10396a02962b32dd02f898e66dd4ca2f1e7bd2af9b9c"
+SRC_URI[md5sum] = "1b85a82301e24802cfb529343cc4e835"
+SRC_URI[sha256sum] = "db6df6e091d55f481f6db2c2d6dec3294bd91be5059d89a7d4f92f057ca74044"
 
 GEM_NAME = "aws-sdk-elasticsearchservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.168.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.168.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "2bf6bdda60b20ed7e32b9e913c81d8ce"
-SRC_URI[sha256sum] = "638a894ca1c12fb397f159896269e43e0635ab6924ea743e7995b35d02166b40"
+SRC_URI[md5sum] = "027e67a9c945cf0d4c72823a577ad4b3"
+SRC_URI[sha256sum] = "466ac91c53160852af3f155758c396de3962f7e3d38a2b368bf0e2c8ff82e8aa"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-redshift_1.109.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-redshift_1.109.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7cd51bf7fa2dd576b3406c9fcc114d88"
-SRC_URI[sha256sum] = "eff54ff06be0b26ebfd1d76124cfba66fca70a9b1663368de99f3173459db3f1"
+SRC_URI[md5sum] = "991c74d3de73c6c48377a488c255720b"
+SRC_URI[sha256sum] = "651ff4fb5b2934ed61080816bd6bbd4e848c740c5aae99b8e4ae94c0b4e46fad"
 
 GEM_NAME = "aws-sdk-redshift"
 

--- a/recipes-rubygems/rubygems-aws-sdk-wafv2_1.76.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-wafv2_1.76.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "91f54458fedf558ccddf3d8a05e83517"
-SRC_URI[sha256sum] = "b2aa3d7a97d43d5b6a6baa403c1b18ca8c0685265a295361d62abcb95ab5d8e5"
+SRC_URI[md5sum] = "f6a16c6eb35ba735e0282611d3e3b3ff"
+SRC_URI[sha256sum] = "8ca522601e647de80289e53bffcc7f54917e43acb07ff632de46ed44a4c566cb"
 
 GEM_NAME = "aws-sdk-wafv2"
 

--- a/recipes-rubygems/rubygems-flay_2.13.2.bb
+++ b/recipes-rubygems/rubygems-flay_2.13.2.bb
@@ -20,8 +20,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9af7cac9d9ecf0a7785f32cb79bf8d94"
-SRC_URI[sha256sum] = "dfe0bd800e4c331fb5a65ae6cc316137eb2e774a022d532c547fb7564ce1d73a"
+SRC_URI[md5sum] = "dbfc718b78b77538311bbfa3f4ff45f5"
+SRC_URI[sha256sum] = "55d23255ac83ce64f45e86765667c3e0b868dc06a6b08238113201757d1574e2"
 
 GEM_NAME = "flay"
 

--- a/recipes-rubygems/rubygems-googleauth_1.10.0.bb
+++ b/recipes-rubygems/rubygems-googleauth_1.10.0.bb
@@ -20,8 +20,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "977550370a49c74b2d439659ea2d26a7"
-SRC_URI[sha256sum] = "304dba7baf39cd185592656c0236ab97450d4daa22682e9de016a4a7d8d6fbe2"
+SRC_URI[md5sum] = "649026d0bd77a993d1a791b1fd085ed2"
+SRC_URI[sha256sum] = "a73983d8ca6e142e18f894350dca95446f6591bbfae93ecf35201d035b738650"
 
 GEM_NAME = "googleauth"
 

--- a/recipes-rubygems/rubygems-http-accept_2.2.1.bb
+++ b/recipes-rubygems/rubygems-http-accept_2.2.1.bb
@@ -4,15 +4,15 @@ DESCRIPTION = "Parse Accept and Accept-Language HTTP headers."
 HOMEPAGE = "https://github.com/ioquatix/http-accept"
 
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://lib/http/accept/media_types/map.rb;beginline=5;endline=21;md5=7f7c2007e48f6b5170afcdeeda85abc0"
+LIC_FILES_CHKSUM = "file://license.md;md5=46bdd4fdbcc0fcefa757bbd1bf912838"
 
 EXTRA_DEPENDS:append = " "
 EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d397d6a718c80d15bba354a37729a27e"
-SRC_URI[sha256sum] = "d589cfc6409d41862fa6b73e225a0237ffa9f66d5cd606c67a80872f82390ee7"
+SRC_URI[md5sum] = "bdd2f1c5346da6fd0a3884db5a027b7b"
+SRC_URI[sha256sum] = "f8481ded20f782e43555f5c6b20222449fff4e5322462721c79c056b89ad500f"
 
 GEM_NAME = "http-accept"
 

--- a/recipes-rubygems/rubygems-multipart-post_2.4.0.bb
+++ b/recipes-rubygems/rubygems-multipart-post_2.4.0.bb
@@ -4,15 +4,15 @@ DESCRIPTION = "A multipart form post accessory for Net::HTTP."
 HOMEPAGE = "https://github.com/socketry/multipart-post"
 
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://license.md;md5=3dc66ef212fde3c72a46c033bcd535ab"
+LIC_FILES_CHKSUM = "file://license.md;md5=18276da62cdadda4675dbf0abecf9c02"
 
 EXTRA_DEPENDS:append = " "
 EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "067cd7270a1f476ce71454d499213671"
-SRC_URI[sha256sum] = "3dcdd74a767302559fcf91a63b568ee00770494ce24195167b1c147ab3f6fe51"
+SRC_URI[md5sum] = "626fd8b3f8cd080c1eccfa0e25d7bfed"
+SRC_URI[sha256sum] = "c7c48ce6cd32cd7a3bf5fa58fed39cf58e90f75a526de24fbaa91913cab86380"
 
 GEM_NAME = "multipart-post"
 

--- a/recipes-rubygems/rubygems-nokogiri_1.16.2.bb
+++ b/recipes-rubygems/rubygems-nokogiri_1.16.2.bb
@@ -24,8 +24,8 @@ GEM_INSTALL_FLAGS:append = " \
     --use-system-libraries \
 "
 
-SRC_URI[md5sum] = "4b134c777141ca84001a913ec65392df"
-SRC_URI[sha256sum] = "341388184e975d091e6e38ce3f3b3388bfb7e4ac3d790efd8e39124844040bd1"
+SRC_URI[md5sum] = "f6a3fb5da5c354ffef015197d2986b7b"
+SRC_URI[sha256sum] = "68922ee5cde27497d995c46f2821957bae961947644eed2822d173daf7567f9c"
 
 GEM_NAME = "nokogiri"
 

--- a/recipes-rubygems/rubygems-specinfra_2.88.0.bb
+++ b/recipes-rubygems/rubygems-specinfra_2.88.0.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "ae201ccdbbf522a6e1122f5c40e4e3b0"
-SRC_URI[sha256sum] = "969dcf7d5bcd39222bd2abf9371c9a23bb677754750bccc6976c728d6b51a521"
+SRC_URI[md5sum] = "e3d2367dcb8fb637fa2f44c381652a36"
+SRC_URI[sha256sum] = "2a932c44aa2435fb06aa16be9220176fc910073a40ef0a5ab5bc28a05857dd81"
 
 GEM_NAME = "specinfra"
 

--- a/recipes-rubygems/rubygems-zeitwerk_2.6.13.bb
+++ b/recipes-rubygems/rubygems-zeitwerk_2.6.13.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "074f6ab751892775cee50d9557c433d9"
-SRC_URI[sha256sum] = "561e12975d0332fd3b62cc859aff3bab432e5f320689c8a10cd4674b5c0439be"
+SRC_URI[md5sum] = "87c8b2fa01470756c5d9d2dfaa9ce2c7"
+SRC_URI[sha256sum] = "2db861b021d020f48b5bf51613f355fcd041bf0a27ad8c748fa88fa974c5c7d4"
 
 GEM_NAME = "zeitwerk"
 


### PR DESCRIPTION
* aws-sdk-core: update to 3.191.1
* zeitwerk: update to 2.6.13
* rspec: update to 3.13.0
* googleauth: update to 1.10.0
* aws-sdk-ecs: update to 1.142.0
* http-accept: update to 2.2.1
* aws-sdk-codepipeline: update to 1.69.0
* aws-sdk-cloudwatchlogs: update to 1.79.0
* multipart-post: update to 2.4.0
* aws-sdk-elasticsearchservice: update to 1.82.0
* aws-sdk-redshift: update to 1.109.0
* specinfra: update to 2.88.0
* aws-sdk-batch: update to 1.81.0
* nokogiri: update to 1.16.2
* aws-sdk-wafv2: update to 1.76.0
* aws-sdk-glue: update to 1.168.0
* flay: update to 2.13.2