### PR TITLE
gems: add xmldsig

### DIFF
--- a/lib/oeqa/runtime/cases/rubygems_rubygems_xmldsig.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_xmldsig.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_xmldsig(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_xmldsig(self):
+        self.gem_is_installed("xmldsig")
+
+    def test_load_xmldsig(self):
+        self.gem_is_loadable("xmldsig")
+

--- a/packagegroups-rubygems/packagegroup-rubygems.bb
+++ b/packagegroups-rubygems/packagegroup-rubygems.bb
@@ -351,6 +351,7 @@ RDEPENDS:${PN} += "\
     rubygems-winrm-fs \
     rubygems-wisper \
     rubygems-wmi-lite \
+    rubygems-xmldsig \
     rubygems-yajl-ruby \
     rubygems-yaml-safe-load-stream3 \
     rubygems-yard \

--- a/recipes-rubygems/rubygems-xmldsig_0.7.0.bb
+++ b/recipes-rubygems/rubygems-xmldsig_0.7.0.bb
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: xmldsig"
+DESCRIPTION = "This gem is a (partial) implementation of the XMLDsig specification"
+HOMEPAGE = "https://github.com/benoist/xmldsig"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=89e04fc79764acf1bd5023faecc03b42"
+
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+DEPENDS:class-native += "\
+    rubygems-nokogiri-native \
+"
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "ad09526516552aae1f999a857a06adb6"
+SRC_URI[sha256sum] = "8e004ddb8fec987ca839ff5d2e210e06aa3b7689f8a3dc2610a57c1057facbdf"
+
+GEM_NAME = "xmldsig"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS:${PN}:class-target += "\
+    rubygems-nokogiri \
+"
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
Provides (partial) support for signing and validation of XML documents in accordance with the XMLDsig W3C recommendation.

See https://rubygems.org/gems/xmldsig