### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.958.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.958.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f2a44c25a64fb4813a49579a1f595439"
-SRC_URI[sha256sum] = "ed1b897122426f019c1d4d6187baf659212a6adea880d72d61c196b843842689"
+SRC_URI[md5sum] = "e71691c8cd9c7edab83c626b74d6c156"
+SRC_URI[sha256sum] = "a4cd09bb05c8bbf906318b8eb8a14c6a5d57e34da5190ca6e565dc83886457f3"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-applicationautoscaling_1.90.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-applicationautoscaling_1.90.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "0a7fb949af9b9f30e1a1b2b759363998"
-SRC_URI[sha256sum] = "c7cc3b334ddf2e1569e4abd9e6044dcfd9e4110fe3ab0542f8923347a2882606"
+SRC_URI[md5sum] = "8406a068cd5dd436bd0b3ed54534bffa"
+SRC_URI[sha256sum] = "8c036efae39efa26f29c5cf5da1f59ebb59d0db6c11e724c54f8c8b43aff99a1"
 
 GEM_NAME = "aws-sdk-applicationautoscaling"
 

--- a/recipes-rubygems/rubygems-aws-sdk-codecommit_1.72.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-codecommit_1.72.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "bc23fdef3c0c3035486bd5747a3e2245"
-SRC_URI[sha256sum] = "738e1a83b0ce29adde926946e61090dca1658bf85afe3eb978d20b40cd1e113f"
+SRC_URI[md5sum] = "ad821da94344db9258f641ae834f63a2"
+SRC_URI[sha256sum] = "db642ca21ff9863068d75a18d5c4620ba74bcacf2ddbc9ad548cb8ca118469ff"
 
 GEM_NAME = "aws-sdk-codecommit"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.201.3.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.201.3.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "71c181486c776fc81a5b731648893abb"
-SRC_URI[sha256sum] = "6b595926c33aadc5fc61026260b7f69adc55827ebdf9d9fa2205aad6207a26f4"
+SRC_URI[md5sum] = "4513d88fdfb723a7395290c3d54f9019"
+SRC_URI[sha256sum] = "c045a7ff37b4a6f1de5742e64def0841bdf70d215cb17d3875b2c5bdd9e99d52"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-dynamodb_1.118.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-dynamodb_1.118.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "5a3372a07ccc400eec1e000cbee78246"
-SRC_URI[sha256sum] = "e07c59bc938719d25b5028a60404210a6eaff4108e11f55ba961037bddb649fa"
+SRC_URI[md5sum] = "4d5de63cc47accda49452c36853a106b"
+SRC_URI[sha256sum] = "f3b3f82236a39f248708ad928369beba6ce4cd2b9e935ee1711c47c0760b043e"
 
 GEM_NAME = "aws-sdk-dynamodb"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.467.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.467.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "cf202d1bde3f6b82cc4ca7e88da50eb0"
-SRC_URI[sha256sum] = "17a32aaed1d1e0c0c078e4a68bd5cf336eafa96acbbace938cbe80c35a80a17f"
+SRC_URI[md5sum] = "4b8f90993610214036a661e2ed9506ac"
+SRC_URI[sha256sum] = "c9804ef4a5938b8437180d40592149fad0f8b5794868db2b9294a547d98909fb"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecr_1.79.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecr_1.79.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e54eeb85ad4a996692b6c648255aed4d"
-SRC_URI[sha256sum] = "9474595bd9d9a328cc81a5c4ed7d1370526a3ee6d3ae9d8e853731697cda104d"
+SRC_URI[md5sum] = "e53c700b4abf3430e1514e31632f6bf8"
+SRC_URI[sha256sum] = "3f6a126f4259c4c0c39b3946ef21214d2ad05b8857c1535e0f663d7019d73728"
 
 GEM_NAME = "aws-sdk-ecr"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eks_1.111.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eks_1.111.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "3f1ddc9c6aad4cabd74aa6a5753e982b"
-SRC_URI[sha256sum] = "c13081b30f9bfe2fe4d93b9fe7aab3d281a49e3b8767696c5ed87a7275ae8c3f"
+SRC_URI[md5sum] = "dec77c6c45e5414af3d1bf8ee59d539a"
+SRC_URI[sha256sum] = "3a7aebced583a170eb84dbe10d8a3345ca3bb17cceb874ce4d53d3993651bb50"
 
 GEM_NAME = "aws-sdk-eks"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticloadbalancingv2_1.109.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticloadbalancingv2_1.109.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c22d176b05ab4948221d4c3d71599af4"
