### PR TITLE
Package update

### DIFF
--- a/lib/oeqa/runtime/cases/rubygems_rubygems_rubyzip.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_rubyzip.py
@@ -5,6 +5,9 @@ class RubyGemsTestrubygems_rubyzip(RubyGemsTestUtils):
     def test_gem_list_rubygems_rubyzip(self):
         self.gem_is_installed("rubyzip")
 
+    def test_load_rubyzip(self):
+        self.gem_is_loadable("rubyzip")
+
     def test_load_zip(self):
         self.gem_is_loadable("zip")
 

--- a/recipes-rubygems/rubygems-aws-partitions_1.1261.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.1261.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "43cf7eba288fea25016d4698471d2d12"
-SRC_URI[sha256sum] = "045aff79be010126538f39e03141088e1fd2428d2d065e220e7fb3c3ba2b337a"
+SRC_URI[md5sum] = "8f55e6738e654240c1eb8ecf3d7f6855"
+SRC_URI[sha256sum] = "89eda89781c1ea4e1be2a2dcdc72318c62c6171a01cdaeaa0cbecf3cea6f9fdc"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-applicationautoscaling_1.124.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-applicationautoscaling_1.124.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "32538f204de24e01ff629d7ade53790b"
-SRC_URI[sha256sum] = "bfae8b66622e085232e109ce71a6ba89afce43637840ed2039a5feb22fbb50a9"
+SRC_URI[md5sum] = "d17f6a9e432a0b6374a7fa9042755a90"
+SRC_URI[sha256sum] = "0f2725a2b5e1ebcea9f33b43197e56ad1f1e042bc3a378571945b64f61d425f7"
 
 GEM_NAME = "aws-sdk-applicationautoscaling"
 

--- a/recipes-rubygems/rubygems-aws-sdk-batch_1.146.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-batch_1.146.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e11837c4b0bcfc5032ead60ce7b71d40"
-SRC_URI[sha256sum] = "881b13acd0076a23a668ab3608306294e319256eac0ea4c1704c8c0444d73315"
+SRC_URI[md5sum] = "5f8e6b36a99434d441079de429855419"
+SRC_URI[sha256sum] = "a5791dc2e31ff92d41200700d6cf9c29c4feb29096ba80a9d526bde547c085e6"
 
 GEM_NAME = "aws-sdk-batch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.156.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.156.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "88c54ee91df213d41ebb03acc0be44b1"
-SRC_URI[sha256sum] = "7e591874098870448ac18f45996216aeee855fc2ea6fe760231823b0c174e80c"
+SRC_URI[md5sum] = "68607055af62536efe9ed236fe5a4d3e"
+SRC_URI[sha256sum] = "8e9e6854a2da907725c5bc517f15e0a90d9aaf945b7094883e66fb0b5049dc64"
 
 GEM_NAME = "aws-sdk-cloudwatchlogs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cognitoidentityprovider_1.145.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cognitoidentityprovider_1.145.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c307069e8992daf2bbccfc6099917c71"
-SRC_URI[sha256sum] = "99ece7652b7e52b80951522ae7e476eccae24390525bad35ab2926748bba3baf"
+SRC_URI[md5sum] = "25cda935a62401735e035bd683bb3750"
+SRC_URI[sha256sum] = "05a808842e90d5f36eba234ce24b94f733406a5b0ce70312cf75973d79911fe9"
 
 GEM_NAME = "aws-sdk-cognitoidentityprovider"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.624.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.624.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "83a02638b0544e7b24e53bcb362dd09e"
-SRC_URI[sha256sum] = "6c2ac281b4d3cf04caaa88f39045333cd89bc9b8fccf9fabadb9c1e3ee6cfbe0"
+SRC_URI[md5sum] = "c6babbf1718ea8e29a3134bd9eb1d300"
+SRC_URI[sha256sum] = "816002b667f4dc0c6f031f02b1a43b84d646db5f55cf248fc4fa531a11bcbd98"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.238.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.238.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "89f56c67339236c65eb27b1ac7ecd8d2"
-SRC_URI[sha256sum] = "2db522bc350962e7709d7174cb06da7dc3e4af0aeb55c76dbebcf655224b27ae"
+SRC_URI[md5sum] = "62cacefd429df622f9925b8cc7b596f0"
+SRC_URI[sha256sum] = "504537e726804b5ac9d4edc0416cc5252506cb4fb09be82911b3605dcd6fda00"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eks_1.170.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eks_1.170.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c1a8231c1b22b3b1b9379c1f32f15ae6"
-SRC_URI[sha256sum] = "3a867a775383925c1288bf5300fd115c3c17ac003c956be635ea4b985f433ed5"
+SRC_URI[md5sum] = "778b88369d5fa6ff8e5006901bfb7383"
+SRC_URI[sha256sum] = "91fc2629443fc15d131c51a1d42a952a90cbdda2b3e3dec6dff178d88331e8c1"
 
 GEM_NAME = "aws-sdk-eks"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.263.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.263.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "5ae7e5c71652cc0598da4e323e1471a3"
