### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.965.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.965.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "0d6e7affa0c506b848b23ba996977267"
-SRC_URI[sha256sum] = "652945df9887bb9185fa36ac29eb63ab4e91622d3ceb79de21fea4bf425356ff"
+SRC_URI[md5sum] = "d6680da49d04824caf36f2a3de3f30f9"
+SRC_URI[sha256sum] = "5b9486c44677277c32e7e5cd0fac03113660791ccf0c0cfc9c54efa3f42f0e09"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-amplify_1.66.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-amplify_1.66.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b8222be0c73a8ef3751052523cfc2f12"
-SRC_URI[sha256sum] = "49d99810fd69f77a0bca4160d46b4be2ee1c8027884a0b78593f5590e75806a8"
+SRC_URI[md5sum] = "d7835415d5c706ae2ffb7c37c8807288"
+SRC_URI[sha256sum] = "b8557ead84d2afc0d8df6bacfc2a0f2c254859c7192aaf1ac6bdd68544f8619c"
 
 GEM_NAME = "aws-sdk-amplify"
 

--- a/recipes-rubygems/rubygems-aws-sdk-batch_1.95.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-batch_1.95.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d3f641b35ea8c9a4d262ebc81468dafc"
-SRC_URI[sha256sum] = "da4b537458b57abd9fd4d604a1243c2196591405266f7e09de5bd682d6144fbd"
+SRC_URI[md5sum] = "5599a1ce143617652d866c56d7454002"
+SRC_URI[sha256sum] = "fb3528d1348b1261a1ea45877a900218d348625c406b1a4db4b6e3a0c8b43f17"
 
 GEM_NAME = "aws-sdk-batch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-configservice_1.114.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-configservice_1.114.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "39155dbf2a0921e266e7eb8b06bdf8f5"
-SRC_URI[sha256sum] = "aedfdae52fcfb24aead31dc05b97227bb5eb4b33b460b9eec6cc9f7c575a5128"
+SRC_URI[md5sum] = "f44ac45fdb404e842c84bbdd1437d6f6"
+SRC_URI[sha256sum] = "83d3e60bf05eca88762a4464571212c3343ae5bfa47a44907fffc5b98b87b4b4"
 
 GEM_NAME = "aws-sdk-configservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.201.5.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.201.5.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "3601b6fc8e1e45060c2f5dabb5d5f067"
-SRC_URI[sha256sum] = "5f1b8dd75abfe0694557471856cfcda97277a423b221fe9c286047e8ee60f82c"
+SRC_URI[md5sum] = "e7b6131e2653d7db64cab0a81d005f2b"
+SRC_URI[sha256sum] = "1848c52fa93118cf527f2b2a70196b1fe4586f4d37dca8ffb86365b5df19ac50"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.469.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.469.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c2f726cb3e7799960864cd4995d38881"
-SRC_URI[sha256sum] = "4af238ce719c09d480a20d763f1508a764713535bdfa1a08d6d4d7493cd2da37"
+SRC_URI[md5sum] = "e9aac12389dbd547207f662cb1b1f05b"
+SRC_URI[sha256sum] = "b525ae8a14217cfd7e844955bcabf7f2e6c328bef4dd4d8c5f45e61e9624ad2b"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.153.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.153.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d40068b94926b919fa0de00ea804a50a"
-SRC_URI[sha256sum] = "648695119f81194e43c8339561e5ffac9f89d7fabfdbf9c44c24b604dabad763"
+SRC_URI[md5sum] = "d53df1c9551ca1b01e838ccfdca8fba8"
+SRC_URI[sha256sum] = "ba95ac5493227527957a57dff5c654f3caf0a6bb5be4e4a6f53fa034fde44e8f"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eks_1.112.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eks_1.112.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "dec77c6c45e5414af3d1bf8ee59d539a"
-SRC_URI[sha256sum] = "3a7aebced583a170eb84dbe10d8a3345ca3bb17cceb874ce4d53d3993651bb50"
+SRC_URI[md5sum] = "36cc4aeb6d130528b5643d172ab19caa"
+SRC_URI[sha256sum] = "a8f002a6d1e5f7f9d846334c2e4136550396ba6c4c07f2cd1951f91bfd4a892e"
 
 GEM_NAME = "aws-sdk-eks"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.189.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.189.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "623f413b0def2c7c9a94f3fba009339c"
-SRC_URI[sha256sum] = "b1460f5d9e12d57653eade7118b7011e788c5d503107eeeb54c866377c6615e1"
+SRC_URI[md5sum] = "ebae29da816daf0fae72d35b4f391964"
+SRC_URI[sha256sum] = "871c19f4e6102d68a1823200ba0114c64662b32b3462a4d0b8153e6307d46adf"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-iam_1.105.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-iam_1.105.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "14b14f40be2e23b7525eb9fe2fbc6570"
-SRC_URI[sha256sum] = "8d020093d029b726eb1e814cd1ab4a1629c1cc2b56ef9cbcc078f44b459e4b06"
+SRC_URI[md5sum] = "7c3f344700484f92372c1de1659fb6d7"
+SRC_URI[sha256sum] = "7bc61f194f7ace03ca413208b60beab5ee80f893e6ba67267527e2de55f52c7a"
 
 GEM_NAME = "aws-sdk-iam"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.158.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.158.0.bb