-SRC_URI[sha256sum] = "bb656f064e04a585da3806e14b4db50cdd1f9891236dfe14cd56b5ba2e1787d8"
+SRC_URI[md5sum] = "ad3a3944c8aa4ebc453cb7cd7fd52d4f"
+SRC_URI[sha256sum] = "a21379e41db4984fd61141654659084e8ebcdf31cfb34ed62423df25e2f210e7"
 
 GEM_NAME = "aws-sdk-elasticloadbalancingv2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-networkfirewall_1.48.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-networkfirewall_1.48.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6477598c64386429cc14d091585ce6a0"
-SRC_URI[sha256sum] = "4df007118b14c60f3604bbb439dbf9f58b2f7ade57621454eabdae1ed452c3ee"
+SRC_URI[md5sum] = "7605bddb3943d93e5b4dd11438db2889"
+SRC_URI[sha256sum] = "b23c0e0dbae2c642ec3d80a472a7cc7d84dd968aee10c734f982b2c31d507e26"
 
 GEM_NAME = "aws-sdk-networkfirewall"
 

--- a/recipes-rubygems/rubygems-aws-sdk-states_1.73.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-states_1.73.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f683641f6ac3a6224a43f4e70651db8e"
-SRC_URI[sha256sum] = "4a50138662f2c3f30a13f9669a8eb2e2b3fb4e555398743697bd4b1e15b32748"
+SRC_URI[md5sum] = "64ebcc2b6e4cab1eab7ca9e43d5f7182"
+SRC_URI[sha256sum] = "b7d89796b5541086d125f06ae3d81f257e1d1d72909937f59bb192698626a93b"
 
 GEM_NAME = "aws-sdk-states"
 

--- a/recipes-rubygems/rubygems-aws-sigv4_1.9.0.bb
+++ b/recipes-rubygems/rubygems-aws-sigv4_1.9.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "586f3e0e914c67bae0b8793e64347c03"
-SRC_URI[sha256sum] = "84dd99768b91b93b63d1d8e53ee837cfd06ab402812772a7899a78f9f9117cbc"
+SRC_URI[md5sum] = "f4e1d798cd88d0e2ef4fec78613fea7f"
+SRC_URI[sha256sum] = "32d0807a1d613373bec44fe3e18d4786834c85fd75bb9c233f215aae7066fd5a"
 
 GEM_NAME = "aws-sigv4"
 

--- a/recipes-rubygems/rubygems-bson_5.0.1.bb
+++ b/recipes-rubygems/rubygems-bson_5.0.1.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d9175b22169a5baee1270b70ea0b0f51"
-SRC_URI[sha256sum] = "8df40bededc42e4b990af6978cc923dc69355b9caf60a3d8d197e4c64ea851f3"
+SRC_URI[md5sum] = "c55039e3e0467616cae9f04f836c6954"
+SRC_URI[sha256sum] = "5781d19ae352fe0d3078eed9ae3305504b87aafe0cc4ee57343b2f986fa9ffa5"
 
 GEM_NAME = "bson"
 

--- a/recipes-rubygems/rubygems-docile_1.4.1.bb
+++ b/recipes-rubygems/rubygems-docile_1.4.1.bb
@@ -4,10 +4,15 @@ DESCRIPTION = "Docile treats the methods of a given ruby object as a DSL (domain
 HOMEPAGE = "https://ms-ati.github.io/docile/"
 
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=e74ce31842082484e7525142a0cae01f"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b3f621a34beb804b35794f00084ef8c"
 
-SRC_URI[md5sum] = "346d8ca3988c5e5dab44d50545e9b239"
-SRC_URI[sha256sum] = "5f1734bde23721245c20c3d723e76c104208e1aa01277a69901ce770f0ebb8d3"
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "3de8db90caf04722a3e85224a0a4801e"
+SRC_URI[sha256sum] = "96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e"
 
 GEM_NAME = "docile"
 

--- a/recipes-rubygems/rubygems-facter_4.8.0.bb
+++ b/recipes-rubygems/rubygems-facter_4.8.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d3f01f858bc7b0a625d0ff0033730047"
-SRC_URI[sha256sum] = "9bdb64175b35024a7e44cbc7b56a30a34f206c2c5311b567d6ae5ad481d92217"
+SRC_URI[md5sum] = "fdcdbd04cb3aaee32c39e79a5ea05478"
+SRC_URI[sha256sum] = "0950375502fc2ec8a0e55d89d4610be639f6ce5418ab6c5df2205e90e6af6084"
 
 GEM_NAME = "facter"
 