-SRC_URI[sha256sum] = "8c51a38639db00339ecaf50ea2a26f1979669bf7230f13966cf6e909434f8fc9"
+SRC_URI[md5sum] = "be706d1780ad92519997a686043008d0"
+SRC_URI[sha256sum] = "613446cce82117af2d67cf38330ed703c933a1e4a2524b1fe0588f21343aba8e"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-lambda_1.184.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-lambda_1.184.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9827eff235759fef5b4781c83efa3833"
-SRC_URI[sha256sum] = "3dbf19f07e2d484108ec9e7f45c6482ee2f5f3023ee5df1434caa8a4d84f3ae4"
+SRC_URI[md5sum] = "75bd90cdf2c0b7d91d4e13f694f257a0"
+SRC_URI[sha256sum] = "27078229843bcaf9a87386be96ff36bcbd5b3c77f8bcb0ac83fd1c22eddc9034"
 
 GEM_NAME = "aws-sdk-lambda"
 

--- a/recipes-rubygems/rubygems-aws-sdk-mq_1.98.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-mq_1.98.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7432fe76eb682addbed8360380ea9cea"
-SRC_URI[sha256sum] = "d54037d08bcac17110c501b086a6e6b11dd740e3d48af0d8916bbfabba086bad"
+SRC_URI[md5sum] = "c20c012502d5ca6ce3e683fdbfe13ed2"
+SRC_URI[sha256sum] = "55157af4a1bc34f25c472d179e659fe207ddf9a0be42ad67914d64b6e51ef1ff"
 
 GEM_NAME = "aws-sdk-mq"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.316.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.316.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "cd96b7a25233b0a2f3b0c2d53c2d1904"
-SRC_URI[sha256sum] = "38b34feea112fc039f93886d90476ef40f637682074b6fa06b7fe4d92dac4cd8"
+SRC_URI[md5sum] = "aece6d1111fa4b75ab099fea1b548521"
+SRC_URI[sha256sum] = "81fec624bee0e66c8360fa6295e33c615719d9847bb4ebb6f145738699217804"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-aws-sdk-route53resolver_1.101.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-route53resolver_1.101.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b7312eed99eb2511779d80927dbb939a"
-SRC_URI[sha256sum] = "09deec68522743f48202fb95293df634304021ac3e42aad451168d5c83853e07"
+SRC_URI[md5sum] = "e13a17ab7ac4d1852b41d5cd7a8b0d00"
+SRC_URI[sha256sum] = "d9d0d7955d50a090e313948ffce5e069c61036425c2b3ef188487a2c27aedd12"
 
 GEM_NAME = "aws-sdk-route53resolver"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.226.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.226.0.bb
@@ -17,8 +17,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "51b586aaa33eaacc460589270013b28c"
-SRC_URI[sha256sum] = "d4b23a8db9b0a5548766b52d382b184f47f7e126560acdb731dd46adb5e26512"
+SRC_URI[md5sum] = "4f404db6a9cf8b95b8c885f7838b7846"
+SRC_URI[sha256sum] = "e599f431e006ec9b92c61ee0f14d3f658a1f6c8a1d623d2160be927ac958e2bf"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-aws-sdk-synthetics_1.86.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-synthetics_1.86.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "690dc8035f0a3dc09fea65dca05552e3"
-SRC_URI[sha256sum] = "37e86c9194654ae7e98c23406c539dc1d16dc5bc9681456d57c4c7c1b341637b"
+SRC_URI[md5sum] = "162ba4c8bed7f5b3a21b4b53bd8d2f4b"
+SRC_URI[sha256sum] = "d94bb9f83dba971baf80cb8f5807f026f0145d9ca69a300302f64f1ed931ca3e"
 
 GEM_NAME = "aws-sdk-synthetics"
 

