### PR TITLE
gems: add sd-notify

### DIFF
--- a/lib/oeqa/runtime/cases/rubygems_rubygems_sd_notify.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_sd_notify.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_sd_notify(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_sd_notify(self):
+        self.gem_is_installed("sd_notify")
+
+    def test_load_sd_notify(self):
+        self.gem_is_loadable("sd_notify")
+

--- a/packagegroups-rubygems/packagegroup-rubygems.bb
+++ b/packagegroups-rubygems/packagegroup-rubygems.bb
@@ -295,6 +295,7 @@ RDEPENDS:${PN} += "\
     rubygems-safe-yaml \
     rubygems-sassc \
     rubygems-scanf \
+    rubygems-sd-notify \
     rubygems-semantic-puppet \
     rubygems-semverse \
     rubygems-serverspec \

--- a/recipes-rubygems/rubygems-sd-notify_0.1.1.bb
+++ b/recipes-rubygems/rubygems-sd-notify_0.1.1.bb
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: sd_notify"
+DESCRIPTION = "sd_notify can be used to notify systemd about various service status changes of Ruby programs"
+HOMEPAGE = "https://github.com/agis/ruby-sdnotify"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b77c216298aab2ea0d2a7f0835f42763"
+
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "e044ef68e5c786b44f56cb2dd88e545b"
+SRC_URI[sha256sum] = "cbc7ac6caa7cedd26b30a72b5eeb6f36050dc0752df263452ea24fb5a4ad3131"
+
+GEM_NAME = "sd_notify"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
A pure Ruby implementation of [sd_notify(3)](https://man7.org/linux/man-pages/man3/sd_notify.3.html) that can be used to communicate state changes of Ruby programs to systemd.

See https://rubygems.org/gems/sd_notify