### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.1042.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.1042.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "3821743637bffee2b0ae121dbcac2190"
-SRC_URI[sha256sum] = "bf58a2e51c822ae198023c3dc81918e4a214f80cc06b6ff2bcc44929ee6a41af"
+SRC_URI[md5sum] = "d7dd39f67cd43e5b46f0fe4c00796f65"
+SRC_URI[sha256sum] = "5f2f65576714652d77fa0f1220bfb71fa35d145a53816024a016b9abb5a25e01"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-batch_1.108.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-batch_1.108.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "493c1b138c0e401e1ed0912c776f88c3"
-SRC_URI[sha256sum] = "6a3c7195884bb16cc19a54fb59fc28458efa0e479fbdbf044a7428926ce4f853"
+SRC_URI[md5sum] = "5ab7e24dda13086e4995e106dda6eef4"
+SRC_URI[sha256sum] = "551660fce48bdbd9ab87e35af1ffadab18083b6ada8bb5dbdd5d9b5c86e033a2"
 
 GEM_NAME = "aws-sdk-batch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.99.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.99.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d4ad5ded169a5fb91a64a05e1e7b07d0"
-SRC_URI[sha256sum] = "9e8b19b9cfb0be99edaa0f8cc2f7a201894f0c9bce9bf4f53f4d5a9c6eee626e"
+SRC_URI[md5sum] = "b229e2419118770b114e3d41b86c3fcd"
+SRC_URI[sha256sum] = "e3167a32e93440c035ef470b0a133504f462eec99ab873b85fccdfa4171bde47"
 
 GEM_NAME = "aws-sdk-cloudtrail"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.107.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.107.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6845d487c593660782d3bfac46fc9e1d"
-SRC_URI[sha256sum] = "a026bbd782b93061122d33e42c67842db3f44e2abe9128be7cbbe0a0209fe667"
+SRC_URI[md5sum] = "e8500fe679a72748cdab4ed00f8d60ba"
+SRC_URI[sha256sum] = "031e0c364ef62fe2c83c2da431421ea2af138d70422675361d26aaaa3140368d"
 
 GEM_NAME = "aws-sdk-cloudwatchlogs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cognitoidentityprovider_1.114.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cognitoidentityprovider_1.114.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "0c048fd64a7211f2e16af21f0dbd11b2"
-SRC_URI[sha256sum] = "7cbd71f34df5a8724b3d79ffafbebc23aec403ad0e8ec20fd02ac8ad17fdbc56"
+SRC_URI[md5sum] = "f1f356c884b5c8fb638c73b2c7f55b30"
+SRC_URI[sha256sum] = "2cf9547aae35a7d9bef04564595a4e25d52664ca365cdafde107218d686ba808"
 
 GEM_NAME = "aws-sdk-cognitoidentityprovider"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.217.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.217.0.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "0978aebca926e5ecdf610993c798cad7"
-SRC_URI[sha256sum] = "0f87730b5216dbad36084426465515ae399f57b467c7b51c5cb8039f34971222"
+SRC_URI[md5sum] = "92c44ca2349294c9e26bda90a2d06031"
+SRC_URI[sha256sum] = "07ae702f80900653e0f93303a8d58e2963f0be9511cefd7d9b9c78100d14a479"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.502.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.502.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1235dc41ec58d5972efbb5b0e0d05773"
-SRC_URI[sha256sum] = "e3cc22149c75ea3a3b67c1199f829557c320214d5563181afe76d0d215d9d8eb"
+SRC_URI[md5sum] = "cd0e2d250bd2f322af7766b7e79b28b7"
+SRC_URI[sha256sum] = "3c3e74589969bb69cb0b8a1ea40ed9a184a8af396dae8252ff673ae3a6d52715"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eks_1.127.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eks_1.127.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "bbf2e27ce7ea850000c0840e0476c444"
-SRC_URI[sha256sum] = "12038e1279546a938b5767ad96101f4ac063110010a4fb7e299a918e6491003a"
+SRC_URI[md5sum] = "c328cf10c0e3ee74a2349d3a82191a2d"
+SRC_URI[sha256sum] = "f735d0b826f243ede0485e229b5f571acc1957e94761ebc7f02a3cecf4b74f93"
 
 GEM_NAME = "aws-sdk-eks"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.208.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.208.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "88aa465d0b61d0f08d5da5a22f1ec82b"