--- a/recipes-rubygems/rubygems-faraday-net-http_3.1.1.bb
+++ b/recipes-rubygems/rubygems-faraday-net-http_3.1.1.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6fe5aae7b80b61ae48027a03d6757d31"
-SRC_URI[sha256sum] = "1627be414960d0131691190ff524506ba6607402a50fb6eccda9e64ca60f859f"
+SRC_URI[md5sum] = "d05335790ec8355796f74974d2846e5b"
+SRC_URI[sha256sum] = "da93f0f426f4de2c09af0a9a95887726da7889b76eca2a2aff0ce5e66e768938"
 
 GEM_NAME = "faraday-net_http"
 

--- a/recipes-rubygems/rubygems-google-apis-admin-directory-v1_0.58.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-admin-directory-v1_0.58.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e6462d40938ebd98f5f35321c1be9890"
-SRC_URI[sha256sum] = "a57ca0b14b471d65768f228f7fb2c0b3d3e19d666d0ce30edddd18d2ca54f34c"
+SRC_URI[md5sum] = "2a8f0251727460a417e7ba500cd02cbe"
+SRC_URI[sha256sum] = "da5ce7cbbca5c7587967ba793f545d6207f09560c4f4f8814679029bcc280bde"
 
 GEM_NAME = "google-apis-admin_directory_v1"
 

--- a/recipes-rubygems/rubygems-google-apis-compute-v1_0.102.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-compute-v1_0.102.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9a63ddd8087a319b182db76af8b57943"
-SRC_URI[sha256sum] = "1dea57ab0a579424305aac3219cbd70196b6f3e0d1c6387e1412e3b676c25f3f"
+SRC_URI[md5sum] = "79cde39fa2ea5ecbf4902c7077b8ced4"
+SRC_URI[sha256sum] = "8cb711823a07a394cecaa310d994a0b61aab37e5341ee7e10d520604e7908e2d"
 
 GEM_NAME = "google-apis-compute_v1"
 

--- a/recipes-rubygems/rubygems-google-apis-discovery-v1_0.18.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-discovery-v1_0.18.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b9509c84d1fbc06721dc806179b0a676"
-SRC_URI[sha256sum] = "b994027418db57f31e9c00c450a5a2faf3df58c037dde3c5f2798a3492fed433"
+SRC_URI[md5sum] = "8286ac81436dc3d8410f52386120392f"
+SRC_URI[sha256sum] = "75c9c4e0988104461afdc46668198891e0eea9f7739dcd7a7fce2de9ec4a5939"
 
 GEM_NAME = "google-apis-discovery_v1"
 

--- a/recipes-rubygems/rubygems-google-apis-iam-v1_0.61.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-iam-v1_0.61.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "0d93ed0be3a9972205d93676ff5c44ac"
-SRC_URI[sha256sum] = "3ef109ad70fce0704ee132dc80f93f8dea0104119e4e9da71fdb9e73a904aae2"
+SRC_URI[md5sum] = "81cab41a4e44f2aa454385b0fd8d1b78"
+SRC_URI[sha256sum] = "7ef914b36e3ed1731176ee80593b6482717d6386824591525bb1b6a3865a4b48"
 
 GEM_NAME = "google-apis-iam_v1"
 

--- a/recipes-rubygems/rubygems-google-apis-monitoring-v3_0.65.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-monitoring-v3_0.65.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "4e8aa4047711d84fdf12cab7f646e575"
-SRC_URI[sha256sum] = "88b10242a251dc09bbd1a7298bc42127052fbfc27cda12bb2f3b31aadf971d5b"
+SRC_URI[md5sum] = "1c1c7c59a5fbc5a7a57665d31fe77b64"
+SRC_URI[sha256sum] = "f205bc0cd97822ed6e4bdc1ff30e71ae3bc7238417806e38aa2997d3c9a88af6"
 
 GEM_NAME = "google-apis-monitoring_v3"
 

--- a/recipes-rubygems/rubygems-google-apis-storage-v1_0.41.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-storage-v1_0.41.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c4518f683f7cbcc48b8c2ec455c2a138"
-SRC_URI[sha256sum] = "74342dd6870c38dc3a508d66080e78dd2d3c3a92e0e10dace3d51c1bf5448031"
+SRC_URI[md5sum] = "de0ab8e719529e0ffaa0ddda9fac2604"
+SRC_URI[sha256sum] = "f4bc658f473be622c61d39addd82a3b09ac168e9ba1fdc661cd112c5fa1271d9"
 
 GEM_NAME = "google-apis-storage_v1"
 

