### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.1086.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.1086.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7fd3b153908f7275f6bb5213cf82f346"
-SRC_URI[sha256sum] = "b77347af71e71cd457e227997e53635078b4fc8b14961ab606685a385dd7fa8c"
+SRC_URI[md5sum] = "7918ed9b6ce26566dc09baa50b51e78c"
+SRC_URI[sha256sum] = "89c0c06dd68d811d699a4893d5abb2210787184b6ac984f2c5e1f7ae53be9edc"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-applicationautoscaling_1.103.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-applicationautoscaling_1.103.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1fa1a82b8d3e23412aac922a81006de7"
-SRC_URI[sha256sum] = "238a84bc11be623e452d15743a73ffe24a5bb0b95b1fd1a9614b47e8ed7fa699"
+SRC_URI[md5sum] = "e2a5a26d6b99f079a45d28efd1f27fc6"
+SRC_URI[sha256sum] = "d86a5f504da26a03d47065ec495a90b5bab69af5c272f59dc8718bcbbfc6682e"
 
 GEM_NAME = "aws-sdk-applicationautoscaling"
 

--- a/recipes-rubygems/rubygems-aws-sdk-dynamodb_1.140.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-dynamodb_1.140.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f1c54b4d434c41cae4716d0d06e6146f"
-SRC_URI[sha256sum] = "62f086ef059c8b4ad37fc6ee74ef0b5fe3e2e1d953e4407cc51a9ef8ae5281f7"
+SRC_URI[md5sum] = "5be7ce59f10be2a77636ea462a98e42d"
+SRC_URI[sha256sum] = "51a3456682708d3183d12b6e04e522234f318b339d5296773a451c70ac381561"
 
 GEM_NAME = "aws-sdk-dynamodb"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticache_1.125.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticache_1.125.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "66aa968490743e671bb2780741f7c468"
-SRC_URI[sha256sum] = "b74a52530bfe07545006980d5232c9af00ef00a0ceb65e4a94b55da9548949a5"
+SRC_URI[md5sum] = "4d170f4775b46208e2a39d9e1423e1e8"
+SRC_URI[sha256sum] = "ca6359513eeda7bd388cb7acba62137e85bdb88068c4d6c17877a778bc7f9d8f"
 
 GEM_NAME = "aws-sdk-elasticache"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.213.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.213.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "5b9e6bd9178fac16e51829062e753d74"
-SRC_URI[sha256sum] = "6a5e60483c9a733fa1ac4faef6eb895d50e6028c7f1e5c90d01f48b84354a0af"
+SRC_URI[md5sum] = "944e074f6a01f817a23abc5aeb50d84c"
+SRC_URI[sha256sum] = "7692c97a54e7c550c216f59b4f18cd2eebb82fe27d5aec5f4534db43bde2af27"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-securityhub_1.132.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-securityhub_1.132.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "3f2efe1924f50a1049773754ab211c74"
-SRC_URI[sha256sum] = "23ec6fadf606f44fd88d6b7ea5b751ce757a9c1b30b6699e3e4334e3883e0918"
+SRC_URI[md5sum] = "ebfd3fbfbd8d86618611c44ce8f32416"
+SRC_URI[sha256sum] = "45eb5134f33cf0eba657258ada182496da6795122a4760dba8dc4ad3a24f153a"
 
 GEM_NAME = "aws-sdk-securityhub"
 

--- a/recipes-rubygems/rubygems-aws-sdk-transfer_1.116.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-transfer_1.116.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "3b07f2910fab3de1c35a29be267d28c3"
-SRC_URI[sha256sum] = "4b268f065d0d332d416cd6e949d0fef52bd9b05117f3dfc3175d77eaae09bb25"
+SRC_URI[md5sum] = "7471448767c678d15ddf9505c6869517"
+SRC_URI[sha256sum] = "bc280ed89d92b578259081906f76461ad7a270e19eac485e2c60a4d8bf88dbf3"
 
 GEM_NAME = "aws-sdk-transfer"
 

--- a/recipes-rubygems/rubygems-bindata_2.5.1.bb
+++ b/recipes-rubygems/rubygems-bindata_2.5.1.bb
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 SUMMARY = "RubyGem: bindata"
-DESCRIPTION = "BinData is a declarative way to read and write binary file formats."
+DESCRIPTION = "BinData is a declarative way to read and write binary file formats.This means the programmer specifies *what* the format of the binarydata is, and BinData works out *how* to read and write data in thisformat"
 HOMEPAGE = "https://github.com/dmendel/bindata"
 
 LICENSE = "BSD-2-Clause"
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c893016c3b689893b033e12536faeeab"
-SRC_URI[sha256sum] = "29dccb8ba1cc9de148f24bb88930840c62db56715f0f80eccadd624d9f3d2623"
+SRC_URI[md5sum] = "d5929e59e78b22f9f22c61386b584368"
+SRC_URI[sha256sum] = "53186a1ec2da943d4cb413583d680644eb810aacbf8902497aac8f191fad9e58"
 
 GEM_NAME = "bindata"
 

--- a/recipes-rubygems/rubygems-faraday-rack_2.1.2.bb
+++ b/recipes-rubygems/rubygems-faraday-rack_2.1.2.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "3633c44746f1f4a11febca8fd82ec61b"
-SRC_URI[sha256sum] = "41759651c9e8baba520c21f807a8787dbb8480c2dbe64569264346ffad6b0461"
+SRC_URI[md5sum] = "ae337ec611f734fed243e5b9ce13a768"
+SRC_URI[sha256sum] = "b71e7da46249793861d4ed49841d13e25d1c4714788bad9c8ac679d6d26deed5"
 
 GEM_NAME = "faraday-rack"
 

