### PR TITLE
ci: use ubuntu-22.04 as base

### DIFF
--- a/.github/workflows/cron-master-qemu86-64-bump.yml
+++ b/.github/workflows/cron-master-qemu86-64-bump.yml
@@ -21,7 +21,7 @@ jobs:
       TOPDIR: /opt/build
       TEMPLATECONF: /opt/build/sources/meta-rubygems/conf/templates/rubygems-arm64-glibc
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     container:
       image: privkweihmann/yocto-sca-minimal:2004

--- a/.github/workflows/cron-master-qemu86-64-pkgupdate.yml
+++ b/.github/workflows/cron-master-qemu86-64-pkgupdate.yml
@@ -21,7 +21,7 @@ jobs:
       TOPDIR: /opt/build
       TEMPLATECONF: /opt/build/sources/meta-rubygems/conf/templates/rubygems-arm64-glibc
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     container:
       image: privkweihmann/yocto-sca-minimal:2004

--- a/.github/workflows/pr-flake8.yml
+++ b/.github/workflows/pr-flake8.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   check:
     name: "build"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     container:
       image: privkweihmann/yocto-sca-minimal:2004

--- a/.github/workflows/pr-master-qemu86-64-glibc.yml
+++ b/.github/workflows/pr-master-qemu86-64-glibc.yml
@@ -20,7 +20,7 @@ jobs:
       TOPDIR: /opt/build
       TEMPLATECONF: /opt/build/sources/meta-rubygems/conf/templates/rubygems-arm64-glibc
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     container:
       image: privkweihmann/yocto-sca-minimal:2004

--- a/.github/workflows/pr-oelint.yml
+++ b/.github/workflows/pr-oelint.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   check:
     name: "build"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     container:
       image: privkweihmann/yocto-sca-minimal:2004

--- a/.github/workflows/push-master-qemu86-64-glibc.yml
+++ b/.github/workflows/push-master-qemu86-64-glibc.yml
@@ -19,7 +19,7 @@ jobs:
       TOPDIR: /opt/build
       TEMPLATECONF: /opt/build/sources/meta-rubygems/conf/templates/rubygems-arm64-glibc
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     container:
       image: privkweihmann/yocto-sca-minimal:2004


### PR DESCRIPTION
as github seems to ignore the container image,
or simply a ubuntu 24.04 host even from a container is unusable