### PR TITLE
sqlite3: don't install source code

### DIFF
--- a/recipes-rubygems/rubygems-sqlite3_1.7.2.bb
+++ b/recipes-rubygems/rubygems-sqlite3_1.7.2.bb
@@ -27,6 +27,11 @@ inherit rubygems
 inherit rubygentest
 inherit pkgconfig
 
+do_install:append() {
+    # remove sqlite3 source code
+    rm -rf ${D}${libdir}/ruby/gems/${GEMLIB_VERSION}/gems/${GEM_NAME}-${PV}/ports
+}
+
 RDEPENDS:${PN}:class-target += "\
     rubygems-mini-portile2 \
 "


### PR DESCRIPTION
Remove the SQLite3 source code (tarball) to reduce the footprint of the Gem. We don't need it and it's a waste of resources on memory constrained devices.