@@ -17,8 +17,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "4449348ea145ce8f15d7425855380162"
-SRC_URI[sha256sum] = "e1e0c7a268e710a7ccf4a0f9d2c33e3ca685b06968c3048d907e3a792580e990"
+SRC_URI[md5sum] = "d7091eb3e43e524ec954951bac694d2a"
+SRC_URI[sha256sum] = "35d68b49d64523a9bc53245885f15be40b7953cf481132abfef137d02ca6b2a6"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-google-apis-compute-v1_0.104.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-compute-v1_0.104.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "963a4f0bfbdfe42d16c2c01c444f6d75"
-SRC_URI[sha256sum] = "e837ba6cebdcd57720ce05b8a91df42f114c2105bb4546f6b84d9134a1bc222f"
+SRC_URI[md5sum] = "8a654ac0f7cc15d9a02ca05689d62b9c"
+SRC_URI[sha256sum] = "fecc7c2e1af1cfa8f61ea9d0f94f8f8dee12c6105fbc27366984eb5bd7e8c471"
 
 GEM_NAME = "google-apis-compute_v1"
 

--- a/recipes-rubygems/rubygems-google-apis-monitoring-v3_0.67.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-monitoring-v3_0.67.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "668e23be8eed9adcf5ab14e910cac089"
-SRC_URI[sha256sum] = "8d4b7586b1bfbef7ac5ecb99c97dc2bf6dd231916dbbc4198316373fe7feac7b"
+SRC_URI[md5sum] = "b32cfd9c27432fea6bc200e3fc769506"
+SRC_URI[sha256sum] = "d4c222b3c83488f8b0570c0f04ae5767639454a21380a0b7cfb0f2308af6d527"
 
 GEM_NAME = "google-apis-monitoring_v3"
 

--- a/recipes-rubygems/rubygems-google-apis-storage-v1_0.42.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-storage-v1_0.42.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "de0ab8e719529e0ffaa0ddda9fac2604"
-SRC_URI[sha256sum] = "f4bc658f473be622c61d39addd82a3b09ac168e9ba1fdc661cd112c5fa1271d9"
+SRC_URI[md5sum] = "127ff9da5169cea639707d3cf44f54c7"
+SRC_URI[sha256sum] = "24f6f340b7bc68459a62e32a3ac6b97468c5926fb47a56a6374948784c232a5e"
 
 GEM_NAME = "google-apis-storage_v1"
 

--- a/recipes-rubygems/rubygems-http-cookie_1.0.7.bb
+++ b/recipes-rubygems/rubygems-http-cookie_1.0.7.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9f7c37bcfe0dced6084d64e68dc0eea5"
-SRC_URI[sha256sum] = "7713d3196f21ff5ab0944011d7d4e619b62ec082374a52de2193ccfe78924044"
+SRC_URI[md5sum] = "7a5bfcf99eb243ca9d852386ad2b285f"
+SRC_URI[sha256sum] = "cb7a399f3344f720b8a0f3b0765f29b62608ebb9c3ce4abf4d6eeff2caf42253"
 
 GEM_NAME = "http-cookie"
 

--- a/recipes-rubygems/rubygems-parallel_1.26.3.bb
+++ b/recipes-rubygems/rubygems-parallel_1.26.3.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "4534c3e13f3b77e8d7e5066bbb54b9bc"
-SRC_URI[sha256sum] = "968fb64946c8bb29fc115c144b583a366cf10fab890cc62feb41d6615791e23e"
+SRC_URI[md5sum] = "4d194538d7413eaec77d472d4ea58be1"
+SRC_URI[sha256sum] = "d86babb7a2b814be9f4b81587bf0b6ce2da7d45969fab24d8ae4bf2bb4d4c7ef"
 
 GEM_NAME = "parallel"
 

--- a/recipes-rubygems/rubygems-sqlite3_2.0.4.bb
+++ b/recipes-rubygems/rubygems-sqlite3_2.0.4.bb
@@ -23,8 +23,8 @@ GEM_INSTALL_FLAGS:append = " \
     --platform=ruby \
 "
 
-SRC_URI[md5sum] = "efda830162ef961ca5a36e3b47fc1d8f"
-SRC_URI[sha256sum] = "182dbeddea1fc27cdee94f19f1c0ad42565bf65c24193f488eb2c33184b722d0"
+SRC_URI[md5sum] = "650a15a6e7b5da6343c9b065316ed927"
+SRC_URI[sha256sum] = "aace56b02b3932efa2e25d3dec6f7fb67b65f9df8266aad3ba4fdc4fe520918a"
 
 GEM_NAME = "sqlite3"
 


### PR DESCRIPTION
* aws-sdk-core: update to 3.201.5
* http-cookie: update to 1.0.7
* aws-sdk-s3: update to 1.158.0
* parallel: update to 1.26.3
* google-apis-compute_v1: update to 0.104.0
* aws-sdk-glue: update to 1.189.0
* aws-sdk-ecs: update to 1.153.0
* google-apis-monitoring_v3: update to 0.67.0
* aws-sdk-eks: update to 1.112.0
* aws-sdk-configservice: update to 1.114.0
* aws-sdk-ec2: update to 1.469.0
* aws-sdk-batch: update to 1.95.0
* google-apis-storage_v1: update to 0.42.0
* aws-sdk-iam: update to 1.105.0
* aws-sdk-amplify: update to 1.66.0
* sqlite3: update to 2.0.4