### PR TITLE
gems: add sqlite3

### DIFF
--- a/lib/oeqa/runtime/cases/rubygems_rubygems_sqlite3.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_sqlite3.py
@@ -1,0 +1,9 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_sqlite3(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_sqlite3(self):
+        self.gem_is_installed("sqlite3")
+
+    def test_load_sqlite3(self):
+        self.gem_is_loadable("sqlite3")

--- a/packagegroups-rubygems/packagegroup-rubygems.bb
+++ b/packagegroups-rubygems/packagegroup-rubygems.bb
@@ -295,6 +295,7 @@ RDEPENDS:${PN} += "\
     rubygems-simplecov-json-formatter \
     rubygems-slop \
     rubygems-specinfra \
+    rubygems-sqlite3 \
     rubygems-sslshake \
     rubygems-strings \
     rubygems-strings-ansi \

--- a/recipes-rubygems/rubygems-sqlite3_1.7.2.bb
+++ b/recipes-rubygems/rubygems-sqlite3_1.7.2.bb
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: sqlite3"
+DESCRIPTION = "Ruby library to interface with the SQLite3 database engine (http://www.sqlite.org)"
+HOMEPAGE = "https://github.com/sparklemotion/sqlite3-ruby"
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=f24ce0d57c8f8576a36e2803d35bcfec"
+
+EXTRA_DEPENDS:append = " sqlite3"
+EXTRA_RDEPENDS:append = " sqlite3"
+
+DEPENDS:class-native += "\
+    rubygems-mini-portile2-native \
+"
+
+GEM_INSTALL_FLAGS:append = " \
+    --platform=ruby -- \
+    --enable-system-libraries \
+"
+
+SRC_URI[md5sum] = "792ea16701e163ba4f49f18d296d3509"
+SRC_URI[sha256sum] = "16050775fea3095035c8d4cb33968523e8ef411ac2d6bfa5f27d4c2b119cfd8c"
+
+GEM_NAME = "sqlite3"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS:${PN}:class-target += "\
+    rubygems-mini-portile2 \
+"
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
Add a Gem to allow Ruby programs to use the SQLite3 serverless database engine.

Requires that libsqlite3 is already compiled and installed on your target, because one might prefer special compile time options or extensions for SQLite3 tailored for the target machine.

See https://github.com/sparklemotion/sqlite3-ruby