### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.970.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.970.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "5e1e2d5a688680091b7933d3389c4635"
-SRC_URI[sha256sum] = "49f83f7e4a027fb2c37d6c4b9141ffece7e547f285d7282ee5819ccd69cee454"
+SRC_URI[md5sum] = "bcaec576085a18abed80dc40d7b78a31"
+SRC_URI[sha256sum] = "88afd3c8627af3828113a3976b302fb4827e74d700b5287de59de83eefe58e0d"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.89.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.89.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d5e28d186ebe8bc07173092fea8dff54"
-SRC_URI[sha256sum] = "eaa85ca7ed3026ff5bb41b9d5a43350d3db0ed2803a82b82351e4ee8a96291b9"
+SRC_URI[md5sum] = "2c84a6674cc26a4480b05fbfc3f13fcb"
+SRC_URI[sha256sum] = "d95b86fb903849759ae0331ff768952a0e39b9a94c087a646eeb573f08196e92"
 
 GEM_NAME = "aws-sdk-cloudwatchlogs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.202.2.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.202.2.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e7b6131e2653d7db64cab0a81d005f2b"
-SRC_URI[sha256sum] = "1848c52fa93118cf527f2b2a70196b1fe4586f4d37dca8ffb86365b5df19ac50"
+SRC_URI[md5sum] = "d10aafa67faccd48f61bbc2c44cf2397"
+SRC_URI[sha256sum] = "732a51d71938db90aab5dcb6fe9c86f023c0b431b350b324ecff16efcc667092"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.471.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.471.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1cd1ef001d1f483a592d6b79c7fd1c57"
-SRC_URI[sha256sum] = "ce9d1896a0ed550bf27d3ea95b505d3d5e749f45187687a0a418fb9f7e99ff7c"
+SRC_URI[md5sum] = "4b0b5c7e1a5ce63de428e88cae16f117"
+SRC_URI[sha256sum] = "0d3947185db72afd93795f5079c69d96bbdc2faedac9f324f503358c75a65c7f"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-states_1.74.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-states_1.74.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "64ebcc2b6e4cab1eab7ca9e43d5f7182"
-SRC_URI[sha256sum] = "b7d89796b5541086d125f06ae3d81f257e1d1d72909937f59bb192698626a93b"
+SRC_URI[md5sum] = "2cd5afc8f5f8bf8f0762d181ad10f61e"
+SRC_URI[sha256sum] = "24fdc4b49914fa8fb4c359466201e3720a08a276255ca7a5e74b12917eab8791"
 
 GEM_NAME = "aws-sdk-states"
 

--- a/recipes-rubygems/rubygems-aws-sdk-wafv2_1.89.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-wafv2_1.89.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "93628866ac3b4db35459f7e718088e7a"
-SRC_URI[sha256sum] = "ddb588074e333a32bd1fb1df614ec4f2b918084eeccee4808da9e51c28baebc8"
+SRC_URI[md5sum] = "d197d82368e98ce577ef3196efe23773"
+SRC_URI[sha256sum] = "4052400cdc1e2f9bfbd688f8d8d57743debc331243ac8b6c2be32b5e33d67540"
 
 GEM_NAME = "aws-sdk-wafv2"
 

--- a/recipes-rubygems/rubygems-faraday-net-http_3.3.0.bb
+++ b/recipes-rubygems/rubygems-faraday-net-http_3.3.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "2bf9d604ca9fb2c5e19b6281c76808d7"
-SRC_URI[sha256sum] = "a3152bc61bb164b8f9dd30ee45c03c79d10085a8f02a322dbd66ed92ee2e4c71"
+SRC_URI[md5sum] = "7e6378aaa271587dd4109795c0a05769"
+SRC_URI[sha256sum] = "93e6b0f679b1e8e358bcb4e983a52328dfc47ebbe6a232e4f9e8aba9c924e565"
 
 GEM_NAME = "faraday-net_http"
 

--- a/recipes-rubygems/rubygems-faraday_2.11.0.bb
+++ b/recipes-rubygems/rubygems-faraday_2.11.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "39761271dd1afc1eb98dc03d723382ad"
-SRC_URI[sha256sum] = "6bc9fba3f6191684449d94215195b2c43e2a07bd40b321d245881450923d9a80"
+SRC_URI[md5sum] = "c35ce61672c53029a00ad0ae2b61124f"
+SRC_URI[sha256sum] = "e6ead2c9aa1304107d3bb342e9f930cf7e649a71e3ec1e782c3256672f19ed02"
 
 GEM_NAME = "faraday"
 

--- a/recipes-rubygems/rubygems-google-apis-storage-v1_0.44.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-storage-v1_0.44.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6abfd133b43e31360b72b6703a092f55"
-SRC_URI[sha256sum] = "aa4ac2fea4b7ebeece0c4f13cfcc046ea6678a2717cd9b8a080aae358eaa0a51"
+SRC_URI[md5sum] = "26bb714cda1c5f10e54d3bbc385b1c06"
+SRC_URI[sha256sum] = "523eb64ff4ea4fdb76ad52b64a9deca38f6bbe4e1ade9e27b452a7aef4fb431c"
 
 GEM_NAME = "google-apis-storage_v1"
 

--- a/recipes-rubygems/rubygems-google-cloud-env_2.2.0.bb
+++ b/recipes-rubygems/rubygems-google-cloud-env_2.2.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "0175a2ce93b53f42141e8b24acef763f"
-SRC_URI[sha256sum] = "cf4bb8c7d517ee1ea692baedf06e0b56ce68007549d8d5a66481aa9f97f46999"
+SRC_URI[md5sum] = "3543ee0872e8b37ff5d0f3f0c8e1df6f"
+SRC_URI[sha256sum] = "12091202a6dba77a7b749714797ccde8137ed8b7cbdd4048c116c108ad8b9c6e"
 
 GEM_NAME = "google-cloud-env"
 

--- a/recipes-rubygems/rubygems-thor_1.3.2.bb
+++ b/recipes-rubygems/rubygems-thor_1.3.2.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f8e40a78ed7e67821a7afa82e1c172a7"
-SRC_URI[sha256sum] = "fa7e3471d4f6a27138e3d9c9b0d4daac9c3d7383927667ae83e9ab42ae7401ef"
+SRC_URI[md5sum] = "101b7c60d468c9affc74649d1a4ec010"
+SRC_URI[sha256sum] = "eef0293b9e24158ccad7ab383ae83534b7ad4ed99c09f96f1a6b036550abbeda"
 
 GEM_NAME = "thor"
 


### PR DESCRIPTION
* aws-sdk-core: update to 3.202.2
* faraday: update to 2.11.0
* thor: update to 1.3.2
* aws-sdk-states: update to 1.74.0
* google-apis-storage_v1: update to 0.44.0
* aws-sdk-wafv2: update to 1.89.0
* aws-sdk-ec2: update to 1.471.0
* aws-sdk-cloudwatchlogs: update to 1.89.0
* google-cloud-env: update to 2.2.0