--- a/recipes-rubygems/rubygems-aws-sdk-wafv2_1.132.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-wafv2_1.132.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "20e1281960ddc59b0b647913f3083057"
-SRC_URI[sha256sum] = "2c9383cd28ea050348a2487a8f1514f332eaa528f9113d17bc89ab43849c1f82"
+SRC_URI[md5sum] = "4a25684e4449de8a95a3ac2b67b5976b"
+SRC_URI[sha256sum] = "ba7f17b740bc3941c25565eb6f93cc9fd2d7f86208707f6b4e95b4a12f8964d4"
 
 GEM_NAME = "aws-sdk-wafv2"
 

--- a/recipes-rubygems/rubygems-faraday_2.14.3.bb
+++ b/recipes-rubygems/rubygems-faraday_2.14.3.bb
@@ -17,8 +17,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d81f69a68f9e7a0ceea37dde776a680c"
-SRC_URI[sha256sum] = "73ccb9994a9e8648f010e32eca2ae82e41c57860aa10932cda29418b9e0223ad"
+SRC_URI[md5sum] = "03e148b8aa90790bd521076b9b799f5a"
+SRC_URI[sha256sum] = "1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278"
 
 GEM_NAME = "faraday"
 

--- a/recipes-rubygems/rubygems-google-apis-admin-directory-v1_0.78.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-admin-directory-v1_0.78.0.bb
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
-SUMMARY = "RubyGem: google-apis-monitoring_v3"
-DESCRIPTION = "This is the simple REST client for Cloud Monitoring API V3"
+SUMMARY = "RubyGem: google-apis-admin_directory_v1"
+DESCRIPTION = "This is the simple REST client for Admin SDK API DirectoryV1"
 HOMEPAGE = "https://github.com/google/google-api-ruby-client"
 
 LICENSE = "Apache-2.0"
@@ -15,10 +15,10 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b56d666221a01654283d38c74e0f8dcb"
-SRC_URI[sha256sum] = "33df0b0405e64b9c2b88a5c16b6f601b7ad6c5f1e1fed8dbc5e017849f295e7a"
+SRC_URI[md5sum] = "91640d46178b3c3385f0ddbf253bec0b"
+SRC_URI[sha256sum] = "8b9e962a598eb935cdadf49041237cef6adb32496d3fc8b39f09e38056526a68"
 
-GEM_NAME = "google-apis-monitoring_v3"
+GEM_NAME = "google-apis-admin_directory_v1"
 
 inherit rubygems
 inherit rubygentest

--- a/recipes-rubygems/rubygems-google-apis-discovery-v1_0.21.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-discovery-v1_0.21.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e6d3c6a544b91351ee218faa242c0c4a"
-SRC_URI[sha256sum] = "6e0fdb80854c063feeed253dedbe777ab1eccd81ce81c94332fd18e7aee3c1c0"
+SRC_URI[md5sum] = "ea5a38890c355a89fe2d0418e80dcf19"
+SRC_URI[sha256sum] = "fce49cb075013609485047f15e331a6db69ff42e202f154249cded2a2bfe8f3c"
 
 GEM_NAME = "google-apis-discovery_v1"
 

--- a/recipes-rubygems/rubygems-google-apis-monitoring-v3_0.85.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-monitoring-v3_0.85.0.bb
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
-SUMMARY = "RubyGem: google-apis-admin_directory_v1"
-DESCRIPTION = "This is the simple REST client for Admin SDK API DirectoryV1"
+SUMMARY = "RubyGem: google-apis-monitoring_v3"
+DESCRIPTION = "This is the simple REST client for Cloud Monitoring API V3"
 HOMEPAGE = "https://github.com/google/google-api-ruby-client"
 
 LICENSE = "Apache-2.0"
@@ -15,10 +15,10 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "463c7d652eccae8d309d3bdf11a5247f"
-SRC_URI[sha256sum] = "e5aa0c86aa2fd1c4035745407ad9e356bb926ba8e7d30648d88dd07f57c42ca9"
+SRC_URI[md5sum] = "afde4a4156a08c3d80d1153455c60d1f"
+SRC_URI[sha256sum] = "c304ff07eef6582cc81af61a441270af228169253d8257ab70cac38645801388"
 
-GEM_NAME = "google-apis-admin_directory_v1"
+GEM_NAME = "google-apis-monitoring_v3"
 
 inherit rubygems
 inherit rubygentest

