### PR TITLE
Package update

### DIFF
--- a/recipes-rubygems/rubygems-aws-partitions_1.1260.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.1260.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9063b5f6a55a2083db0b0d79a03f2b1b"
-SRC_URI[sha256sum] = "3fee017570594ecf5e7f4c845b115fef8000530e57bdaf2b927357e5bf08967f"
+SRC_URI[md5sum] = "43cf7eba288fea25016d4698471d2d12"
+SRC_URI[sha256sum] = "045aff79be010126538f39e03141088e1fd2428d2d065e220e7fb3c3ba2b337a"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatch_1.140.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatch_1.140.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6deb9a72a9b8aac9be0246a14b363fe3"
-SRC_URI[sha256sum] = "07725a68bb3f3e9d5e4282eb990d0526a7037c2f6a0fbbc61772e483275f27c6"
+SRC_URI[md5sum] = "a471c1222ac7fe54b81b12a59b74bed1"
+SRC_URI[sha256sum] = "f39c0a3949949051ec76523282773c696e43f5159cf23349ed95e32a07209c3f"
 
 GEM_NAME = "aws-sdk-cloudwatch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-core_3.252.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-core_3.252.0.bb
@@ -21,8 +21,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a9f6dc20ac01999235d55bfdc73178fc"
-SRC_URI[sha256sum] = "ef8186cb5509147e590310da58fab4c5b0901eba0e85a72955abdf772e425c87"
+SRC_URI[md5sum] = "f69c6d08040a296f7af9d44b95034f50"
+SRC_URI[sha256sum] = "09c042cbfc2acf2239441cc9b982ebab2a999bed2ef6bdc51849e7b3d6e48a1c"
 
 GEM_NAME = "aws-sdk-core"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.623.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.623.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "97f48bd1ae14875cddaddd17c01eaa6d"
-SRC_URI[sha256sum] = "ae88d6ea04eb52ef13e7d12ea43651eb6ebc1a31d10d3d5560e8875b687a9d08"
+SRC_URI[md5sum] = "83a02638b0544e7b24e53bcb362dd09e"
+SRC_URI[sha256sum] = "6c2ac281b4d3cf04caaa88f39045333cd89bc9b8fccf9fabadb9c1e3ee6cfbe0"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.236.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.236.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "19496debbb4909b92249ae9e76649667"
-SRC_URI[sha256sum] = "3a65eba412d8803d1fbc166f56af9c4b8fcec65cd9b0bc24fe06afa4c2b3886b"
+SRC_URI[md5sum] = "89f56c67339236c65eb27b1ac7ecd8d2"
+SRC_URI[sha256sum] = "2db522bc350962e7709d7174cb06da7dc3e4af0aeb55c76dbebcf655224b27ae"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eks_1.169.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eks_1.169.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1ce86f8179a0647e4857a18be838539a"
-SRC_URI[sha256sum] = "21bda9ccfcf4115dd906679ff01f59f9cf59f9040cd8203dee4193f35b19c864"
+SRC_URI[md5sum] = "c1a8231c1b22b3b1b9379c1f32f15ae6"
+SRC_URI[sha256sum] = "3a867a775383925c1288bf5300fd115c3c17ac003c956be635ea4b985f433ed5"
 
 GEM_NAME = "aws-sdk-eks"
 

--- a/recipes-rubygems/rubygems-aws-sdk-firehose_1.111.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-firehose_1.111.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "3d61709576a7904a2577c5666dd7527f"
-SRC_URI[sha256sum] = "03cd46e840d39d0f5ee632c95a18b2cd52e85bac8da44ec5f099b3713a56c016"
+SRC_URI[md5sum] = "130e8b5a9eb2a949d0ea32589b7ba6d9"
+SRC_URI[sha256sum] = "6e5ce263ce4445cddfa190b4f0abbdae43b5ffe9cd84a4c1aaf8d944be4a133c"
 
 GEM_NAME = "aws-sdk-firehose"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.261.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.261.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "dbe5835d3bbdf1f64d2bfc0306da7cf2"
