### PR TITLE
gems: add bindata

### DIFF
--- a/lib/oeqa/runtime/cases/rubygems_rubygems_bindata.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_bindata.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_bindata(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_bindata(self):
+        self.gem_is_installed("bindata")
+
+    def test_load_bindata(self):
+        self.gem_is_loadable("bindata")
+

--- a/packagegroups-rubygems/packagegroup-rubygems.bb
+++ b/packagegroups-rubygems/packagegroup-rubygems.bb
@@ -97,6 +97,7 @@ RDEPENDS:${PN} += "\
     rubygems-azure-mgmt-security \
     rubygems-azure-mgmt-storage \
     rubygems-bcrypt-pbkdf \
+    rubygems-bindata \
     rubygems-bson \
     rubygems-builder \
     rubygems-chef \

--- a/recipes-rubygems/rubygems-bindata_2.5.0.bb
+++ b/recipes-rubygems/rubygems-bindata_2.5.0.bb
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: bindata"
+DESCRIPTION = "BinData is a declarative way to read and write binary file formats."
+HOMEPAGE = "https://github.com/dmendel/bindata"
+
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=61b188c157f57c801173844363bb013d"
+
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "c893016c3b689893b033e12536faeeab"
+SRC_URI[sha256sum] = "29dccb8ba1cc9de148f24bb88930840c62db56715f0f80eccadd624d9f3d2623"
+
+GEM_NAME = "bindata"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
BinData is a declarative way to read and write binary file formats.
This means the programmer specifies *what* the format of the binary
data is, and BinData works out *how* to read and write data in this format.
It is an easier (and more readable) alternative to ruby's  #pack and #unpack methods.

See https://rubygems.org/gems/bindata/
Documentation https://github.com/dmendel/bindata/wiki