--- a/recipes-rubygems/rubygems-googleauth_1.17.1.bb
+++ b/recipes-rubygems/rubygems-googleauth_1.17.1.bb
@@ -21,8 +21,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d42e66a6c76956f9b45ff3c7d925d66a"
-SRC_URI[sha256sum] = "dbddcaa3b78469fa9392c0e784ab6d8f3f760a1e5f6c6dbbbaa44a612c4198b0"
+SRC_URI[md5sum] = "f69e333a72226b57fa60ec6df1d19a7e"
+SRC_URI[sha256sum] = "0f7e6fc70e204cee1b2d71f1e1de2d3b349d432404197fe68ebf7fa23d0821b9"
 
 GEM_NAME = "googleauth"
 

--- a/recipes-rubygems/rubygems-i18n_1.15.2.bb
+++ b/recipes-rubygems/rubygems-i18n_1.15.2.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7dce69cb309c1c72cf201f8e8edf7ace"
-SRC_URI[sha256sum] = "285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5"
+SRC_URI[md5sum] = "89c99db56e111331e51f15279e43bdea"
+SRC_URI[sha256sum] = "00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5"
 
 GEM_NAME = "i18n"
 

--- a/recipes-rubygems/rubygems-nokogiri_1.19.4.bb
+++ b/recipes-rubygems/rubygems-nokogiri_1.19.4.bb
@@ -24,8 +24,8 @@ GEM_INSTALL_FLAGS:append = " \
     --use-system-libraries \
 "
 
-SRC_URI[md5sum] = "f6ab9377b07a606b07d05514997dc8f3"
-SRC_URI[sha256sum] = "78312cbac32a40c812780d9678221b79d51288eec00054c1a8d15f7ce05960e8"
+SRC_URI[md5sum] = "0d54395ae619300970827b8b1d394f7c"
+SRC_URI[sha256sum] = "50c951611c92bca05c51411aef45f1cbc50f2821c4802758c5c6d34696533ab5"
 
 GEM_NAME = "nokogiri"
 

--- a/recipes-rubygems/rubygems-ohai_19.1.37.bb
+++ b/recipes-rubygems/rubygems-ohai_19.1.37.bb
@@ -27,8 +27,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "da79b5ddfef76aa4df3f5fc35f62f538"
-SRC_URI[sha256sum] = "a15f3fd2298321a494c536a7af0e97020d71e4034963d42598bd4f33eacd7758"
+SRC_URI[md5sum] = "420e04a48d7722caeb54ce2c1fa1ee46"
+SRC_URI[sha256sum] = "4f7887558b286305cc2b6444f3eb235d0eddb9d610f9f58724367d348218f105"
 
 GEM_NAME = "ohai"
 

--- a/recipes-rubygems/rubygems-retriable_4.2.0.bb
+++ b/recipes-rubygems/rubygems-retriable_4.2.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "2aef87e90b610583dd075038d644f837"
-SRC_URI[sha256sum] = "6c25151721cba9d5d1c0aa9dbb38012aee36dd84752069f13dec98e7f8b51cec"
+SRC_URI[md5sum] = "5622ac787066fe981bc061b36ea52ce9"
+SRC_URI[sha256sum] = "90c3b257472a1c02f2a3dfa64dd35a420f7a624cef1a5981e20fdac5730f8cdc"
 
 GEM_NAME = "retriable"
 

--- a/recipes-rubygems/rubygems-rubocop_1.88.0.bb
+++ b/recipes-rubygems/rubygems-rubocop_1.88.0.bb
@@ -24,8 +24,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "ba2a40dec95779df511eabf98d483785"
-SRC_URI[sha256sum] = "b9d9ddf55116a513f8ef2c7ae660662d8b49301f118d3f0df61865b33a5c188d"
+SRC_URI[md5sum] = "87c9afda06edfef7b887195093012a61"
+SRC_URI[sha256sum] = "e420ddf1662d0ef34bc8a2910ac4b396a7ddda0b51a708264405241734b08e0b"
 
 GEM_NAME = "rubocop"
 

--- a/recipes-rubygems/rubygems-rubyzip_3.4.0.bb
+++ b/recipes-rubygems/rubygems-rubyzip_3.4.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1ae45adfd98dad9703bd5dc119c7a34a"
-SRC_URI[sha256sum] = "2ed92112c7c43ba2b2527f35e6d99d9c2c99270b640aad5227516436481b1e4e"
+SRC_URI[md5sum] = "2c848dbdba2380748f87867a50e8278e"
+SRC_URI[sha256sum] = "6de39bc9eba302b635a476d16c9e16b0872ad24517c2f98f2b3a7ea23caff57b"
 
 GEM_NAME = "rubyzip"
 

