### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.1244.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.1244.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6916bd09bb54342e54a6452d06b58871"
-SRC_URI[sha256sum] = "cd0efc435de2782e8bdc77ae76bdafe70f493d54398071a88dbb1e1d32026cbe"
+SRC_URI[md5sum] = "7e0a04f665566f7beea7b9d6c806168d"
+SRC_URI[sha256sum] = "e6e5ded095e3bd775db3b64f84533e1ddf7c74f070b3d0373f08dc77c8c3592b"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-account_1.57.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-account_1.57.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7e442fa911052129a2dbdcf88ee3259f"
-SRC_URI[sha256sum] = "28ef83349c3f2841ac375e9fae5027e1aa79bf8b766d0390f18606781a5c24a4"
+SRC_URI[md5sum] = "b9e80c6f5b8e4a4d712fbb322e192611"
+SRC_URI[sha256sum] = "8951bf54ed96d80777b5cb613b458576c0b3d4ac95cbcce0bc8fe48895efa159"
 
 GEM_NAME = "aws-sdk-account"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.144.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudfront_1.144.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "427418017709d662c46c63f9134f79f1"
-SRC_URI[sha256sum] = "2a5bd39a6d849dbe793ffb20db909aee1bbe7692f8d0a44435e46b32ca7382fb"
+SRC_URI[md5sum] = "cdb6c7696d4afcd0a7be307bc433a220"
+SRC_URI[sha256sum] = "472b94c5b6699dab4dbfaf7e8c985211958b4d736e8b874d5be7a09a533d8475"
 
 GEM_NAME = "aws-sdk-cloudfront"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatch_1.135.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatch_1.135.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "28b8617cb9f83164eac4e03dbfb5551b"
-SRC_URI[sha256sum] = "48d88345c3408aded206717c3277a37e317ed79be91066a97bea8034f2e687f5"
+SRC_URI[md5sum] = "32597036eae1148b4c48336196ae6531"
+SRC_URI[sha256sum] = "c6ff0d81b3eadb597249e47ef76f2578b6a884a2be5f7587f85d1093298a853a"
 
 GEM_NAME = "aws-sdk-cloudwatch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.148.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.148.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "0a50d8a0450c5ca29373c2d0c66e4784"
-SRC_URI[sha256sum] = "546bc39964dd4e336370dbeaf7b7ef87ae6d320bc1a1675c6db16d70d13ac646"
+SRC_URI[md5sum] = "89eec911db34848c428b112ac766850b"
+SRC_URI[sha256sum] = "25ebb7268c8a1019efc339ae252e7a8b36ef3763c67ad5bd1181bff28f1940c1"
 
 GEM_NAME = "aws-sdk-cloudwatchlogs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecr_1.126.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecr_1.126.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "bb892ab691e7bde6270ef599d797c3f1"
-SRC_URI[sha256sum] = "3dabe3fb32fceaf0e6e6a2467964efa524e7398016b6814255ebb163ef6113b4"
+SRC_URI[md5sum] = "9b4108cdfca93921ef8da4aac3bf60ab"
+SRC_URI[sha256sum] = "73829d8adaf7a1a78d7705ccf2877e24f9fc52aa0933c2a4fb3fd43789cad73b"
 
 GEM_NAME = "aws-sdk-ecr"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eks_1.164.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eks_1.164.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "29532484ca5456bec51f117b1655b08a"
-SRC_URI[sha256sum] = "e255488856eec6428dd902736b4f876663e992d6e2e11b501c81aa9af87216fa"
+SRC_URI[md5sum] = "6155b29ef809d5945f42df2da5c0c591"
+SRC_URI[sha256sum] = "c59134f98b7cf8ce02e1d8e3087f3efe33c7a701fc62ef40db4c6c0cbab3ae7c"
 
 GEM_NAME = "aws-sdk-eks"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.254.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.254.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "da1ced11acb895e81e0e8da805d2def4"