-SRC_URI[sha256sum] = "e44918b8ecaaff4c6627ed187bf4bbbead4f4b811dd491efcfe9ad7e956c0dd7"
+SRC_URI[md5sum] = "5aff824b399b72058e75cb3d556e7037"
+SRC_URI[sha256sum] = "86aea4eee80e71bf2da3a26a6d771e84ad9edff2f345ea3a28107b7b30646345"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-sns_1.94.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-sns_1.94.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "12fceecfcc36c57de2741292e2a5d68d"
-SRC_URI[sha256sum] = "5191a229b76fc6511a8f6a9860a4468bf9c153b3ffaad7a193d5e2f55a245b73"
+SRC_URI[md5sum] = "d4639917502ede8e91ce0a846d1ad845"
+SRC_URI[sha256sum] = "6cf0b27e045a5021c6a8925957e389d0bd570cca2485f33b50745caa4fd1f06d"
 
 GEM_NAME = "aws-sdk-sns"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ssm_1.188.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ssm_1.188.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "10f371133a40b876723196ec9fa33d3b"
-SRC_URI[sha256sum] = "19e9e93acdb48cdbc7d2da17731e24ee47ba7e01e28e6b00070367238b63d558"
+SRC_URI[md5sum] = "1069e1e770958e8f430dc938319e423a"
+SRC_URI[sha256sum] = "bfcbbb6e6246c3e3a4e6331f6433138621dbbb38bf0cf612942dab12477d2874"
 
 GEM_NAME = "aws-sdk-ssm"
 

--- a/recipes-rubygems/rubygems-aws-sdk-transfer_1.111.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-transfer_1.111.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "45620a94c04ccca7ccbf28a0a818be5d"
-SRC_URI[sha256sum] = "4294209bfdcee333e845cccd8aa5b3208cd314873e28e71953d184692cfd4dc7"
+SRC_URI[md5sum] = "ff47ff369c67384ab3666e659903d112"
+SRC_URI[sha256sum] = "23501ff0d8a3e1cb3610663652a92b9dc50fa451816e6320460f93d09bc73c5b"
 
 GEM_NAME = "aws-sdk-transfer"
 

--- a/recipes-rubygems/rubygems-dry-types_1.8.1.bb
+++ b/recipes-rubygems/rubygems-dry-types_1.8.1.bb
@@ -20,8 +20,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "218e63f0c86ffc01e55ea6b07aad41e5"
-SRC_URI[sha256sum] = "bdf444e0d2ff83f500271c7d38cb29690c2654fa78e588f68349a7b1e7341131"
+SRC_URI[md5sum] = "5c461535ca30312e3c369b04f515d976"
+SRC_URI[sha256sum] = "3fe395835763c64fb76f1076b564d718e0c2519afbfddb8ab5609a4724d70a95"
 
 GEM_NAME = "dry-types"
 

--- a/recipes-rubygems/rubygems-googleauth_1.13.1.bb
+++ b/recipes-rubygems/rubygems-googleauth_1.13.1.bb
@@ -21,8 +21,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "822a9bcb6e84af6a293f1b5d5b4ba709"
-SRC_URI[sha256sum] = "3d3177b1b253a9a3ce92222a91fcabcfad206cec2a5c823a6a251a6db4d8d67f"
+SRC_URI[md5sum] = "c7d0455e417fafe3ab7dbdf1cacedebb"
+SRC_URI[sha256sum] = "33448ce662e40afeb3e6db5eb9f4ee712467b1701f3857ef9c0aecac8447eca0"
 
 GEM_NAME = "googleauth"
 

--- a/recipes-rubygems/rubygems-i18n_1.14.7.bb
+++ b/recipes-rubygems/rubygems-i18n_1.14.7.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "30d3f1125a930ce4a4240793c2007f42"
-SRC_URI[sha256sum] = "dc229a74f5d181f09942dd60ab5d6e667f7392c4ee826f35096db36d1fe3614c"
+SRC_URI[md5sum] = "e4ebd0affe4111dd965eacbfff4aef30"
+SRC_URI[sha256sum] = "ceba573f8138ff2c0915427f1fc5bdf4aa3ab8ae88c8ce255eb3ecf0a11a5d0f"
 
 GEM_NAME = "i18n"
 

--- a/recipes-rubygems/rubygems-launchy_3.1.0.bb
+++ b/recipes-rubygems/rubygems-launchy_3.1.0.bb
@@ -12,12 +12,13 @@ EXTRA_RDEPENDS:append = " "
 DEPENDS:class-native += "\
     rubygems-addressable-native \
     rubygems-childprocess-native \
+    rubygems-logger-native \
 "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "95fd96c4bf190cd1904a1312b347d425"