--- a/recipes-rubygems/rubygems-liquid_5.5.1.bb
+++ b/recipes-rubygems/rubygems-liquid_5.5.1.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "3fb32f72f0f802f0647eecc0676ac8be"
-SRC_URI[sha256sum] = "b3f8591f7a4c29f7d13e654ddddcf94386e8cdbb0ea8cbf8523b22b584b18e38"
+SRC_URI[md5sum] = "049244aeb7af07924688f34b796c7af6"
+SRC_URI[sha256sum] = "a6c29cda6e38d67313c466e35d531cb0529e3b73f3c0fedcfa39745233002e15"
 
 GEM_NAME = "liquid"
 

--- a/recipes-rubygems/rubygems-public-suffix_6.0.1.bb
+++ b/recipes-rubygems/rubygems-public-suffix_6.0.1.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b0ffac71adde79d4485441ad2ed0b53f"
-SRC_URI[sha256sum] = "d2c8e12e076813f8fca0307205c088c6903adc70b92c65ab22479dfa9bc0a89e"
+SRC_URI[md5sum] = "12ec93094a3467364c8c6ee5a6e8325a"
+SRC_URI[sha256sum] = "61d44e1cab5cbbbe5b31068481cf16976dd0dc1b6b07bd95617ef8c5e3e00c6f"
 
 GEM_NAME = "public_suffix"
 

--- a/recipes-rubygems/rubygems-puppet_8.8.1.bb
+++ b/recipes-rubygems/rubygems-puppet_8.8.1.bb
@@ -14,6 +14,7 @@ DEPENDS:class-native += "\
     rubygems-deep-merge-native \
     rubygems-facter-native \
     rubygems-fast-gettext-native \
+    rubygems-getoptlong-native \
     rubygems-locale-native \
     rubygems-multi-json-native \
     rubygems-puppet-resource-api-native \
@@ -23,8 +24,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "0fca1575e378a8c84c1284041c146480"
-SRC_URI[sha256sum] = "15753248428f4013e175b10d1039ae0e1da3661a1a2a0ef9c9dfff1b5af3d906"
+SRC_URI[md5sum] = "2f039fa86f8bd02e1258bca40dcc9b6b"
+SRC_URI[sha256sum] = "51733019f7f40fc985f916e89b289c481718c1a4a75edaba8b2dda61d5c4526c"
 
 GEM_NAME = "puppet"
 
@@ -46,6 +47,7 @@ RDEPENDS:${PN}:class-target += "\
     rubygems-deep-merge \
     rubygems-facter \
     rubygems-fast-gettext \
+    rubygems-getoptlong \
     rubygems-locale \
     rubygems-multi-json \
     rubygems-puppet-resource-api \

--- a/recipes-rubygems/rubygems-specinfra_2.90.0.bb
+++ b/recipes-rubygems/rubygems-specinfra_2.90.0.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6f37ad18a087c8300c3ac1ab94e6ef2e"
-SRC_URI[sha256sum] = "acc2f1b04bdfa6e8225e1aa7c9fc0349125a40f25cfa3a6dd2c637d8be24c302"
+SRC_URI[md5sum] = "751f39f467a9aaedf65ca5d08a8f3c68"
+SRC_URI[sha256sum] = "b96ae1fe9f309012796ec4777e5542d8ba939727c886932b015379d1e8671724"
 
 GEM_NAME = "specinfra"
 


### PR DESCRIPTION
* aws-sigv4: update to 1.9.0
* aws-sdk-core: update to 3.201.3
* aws-sdk-dynamodb: update to 1.118.0
* aws-sdk-codecommit: update to 1.72.0
* aws-sdk-networkfirewall: update to 1.48.0
* google-apis-monitoring_v3: update to 0.65.0
* google-apis-storage_v1: update to 0.41.0
* google-apis-iam_v1: update to 0.61.0
* aws-sdk-applicationautoscaling: update to 1.90.0
* bson: update to 5.0.1
* aws-sdk-ecr: update to 1.79.0
* faraday-net_http: update to 3.1.1
* google-apis-compute_v1: update to 0.102.0
* aws-sdk-ec2: update to 1.467.0
* public_suffix: update to 6.0.1
* facter: update to 4.8.0
* aws-sdk-elasticloadbalancingv2: update to 1.109.0
* docile: update to 1.4.1
* specinfra: update to 2.90.0
* aws-sdk-eks: update to 1.111.0
* google-apis-admin_directory_v1: update to 0.58.0
* liquid: update to 5.5.1
* google-apis-discovery_v1: update to 0.18.0
* aws-sdk-states: update to 1.73.0
* puppet: update to 8.8.1