--- a/recipes-rubygems/rubygems-faraday_2.13.0.bb
+++ b/recipes-rubygems/rubygems-faraday_2.13.0.bb
@@ -17,8 +17,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "dd039ae3fe82fbad770c91b0c559da66"
-SRC_URI[sha256sum] = "157339c25c7b8bcb739f5cf1207cb0cefe8fa1c65027266bcbc34c90c84b9ad6"
+SRC_URI[md5sum] = "d0ab03111cbd0f9f307d553e4ad319b5"
+SRC_URI[sha256sum] = "f2697cd61a434dc446ee035f0370de654c2ad64707c4fc2541eb2338702e9614"
 
 GEM_NAME = "faraday"
 

--- a/recipes-rubygems/rubygems-k8s-ruby_0.17.2.bb
+++ b/recipes-rubygems/rubygems-k8s-ruby_0.17.2.bb
@@ -16,21 +16,18 @@ DEPENDS:class-native += "\
     rubygems-dry-configurable-native \
     rubygems-dry-struct-native \
     rubygems-dry-types-native \
-    rubygems-eventmachine-native \
     rubygems-excon-native \
-    rubygems-faye-websocket-native \
     rubygems-hashdiff-native \
     rubygems-jsonpath-native \
     rubygems-recursive-open-struct-native \
-    rubygems-ruby-termios-native \
     rubygems-yajl-ruby-native \
     rubygems-yaml-safe-load-stream3-native \
 "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b9c66189b61577939853e3a3a221c621"
-SRC_URI[sha256sum] = "0e038efa10547822a9d0c54b6aaf295f33ce7d2bce41098565cce3673c82d6be"
+SRC_URI[md5sum] = "6e91472f14dab4f9ebaa0fa4fd10a5b9"
+SRC_URI[sha256sum] = "9197c70ea7547a06fdc5534c81b00740622a0ccfb12416fc6c06af141b59071b"
 
 GEM_NAME = "k8s-ruby"
 
@@ -43,13 +40,10 @@ RDEPENDS:${PN}:class-target += "\
     rubygems-dry-configurable \
     rubygems-dry-struct \
     rubygems-dry-types \
-    rubygems-eventmachine \
     rubygems-excon \
-    rubygems-faye-websocket \
     rubygems-hashdiff \
     rubygems-jsonpath \
     rubygems-recursive-open-struct \
-    rubygems-ruby-termios \
     rubygems-yajl-ruby \
     rubygems-yaml-safe-load-stream3 \
 "

--- a/recipes-rubygems/rubygems-liquid_5.8.4.bb
+++ b/recipes-rubygems/rubygems-liquid_5.8.4.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "af0a308463445506ac6299f07ff60608"
-SRC_URI[sha256sum] = "71c01e4a5df49864b65fd8a652f2b58f4e089c4d9ab3baf843ae0e467e6f4212"
+SRC_URI[md5sum] = "0bf0e19bc53722f47858263b072c5b9c"
+SRC_URI[sha256sum] = "4aa91bb2d8253373be7cabdc53e720fc2a03ecb7d64aae9252f718011ec3a828"
 
 GEM_NAME = "liquid"
 

--- a/recipes-rubygems/rubygems-rubycritic_4.9.2.bb
+++ b/recipes-rubygems/rubygems-rubycritic_4.9.2.bb
@@ -25,8 +25,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7b6e1f2e04d0b95fdca778008456f969"
-SRC_URI[sha256sum] = "1db130571cac57f5bc37dc236d9f5d68a0eaecdbfe18a4e1a0f00fd751b4a0cc"
+SRC_URI[md5sum] = "ae25c6e58a113efac3f62dd4abbed8fa"
+SRC_URI[sha256sum] = "8b925670ef6e7e9480fd6f4aceb882177c9afd2b6a2bb2fb04fdd25c7e7857bb"
 
 GEM_NAME = "rubycritic"
 

--- a/recipes-rubygems/rubygems-train-kubernetes_0.3.1.bb
+++ b/recipes-rubygems/rubygems-train-kubernetes_0.3.1.bb
@@ -18,8 +18,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "828c2218614fc99431ec97aef34c8b54"
-SRC_URI[sha256sum] = "eb918eec7332da49976c6b32d81f6c4702b814b9a9f25e8ed8ece64b9ce4b747"
+SRC_URI[md5sum] = "c9b94a1d2d8089cec446b2e1b99ca285"
+SRC_URI[sha256sum] = "8595d0f41bce5f37cea8791d7b2a9a0ea21202ec4052a0891b473546694ae985"
 
 GEM_NAME = "train-kubernetes"
 


### PR DESCRIPTION
* faraday: update to 2.13.0
* aws-partitions: update to 1.1086.0
* aws-sdk-applicationautoscaling: update to 1.103.0
* liquid: update to 5.8.4
* train-kubernetes: update to 0.3.1
* aws-sdk-securityhub: update to 1.132.0
* aws-sdk-elasticache: update to 1.125.0
* aws-sdk-dynamodb: update to 1.140.0
* aws-sdk-glue: update to 1.213.0
* aws-sdk-transfer: update to 1.116.0
* bindata: update to 2.5.1
* rubycritic: update to 4.9.2
* faraday-rack: update to 2.1.2