-SRC_URI[sha256sum] = "b7fa60bda0197cf57614e271a250a8ca1f6a34ab889a3c73f67ec5d57c8a7f2c"
+SRC_URI[md5sum] = "b8f49209ad5612f388505aacc5e6318c"
+SRC_URI[sha256sum] = "4964ae775cd802f5a57ae5584fbdb1151a8908cb0c626341563430d614a59572"
 
 GEM_NAME = "launchy"
 
@@ -28,6 +29,7 @@ inherit pkgconfig
 RDEPENDS:${PN}:class-target += "\
     rubygems-addressable \
     rubygems-childprocess \
+    rubygems-logger \
 "
 
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-liquid_5.7.1.bb
+++ b/recipes-rubygems/rubygems-liquid_5.7.1.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d6513c204b20b55294cf3f991e7996ff"
-SRC_URI[sha256sum] = "0082ea79cb36d6bede97f70f258a08bd2c4241772bdffbed7f55d69004783560"
+SRC_URI[md5sum] = "7259103be93d349515ef91ac218d9aad"
+SRC_URI[sha256sum] = "43885019a27ab555bd756c138bfbcf1cce0f23fe9a007af8aa7881d078ff3548"
 
 GEM_NAME = "liquid"
 

--- a/recipes-rubygems/rubygems-net-scp_4.1.0.bb
+++ b/recipes-rubygems/rubygems-net-scp_4.1.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a97dcd90f88ec481fdf81b53cfc93285"
-SRC_URI[sha256sum] = "b32ded0d48c88ce70844a063e4e14efb44a95e51a9e0c0bfb0c54b4313b622ea"
+SRC_URI[md5sum] = "110c4e22fcfd0dbf94c10684e90fbe63"
+SRC_URI[sha256sum] = "a99b0b92a1e5d360b0de4ffbf2dc0c91531502d3d4f56c28b0139a7c093d1a5d"
 
 GEM_NAME = "net-scp"
 

--- a/recipes-rubygems/rubygems-nokogiri_1.18.2.bb
+++ b/recipes-rubygems/rubygems-nokogiri_1.18.2.bb
@@ -24,8 +24,8 @@ GEM_INSTALL_FLAGS:append = " \
     --use-system-libraries \
 "
 
-SRC_URI[md5sum] = "ec010eacb07b2733d3078fc5ef392424"
-SRC_URI[sha256sum] = "df18be7e96c34736b6abfdeda80c6e845134fb9afe2fe5d4fbc1cf1f89c68475"
+SRC_URI[md5sum] = "4d13bec2c6f41a9f4ac9c203a70a315f"
+SRC_URI[sha256sum] = "93791cfb33186fe077eb9e1b8a6855b5621e328f81f565334572fa398366f8bf"
 
 GEM_NAME = "nokogiri"
 

--- a/recipes-rubygems/rubygems-rubocop_1.71.0.bb
+++ b/recipes-rubygems/rubygems-rubocop_1.71.0.bb
@@ -23,8 +23,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "541858a00a59711292bf9aa00d9a6bf6"
-SRC_URI[sha256sum] = "96751f8440b36a0ac6e9a8ab596900803118d83d6b83f2037bf8b3d7a5bc440e"
+SRC_URI[md5sum] = "990180c8bccf62f5dae6dbdfcfdd8408"
+SRC_URI[sha256sum] = "e19679efd447346ac476122313d3788ae23c38214790bcf660e984c747608bf0"
 
 GEM_NAME = "rubocop"
 


### PR DESCRIPTION
* aws-sdk-core: update to 3.217.0
* dry-types: update to 1.8.1
* net-scp: update to 4.1.0
* googleauth: update to 1.13.1
* i18n: update to 1.14.7
* aws-sdk-cognitoidentityprovider: update to 1.114.0
* aws-sdk-sns: update to 1.94.0
* aws-sdk-eks: update to 1.127.0
* aws-sdk-batch: update to 1.108.0
* launchy: update to 3.1.0
* aws-sdk-glue: update to 1.208.0
* rubocop: update to 1.71.0
* aws-sdk-cloudwatchlogs: update to 1.107.0
* nokogiri: update to 1.18.2
* aws-sdk-ec2: update to 1.502.0
* aws-sdk-transfer: update to 1.111.0
* liquid: update to 5.7.1
* aws-sdk-ssm: update to 1.188.0
* aws-sdk-cloudtrail: update to 1.99.0