-SRC_URI[sha256sum] = "bae1a5fb0ca3c9ebb57fd7cf4b5de559aa4e0c7716d30de9a6ecd76168d93c04"
+SRC_URI[md5sum] = "db7d22fa1f9433a167aef0b2b4d659e9"
+SRC_URI[sha256sum] = "3c07a98a785f4242cb84fd64c4335b9e15a8a57186d64abd749935ce48c75468"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-iam_1.143.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-iam_1.143.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "13eeba88fbf7cb5d9c580e9486056499"
-SRC_URI[sha256sum] = "61cab3fd32ad3f8540b6c4b2174d39b56fd8913f7f67b4dd2ddb02c26feea54b"
+SRC_URI[md5sum] = "4b547b50110421c87ae0325c71d6cad7"
+SRC_URI[sha256sum] = "6533b362ecd79034ee836ed6b5cfdf2117c2f58b6d1f8c95b7e791c655f99092"
 
 GEM_NAME = "aws-sdk-iam"
 

--- a/recipes-rubygems/rubygems-aws-sdk-kafka_1.110.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-kafka_1.110.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "4b285d8b2f8cea0cc86b04daa935bfac"
-SRC_URI[sha256sum] = "1f783e9e33973ceea3d74ac5a3c99a572a671d153a94b15598092e6acc58d9ed"
+SRC_URI[md5sum] = "68fb5627fa5f2ed2d11bafe187fbdc5e"
+SRC_URI[sha256sum] = "055479085bb9c25c487d396b2a701ffe7fffdfcd946f02fdbc17940580b4ba6b"
 
 GEM_NAME = "aws-sdk-kafka"
 

--- a/recipes-rubygems/rubygems-aws-sdk-kms_1.124.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-kms_1.124.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "fae258ef12d2b5e1802e2dc8b2facb26"
-SRC_URI[sha256sum] = "d405f37e82f8fa32045ca8980be266c0b45b37aaf2012afe0254321a1e811f20"
+SRC_URI[md5sum] = "626d1ac1c749b1cabe77c8ab0ffb9db2"
+SRC_URI[sha256sum] = "40d00ab706d7e49fd620270bd0dcb546f266295abdd49b54fec2611e2a41f37c"
 
 GEM_NAME = "aws-sdk-kms"
 

--- a/recipes-rubygems/rubygems-aws-sdk-transfer_1.137.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-transfer_1.137.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "eea076be22fda901341448bd167ed22f"
-SRC_URI[sha256sum] = "5b221e41adc2e0b1c1d3cbbe5b7d8711ea7a04a533eedafea154f71b85a98119"
+SRC_URI[md5sum] = "72a7735a001b712ea999ab0f47b61a67"
+SRC_URI[sha256sum] = "ea1a7f78508659f77d73e5275dd070cc873a94be48bbed9b51a8de9c5e499483"
 
 GEM_NAME = "aws-sdk-transfer"
 

--- a/recipes-rubygems/rubygems-google-apis-compute-v1_0.144.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-compute-v1_0.144.0.bb
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
-SUMMARY = "RubyGem: google-apis-storage_v1"
-DESCRIPTION = "This is the simple REST client for Cloud Storage JSON API V1"
+SUMMARY = "RubyGem: google-apis-compute_v1"
+DESCRIPTION = "This is the simple REST client for Compute Engine API V1"
 HOMEPAGE = "https://github.com/google/google-api-ruby-client"
 
 LICENSE = "Apache-2.0"
@@ -15,10 +15,10 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "570e404bcaad6336ee441593b27af362"
-SRC_URI[sha256sum] = "b330e599b58e6a01533c189525398d6dbdbaf101ffb0c60145940b57e1c982e8"
+SRC_URI[md5sum] = "44ed1c0177428e7ed5886feaa44fcaf3"
+SRC_URI[sha256sum] = "08ae7f3ad0ae6fa5d4a3019113af3efeb7772c61095fb9e666efcac58b2d53c9"
 
-GEM_NAME = "google-apis-storage_v1"
+GEM_NAME = "google-apis-compute_v1"
 
 inherit rubygems
 inherit rubygentest