-SRC_URI[sha256sum] = "e3c0c84786f212b7e8ff104754b056bf9efb97a46c24f8e31933059a3bfa76f0"
+SRC_URI[md5sum] = "5ae7e5c71652cc0598da4e323e1471a3"
+SRC_URI[sha256sum] = "8c51a38639db00339ecaf50ea2a26f1979669bf7230f13966cf6e909434f8fc9"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-iam_1.148.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-iam_1.148.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6d9797f20c2f97a44b08573d20ad1549"
-SRC_URI[sha256sum] = "a9a7106bfc51976f37c6594a2976fce0897b19264c9a907d8c1d07b3c68324d9"
+SRC_URI[md5sum] = "a05a5df12a4a53739f0c5ef3ba2ebf16"
+SRC_URI[sha256sum] = "9e340346bca25e8430839d60dc25f513b92b2a0831457cfc3306f90dd0bafa1a"
 
 GEM_NAME = "aws-sdk-iam"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.225.1.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.225.1.bb
@@ -17,8 +17,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d51a70a23462f2f6a1f351e39b5aa0c1"
-SRC_URI[sha256sum] = "734752cc77e369c645ff5285b70ff5af207b0dcd3388346de2f727cd4e943924"
+SRC_URI[md5sum] = "51b586aaa33eaacc460589270013b28c"
+SRC_URI[sha256sum] = "d4b23a8db9b0a5548766b52d382b184f47f7e126560acdb731dd46adb5e26512"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-google-apis-core_1.2.3.bb
+++ b/recipes-rubygems/rubygems-google-apis-core_1.2.3.bb
@@ -15,14 +15,15 @@ DEPENDS:class-native += "\
     rubygems-faraday-native \
     rubygems-googleauth-native \
     rubygems-mini-mime-native \
+    rubygems-multi-json-native \
     rubygems-representable-native \
     rubygems-retriable-native \
 "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "f00b8904c5c9ef2660838b26e212fe86"
-SRC_URI[sha256sum] = "965e5e3d87541ab619942f91bc3247a0eee2cd38ee149e48c2d3d3291f95ccec"
+SRC_URI[md5sum] = "a72e6b9a68e414ebfcbd7c220ba92d42"
+SRC_URI[sha256sum] = "2ce34c17c144e24d966ecb0efa5d46aaba3e3e3721ba1faa1ed80db2389e7b08"
 
 GEM_NAME = "google-apis-core"
 
@@ -36,6 +37,7 @@ RDEPENDS:${PN}:class-target += "\
     rubygems-faraday-follow-redirects \
     rubygems-googleauth \
     rubygems-mini-mime \
+    rubygems-multi-json \
     rubygems-representable \
     rubygems-retriable \
 "

--- a/recipes-rubygems/rubygems-google-apis-generator_0.19.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-generator_0.19.0.bb
@@ -19,8 +19,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "fb15693a60459c3cc6516b590832d01c"
-SRC_URI[sha256sum] = "09e7640bf198e05b8f9cc7edacca3c6d62f8123858f7c5aa6acad48423bf401d"
+SRC_URI[md5sum] = "44677a372d7e6540c6887eb544f36792"
+SRC_URI[sha256sum] = "72ed74fbfde4fdd3b23b30e8ed951103b949477a5904b23208ebe211905ae49d"
 
 GEM_NAME = "google-apis-generator"
 

--- a/recipes-rubygems/rubygems-sqlite3_2.9.5.bb
+++ b/recipes-rubygems/rubygems-sqlite3_2.9.5.bb
@@ -23,8 +23,8 @@ GEM_INSTALL_FLAGS:append = " \
     --platform=ruby \
 "
 
-SRC_URI[md5sum] = "ae8738576753f67b3ad0183668c5edf5"
-SRC_URI[sha256sum] = "6161c5b9c17886b289558e6c8082b28a22a814736d2433c9a67f4c6bfcde5c97"
+SRC_URI[md5sum] = "3c58a6ea57f152130a2b7c32e1dd8df3"
+SRC_URI[sha256sum] = "04572973a3f943ad50a8adfffc8dd752a5f06e4c3db2026f71838fed8a982606"
 
 GEM_NAME = "sqlite3"
 


### PR DESCRIPTION
* aws-sdk-core: update to 3.252.0
* google-apis-core: update to 1.2.3
* train-core: update to 3.16.5
* aws-sdk-s3: update to 1.225.1
* train: update to 3.16.5
* aws-sdk-glue: update to 1.261.0
* aws-sdk-iam: update to 1.148.0
* aws-sdk-eks: update to 1.169.0
* aws-sdk-ec2: update to 1.623.0
* aws-sdk-firehose: update to 1.111.0
* aws-sdk-cloudwatch: update to 1.140.0
* aws-sdk-ecs: update to 1.236.0
* google-apis-generator: update to 0.19.0
* sqlite3: update to 2.9.5