--- a/recipes-rubygems/rubygems-sys-filesystem_1.6.0.bb
+++ b/recipes-rubygems/rubygems-sys-filesystem_1.6.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c0645dbdf182b91051c4f7dd8d95fc33"
-SRC_URI[sha256sum] = "6f995890a734b9f0aa55df5e09d99adeb9fd1c288f2c4097269a1f8c95e15033"
+SRC_URI[md5sum] = "49376a622b14ddbaa07bb8f8554cdc75"
+SRC_URI[sha256sum] = "e2a7183e147e9b95aaa1217d65b3e3b479861c554acd18ec36aebb91398b45f6"
 
 GEM_NAME = "sys-filesystem"
 

--- a/recipes-rubygems/rubygems-train-core_3.16.5.bb
+++ b/recipes-rubygems/rubygems-train-core_3.16.5.bb
@@ -20,8 +20,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9c8667265ecd6ef09278c6810e290c2f"
-SRC_URI[sha256sum] = "dffeae2d01e8452ded15facb48e1c80ef8ccf326cbbb4063fa96bf6b7885f277"
+SRC_URI[md5sum] = "35c1ef35016bd7fa73678900f369cfa2"
+SRC_URI[sha256sum] = "29eebf88237bce2bb3f78752a7f19ceacaad77634ae14edae88f18fcf0362a94"
 
 GEM_NAME = "train-core"
 

--- a/recipes-rubygems/rubygems-train_3.16.5.bb
+++ b/recipes-rubygems/rubygems-train_3.16.5.bb
@@ -16,6 +16,7 @@ DEPENDS:class-native += "\
     rubygems-azure-mgmt-resources-native \
     rubygems-azure-mgmt-security-native \
     rubygems-azure-mgmt-storage-native \
+    rubygems-bigdecimal-native \
     rubygems-docker-api-native \
     rubygems-google-apis-admin-directory-v1-native \
     rubygems-google-apis-cloudkms-v1-native \
@@ -33,8 +34,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d05af1963e1d143f82e3e90fcfa0f638"
-SRC_URI[sha256sum] = "1a1f71a00ae8f908a511a4d763425d0ae3b3a4934c029fdb22f7f0aec28ffa03"
+SRC_URI[md5sum] = "1b6b42da3b785f73b280145c9baec356"
+SRC_URI[sha256sum] = "5f43128f86bb7316461dd3f8037f97ca33d79397ebe99327b14c7dca4f9afe88"
 
 GEM_NAME = "train"
 
@@ -49,6 +50,7 @@ RDEPENDS:${PN}:class-target += "\
     rubygems-azure-mgmt-resources \
     rubygems-azure-mgmt-security \
     rubygems-azure-mgmt-storage \
+    rubygems-bigdecimal \
     rubygems-docker-api \
     rubygems-google-apis-admin-directory-v1 \
     rubygems-google-apis-cloudkms-v1 \


### PR DESCRIPTION
* faraday: update to 2.14.3
* train-core: update to 3.16.5
* rubyzip: update to 3.4.0
* nokogiri: update to 1.19.4
* aws-partitions: update to 1.1261.0
* train: update to 3.16.5
* aws-sdk-s3: update to 1.226.0
* i18n: update to 1.15.2
* aws-sdk-ecs: update to 1.238.0
* aws-sdk-route53resolver: update to 1.101.0
* aws-sdk-synthetics: update to 1.86.0
* rubocop: update to 1.88.0
* retriable: update to 4.2.0
* aws-sdk-glue: update to 1.263.0
* aws-sdk-eks: update to 1.170.0
* aws-sdk-mq: update to 1.98.0
* aws-sdk-cognitoidentityprovider: update to 1.145.0
* aws-sdk-lambda: update to 1.184.0
* google-apis-discovery_v1: update to 0.21.0
* aws-sdk-wafv2: update to 1.132.0
* aws-sdk-rds: update to 1.316.0
* aws-sdk-ec2: update to 1.624.0
* aws-sdk-batch: update to 1.146.0
* aws-sdk-cloudwatchlogs: update to 1.156.0
* ohai: update to 19.1.37
* aws-sdk-applicationautoscaling: update to 1.124.0
* sys-filesystem: update to 1.6.0