--- a/recipes-rubygems/rubygems-google-apis-storage-v1_0.62.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-storage-v1_0.62.0.bb
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
-SUMMARY = "RubyGem: google-apis-compute_v1"
-DESCRIPTION = "This is the simple REST client for Compute Engine API V1"
+SUMMARY = "RubyGem: google-apis-storage_v1"
+DESCRIPTION = "This is the simple REST client for Cloud Storage JSON API V1"
 HOMEPAGE = "https://github.com/google/google-api-ruby-client"
 
 LICENSE = "Apache-2.0"
@@ -15,10 +15,10 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "dfe24051e7e7d8cdea33d6528564698b"
-SRC_URI[sha256sum] = "a1f8de2c6a2bc0ba45dff96d2b00aea077c8d1963e6b8884a1f09e022e7133bf"
+SRC_URI[md5sum] = "3c4021f3d8431d79814627a1345833f0"
+SRC_URI[sha256sum] = "f62467c36df53287fb0252ebb4da85f9e25d7b4c5809d045c2aab1fc307760c1"
 
-GEM_NAME = "google-apis-compute_v1"
+GEM_NAME = "google-apis-storage_v1"
 
 inherit rubygems
 inherit rubygentest

--- a/recipes-rubygems/rubygems-nokogiri_1.19.3.bb
+++ b/recipes-rubygems/rubygems-nokogiri_1.19.3.bb
@@ -24,8 +24,8 @@ GEM_INSTALL_FLAGS:append = " \
     --use-system-libraries \
 "
 
-SRC_URI[md5sum] = "5e5691d5ed3e623e66c6ac7d5cab98cf"
-SRC_URI[sha256sum] = "38fdd8b59db3d5ea9e7dfb14702e882b9bf819198d5bf976f17ebce12c481756"
+SRC_URI[md5sum] = "f6ab9377b07a606b07d05514997dc8f3"
+SRC_URI[sha256sum] = "78312cbac32a40c812780d9678221b79d51288eec00054c1a8d15f7ce05960e8"
 
 GEM_NAME = "nokogiri"
 

--- a/recipes-rubygems/rubygems-train-core_3.16.3.bb
+++ b/recipes-rubygems/rubygems-train-core_3.16.3.bb
@@ -20,8 +20,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c3241901b03ab8e8a3805cd20fbc3f16"
-SRC_URI[sha256sum] = "8f95209c6a93c14e61e6748335824228b50e4fd9379ea58e62cb916c23f5e9ef"
+SRC_URI[md5sum] = "9c8667265ecd6ef09278c6810e290c2f"
+SRC_URI[sha256sum] = "dffeae2d01e8452ded15facb48e1c80ef8ccf326cbbb4063fa96bf6b7885f277"
 
 GEM_NAME = "train-core"
 

--- a/recipes-rubygems/rubygems-train_3.16.3.bb
+++ b/recipes-rubygems/rubygems-train_3.16.3.bb
@@ -33,8 +33,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "15040b5e00e86303e984535a7a9fef9e"
-SRC_URI[sha256sum] = "a5fa143534291d5454673c000d4309af8c36b30ffa192dd482b0a8d8f08368a1"
+SRC_URI[md5sum] = "d05af1963e1d143f82e3e90fcfa0f638"
+SRC_URI[sha256sum] = "1a1f71a00ae8f908a511a4d763425d0ae3b3a4934c029fdb22f7f0aec28ffa03"
 
 GEM_NAME = "train"
 


### PR DESCRIPTION
* train-core: update to 3.16.3
* train: update to 3.16.3
* nokogiri: update to 1.19.3
* aws-sdk-kms: update to 1.124.0
* aws-partitions: update to 1.1244.0
* aws-sdk-kafka: update to 1.110.0
* aws-sdk-transfer: update to 1.137.0
* aws-sdk-ecr: update to 1.126.0
* aws-sdk-cloudwatch: update to 1.135.0
* aws-sdk-cloudfront: update to 1.144.0
* aws-sdk-iam: update to 1.143.0
* aws-sdk-account: update to 1.57.0
* aws-sdk-glue: update to 1.254.0
* aws-sdk-cloudwatchlogs: update to 1.148.0
* aws-sdk-eks: update to 1.164.0