### PR TITLE
Package update

### DIFF
--- a/.pkgupdateskip
+++ b/.pkgupdateskip
@@ -16,3 +16,5 @@ rspec-expectations;>=3.12.0
 rspec-mocks;>=3.12.0
 rspec-support;>=3.12.0
 rspec;>=3.12.0
+train-core;==3.16.5
+train;==3.16.5

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_hana.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_hana.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_hana(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_hana(self):
+        self.gem_is_installed("hana")
+
+    def test_load_hana(self):
+        self.gem_is_loadable("hana")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_json_schemer.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_json_schemer.py
@@ -1,0 +1,13 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_json_schemer(RubyGemsTestUtils):
+
+    def test_exec_json_schemer(self):
+        self.gem_exec_wrapper("json_schemer")
+
+    def test_gem_list_rubygems_json_schemer(self):
+        self.gem_is_installed("json_schemer")
+
+    def test_load_json_schemer(self):
+        self.gem_is_loadable("json_schemer")
+

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_rubyzip.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_rubyzip.py
@@ -5,6 +5,9 @@ class RubyGemsTestrubygems_rubyzip(RubyGemsTestUtils):
     def test_gem_list_rubygems_rubyzip(self):
         self.gem_is_installed("rubyzip")
 
+    def test_load_rubyzip(self):
+        self.gem_is_loadable("rubyzip")
+
     def test_load_zip(self):
         self.gem_is_loadable("zip")
 

--- a/lib/oeqa/runtime/cases/rubygems_rubygems_simpleidn.py
+++ b/lib/oeqa/runtime/cases/rubygems_rubygems_simpleidn.py
@@ -1,0 +1,10 @@
+from rubygems_utils import RubyGemsTestUtils
+
+class RubyGemsTestrubygems_simpleidn(RubyGemsTestUtils):
+
+    def test_gem_list_rubygems_simpleidn(self):
+        self.gem_is_installed("simpleidn")
+
+    def test_load_simpleidn(self):
+        self.gem_is_loadable("simpleidn")
+

--- a/packagegroups-rubygems/packagegroup-rubygems.bb
+++ b/packagegroups-rubygems/packagegroup-rubygems.bb
@@ -185,6 +185,7 @@ RDEPENDS:${PN} += "\
     rubygems-googleauth \
     rubygems-gssapi \
     rubygems-gyoku \
+    rubygems-hana \
     rubygems-hashdiff \
     rubygems-hashie \
     rubygems-hiera \
@@ -208,6 +209,7 @@ RDEPENDS:${PN} += "\
     rubygems-jmespath \
     rubygems-json \
     rubygems-json-schema \
+    rubygems-json-schemer \
     rubygems-jsonpath \
     rubygems-jwt \
     rubygems-k8s-ruby \
@@ -312,6 +314,7 @@ RDEPENDS:${PN} += "\
     rubygems-simplecov \
     rubygems-simplecov-html \
     rubygems-simplecov-json-formatter \
+    rubygems-simpleidn \
     rubygems-slop \
     rubygems-socksify \
     rubygems-specinfra \

--- a/recipes-rubygems/rubygems-aws-partitions_1.1262.0.bb
+++ b/recipes-rubygems/rubygems-aws-partitions_1.1262.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "43cf7eba288fea25016d4698471d2d12"
-SRC_URI[sha256sum] = "045aff79be010126538f39e03141088e1fd2428d2d065e220e7fb3c3ba2b337a"
+SRC_URI[md5sum] = "adba4fc9c0909e5a7a4d8c1e2688ba08"
+SRC_URI[sha256sum] = "77e9b1dd3e8f616673f2959d2fc4e762065f83a43140e2cb82274525afbaccf7"
 
 GEM_NAME = "aws-partitions"
 

--- a/recipes-rubygems/rubygems-aws-sdk-applicationautoscaling_1.124.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-applicationautoscaling_1.124.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "32538f204de24e01ff629d7ade53790b"
-SRC_URI[sha256sum] = "bfae8b66622e085232e109ce71a6ba89afce43637840ed2039a5feb22fbb50a9"
+SRC_URI[md5sum] = "d17f6a9e432a0b6374a7fa9042755a90"
+SRC_URI[sha256sum] = "0f2725a2b5e1ebcea9f33b43197e56ad1f1e042bc3a378571945b64f61d425f7"
 
 GEM_NAME = "aws-sdk-applicationautoscaling"
 

--- a/recipes-rubygems/rubygems-aws-sdk-batch_1.146.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-batch_1.146.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e11837c4b0bcfc5032ead60ce7b71d40"
-SRC_URI[sha256sum] = "881b13acd0076a23a668ab3608306294e319256eac0ea4c1704c8c0444d73315"
+SRC_URI[md5sum] = "5f8e6b36a99434d441079de429855419"
+SRC_URI[sha256sum] = "a5791dc2e31ff92d41200700d6cf9c29c4feb29096ba80a9d526bde547c085e6"
 
 GEM_NAME = "aws-sdk-batch"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.157.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudwatchlogs_1.157.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "88c54ee91df213d41ebb03acc0be44b1"
-SRC_URI[sha256sum] = "7e591874098870448ac18f45996216aeee855fc2ea6fe760231823b0c174e80c"
+SRC_URI[md5sum] = "eff49a3eef5f131fa37837ce292404e1"
+SRC_URI[sha256sum] = "5551c4e6cb4b1ed89612026c264551c9bb6c9b3e8af023d795941820cfbc2681"
 
 GEM_NAME = "aws-sdk-cloudwatchlogs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-cognitoidentityprovider_1.145.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cognitoidentityprovider_1.145.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c307069e8992daf2bbccfc6099917c71"
-SRC_URI[sha256sum] = "99ece7652b7e52b80951522ae7e476eccae24390525bad35ab2926748bba3baf"
+SRC_URI[md5sum] = "25cda935a62401735e035bd683bb3750"
+SRC_URI[sha256sum] = "05a808842e90d5f36eba234ce24b94f733406a5b0ce70312cf75973d79911fe9"
 
 GEM_NAME = "aws-sdk-cognitoidentityprovider"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ec2_1.625.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ec2_1.625.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "83a02638b0544e7b24e53bcb362dd09e"
-SRC_URI[sha256sum] = "6c2ac281b4d3cf04caaa88f39045333cd89bc9b8fccf9fabadb9c1e3ee6cfbe0"
+SRC_URI[md5sum] = "cadf168b9c1b436ed65e185bbbfc7301"
+SRC_URI[sha256sum] = "4af293c8d1b5398bc3b8b68b48c6e9f63c5ae898bd2bfc56acb7842b3ea3c7e7"
 
 GEM_NAME = "aws-sdk-ec2"
 

--- a/recipes-rubygems/rubygems-aws-sdk-ecs_1.238.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-ecs_1.238.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "89f56c67339236c65eb27b1ac7ecd8d2"
-SRC_URI[sha256sum] = "2db522bc350962e7709d7174cb06da7dc3e4af0aeb55c76dbebcf655224b27ae"
+SRC_URI[md5sum] = "62cacefd429df622f9925b8cc7b596f0"
+SRC_URI[sha256sum] = "504537e726804b5ac9d4edc0416cc5252506cb4fb09be82911b3605dcd6fda00"
 
 GEM_NAME = "aws-sdk-ecs"
 

--- a/recipes-rubygems/rubygems-aws-sdk-eks_1.170.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-eks_1.170.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c1a8231c1b22b3b1b9379c1f32f15ae6"
-SRC_URI[sha256sum] = "3a867a775383925c1288bf5300fd115c3c17ac003c956be635ea4b985f433ed5"
+SRC_URI[md5sum] = "778b88369d5fa6ff8e5006901bfb7383"
+SRC_URI[sha256sum] = "91fc2629443fc15d131c51a1d42a952a90cbdda2b3e3dec6dff178d88331e8c1"
 
 GEM_NAME = "aws-sdk-eks"
 

--- a/recipes-rubygems/rubygems-aws-sdk-glue_1.263.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-glue_1.263.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "5ae7e5c71652cc0598da4e323e1471a3"
-SRC_URI[sha256sum] = "8c51a38639db00339ecaf50ea2a26f1979669bf7230f13966cf6e909434f8fc9"
+SRC_URI[md5sum] = "be706d1780ad92519997a686043008d0"
+SRC_URI[sha256sum] = "613446cce82117af2d67cf38330ed703c933a1e4a2524b1fe0588f21343aba8e"
 
 GEM_NAME = "aws-sdk-glue"
 

--- a/recipes-rubygems/rubygems-aws-sdk-guardduty_1.155.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-guardduty_1.155.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "12264cd17763b7f3a451f4c01dc140fc"
-SRC_URI[sha256sum] = "5525c6c31c72f8c14837a86bd3fb9a133a934251525198da7c2854f2f3eac248"
+SRC_URI[md5sum] = "2e271914490a160e2b1291b81432338c"
+SRC_URI[sha256sum] = "2c09f66057dac1c279f40d187155e39edd325fe10dcd886c1e8a25d830557f5a"
 
 GEM_NAME = "aws-sdk-guardduty"
 

--- a/recipes-rubygems/rubygems-aws-sdk-kafka_1.115.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-kafka_1.115.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "24aab9352304e0173deb11a12917d3d5"
-SRC_URI[sha256sum] = "6573fa4bea006d228510f06106802eb344516ad217f41c57e434f3014a588503"
+SRC_URI[md5sum] = "ae348ee4ed78932d3446d0a9d6541b7d"
+SRC_URI[sha256sum] = "93ac2050bdbe28fb827263419597170f0ade568d6edfeaf7b6a5259c1f9e3f62"
 
 GEM_NAME = "aws-sdk-kafka"
 

--- a/recipes-rubygems/rubygems-aws-sdk-lambda_1.185.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-lambda_1.185.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "9827eff235759fef5b4781c83efa3833"
-SRC_URI[sha256sum] = "3dbf19f07e2d484108ec9e7f45c6482ee2f5f3023ee5df1434caa8a4d84f3ae4"
+SRC_URI[md5sum] = "fcbecf68e3860d05ea40b945c74d635c"
+SRC_URI[sha256sum] = "ba0e6f083776ff7c3538999bff85e18458c1c182d82538453b84277efc27c50e"
 
 GEM_NAME = "aws-sdk-lambda"
 

--- a/recipes-rubygems/rubygems-aws-sdk-mq_1.98.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-mq_1.98.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7432fe76eb682addbed8360380ea9cea"
-SRC_URI[sha256sum] = "d54037d08bcac17110c501b086a6e6b11dd740e3d48af0d8916bbfabba086bad"
+SRC_URI[md5sum] = "c20c012502d5ca6ce3e683fdbfe13ed2"
+SRC_URI[sha256sum] = "55157af4a1bc34f25c472d179e659fe207ddf9a0be42ad67914d64b6e51ef1ff"
 
 GEM_NAME = "aws-sdk-mq"
 

--- a/recipes-rubygems/rubygems-aws-sdk-rds_1.316.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-rds_1.316.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "cd96b7a25233b0a2f3b0c2d53c2d1904"
-SRC_URI[sha256sum] = "38b34feea112fc039f93886d90476ef40f637682074b6fa06b7fe4d92dac4cd8"
+SRC_URI[md5sum] = "aece6d1111fa4b75ab099fea1b548521"
+SRC_URI[sha256sum] = "81fec624bee0e66c8360fa6295e33c615719d9847bb4ebb6f145738699217804"
 
 GEM_NAME = "aws-sdk-rds"
 

--- a/recipes-rubygems/rubygems-aws-sdk-route53resolver_1.101.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-route53resolver_1.101.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b7312eed99eb2511779d80927dbb939a"
-SRC_URI[sha256sum] = "09deec68522743f48202fb95293df634304021ac3e42aad451168d5c83853e07"
+SRC_URI[md5sum] = "e13a17ab7ac4d1852b41d5cd7a8b0d00"
+SRC_URI[sha256sum] = "d9d0d7955d50a090e313948ffce5e069c61036425c2b3ef188487a2c27aedd12"
 
 GEM_NAME = "aws-sdk-route53resolver"
 

--- a/recipes-rubygems/rubygems-aws-sdk-s3_1.226.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-s3_1.226.0.bb
@@ -17,8 +17,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "51b586aaa33eaacc460589270013b28c"
-SRC_URI[sha256sum] = "d4b23a8db9b0a5548766b52d382b184f47f7e126560acdb731dd46adb5e26512"
+SRC_URI[md5sum] = "4f404db6a9cf8b95b8c885f7838b7846"
+SRC_URI[sha256sum] = "e599f431e006ec9b92c61ee0f14d3f658a1f6c8a1d623d2160be927ac958e2bf"
 
 GEM_NAME = "aws-sdk-s3"
 

--- a/recipes-rubygems/rubygems-aws-sdk-synthetics_1.86.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-synthetics_1.86.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "690dc8035f0a3dc09fea65dca05552e3"
-SRC_URI[sha256sum] = "37e86c9194654ae7e98c23406c539dc1d16dc5bc9681456d57c4c7c1b341637b"
+SRC_URI[md5sum] = "162ba4c8bed7f5b3a21b4b53bd8d2f4b"
+SRC_URI[sha256sum] = "d94bb9f83dba971baf80cb8f5807f026f0145d9ca69a300302f64f1ed931ca3e"
 
 GEM_NAME = "aws-sdk-synthetics"
 

--- a/recipes-rubygems/rubygems-aws-sdk-wafv2_1.132.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-wafv2_1.132.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "20e1281960ddc59b0b647913f3083057"
-SRC_URI[sha256sum] = "2c9383cd28ea050348a2487a8f1514f332eaa528f9113d17bc89ab43849c1f82"
+SRC_URI[md5sum] = "4a25684e4449de8a95a3ac2b67b5976b"
+SRC_URI[sha256sum] = "ba7f17b740bc3941c25565eb6f93cc9fd2d7f86208707f6b4e95b4a12f8964d4"
 
 GEM_NAME = "aws-sdk-wafv2"
 

--- a/recipes-rubygems/rubygems-cookstyle_8.7.6.bb
+++ b/recipes-rubygems/rubygems-cookstyle_8.7.6.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d65c5b9e6d638d097b09360a6d5d1da4"
-SRC_URI[sha256sum] = "9b9df27f3aaaa3e53898a0930a5b2d2bd01abb34b138e6d94a8fd13c8ab4bf57"
+SRC_URI[md5sum] = "9a98fd36a5ff0013fb40b6443745f72d"
+SRC_URI[sha256sum] = "5c10e5c85c91e22c2aded0c8c45fbd31957dcd50003ee9e46e97241ae84f9563"
 
 GEM_NAME = "cookstyle"
 

--- a/recipes-rubygems/rubygems-faraday_2.14.3.bb
+++ b/recipes-rubygems/rubygems-faraday_2.14.3.bb
@@ -17,8 +17,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "d81f69a68f9e7a0ceea37dde776a680c"
-SRC_URI[sha256sum] = "73ccb9994a9e8648f010e32eca2ae82e41c57860aa10932cda29418b9e0223ad"
+SRC_URI[md5sum] = "03e148b8aa90790bd521076b9b799f5a"
+SRC_URI[sha256sum] = "1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278"
 
 GEM_NAME = "faraday"
 

--- a/recipes-rubygems/rubygems-google-apis-discovery-v1_0.21.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-discovery-v1_0.21.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e6d3c6a544b91351ee218faa242c0c4a"
-SRC_URI[sha256sum] = "6e0fdb80854c063feeed253dedbe777ab1eccd81ce81c94332fd18e7aee3c1c0"
+SRC_URI[md5sum] = "ea5a38890c355a89fe2d0418e80dcf19"
+SRC_URI[sha256sum] = "fce49cb075013609485047f15e331a6db69ff42e202f154249cded2a2bfe8f3c"
 
 GEM_NAME = "google-apis-discovery_v1"
 

--- a/recipes-rubygems/rubygems-hana_1.3.7.bb
+++ b/recipes-rubygems/rubygems-hana_1.3.7.bb
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: hana"
+DESCRIPTION = "Implementation of [JSON Patch][1] and [JSON Pointer][2] RFC."
+HOMEPAGE = "http://github.com/tenderlove/hana"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "c3776ca474702c6bdc9a5d1778b9840e"
+SRC_URI[sha256sum] = "5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d"
+
+GEM_NAME = "hana"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-i18n_1.15.2.bb
+++ b/recipes-rubygems/rubygems-i18n_1.15.2.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7dce69cb309c1c72cf201f8e8edf7ace"
-SRC_URI[sha256sum] = "285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5"
+SRC_URI[md5sum] = "89c99db56e111331e51f15279e43bdea"
+SRC_URI[sha256sum] = "00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5"
 
 GEM_NAME = "i18n"
 

--- a/recipes-rubygems/rubygems-inspec-bin_5.24.24.bb
+++ b/recipes-rubygems/rubygems-inspec-bin_5.24.24.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "ff1234ab3be9505e775f0a59645e9825"
-SRC_URI[sha256sum] = "cb82849a468e9aadde27f3d3391281eb1b829ce58180af47f62244d3ee4657d0"
+SRC_URI[md5sum] = "7126ba48751700a81b1e4c6a07dd4617"
+SRC_URI[sha256sum] = "b818d081b8175f6b633f4cb8be8f115fed68130443fd91759bda8123ffe502c6"
 
 GEM_NAME = "inspec-bin"
 

--- a/recipes-rubygems/rubygems-inspec-core_5.24.24.bb
+++ b/recipes-rubygems/rubygems-inspec-core_5.24.24.bb
@@ -23,6 +23,7 @@ DEPENDS:class-native += "\
     rubygems-parallel-native \
     rubygems-parslet-native \
     rubygems-pry-native \
+    rubygems-public-suffix-native \
     rubygems-rspec-its-native \
     rubygems-rspec-native \
     rubygems-rubyzip-native \
@@ -37,8 +38,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "dcf594f8700f65db76947f2ff4ae94e6"
-SRC_URI[sha256sum] = "847b29e13963beb303b2c3d1f7ca1c93060e26c91e3d2262850bc66903b5f9f6"
+SRC_URI[md5sum] = "9730bb9598de4219a8d9c440c8b43f25"
+SRC_URI[sha256sum] = "2b23939869add90dde39f195160f7c3e05cf89f749b77a9c94631d201e626ee3"
 
 GEM_NAME = "inspec-core"
 
@@ -60,6 +61,7 @@ RDEPENDS:${PN}:class-target += "\
     rubygems-parallel \
     rubygems-parslet \
     rubygems-pry \
+    rubygems-public-suffix \
     rubygems-rspec \
     rubygems-rspec-its \
     rubygems-rubyzip \

--- a/recipes-rubygems/rubygems-inspec_5.24.24.bb
+++ b/recipes-rubygems/rubygems-inspec_5.24.24.bb
@@ -26,8 +26,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a026c4b2f5da63fa6ac4d97c8c4f338b"
-SRC_URI[sha256sum] = "0cd39d951b37e1a432db9adc2ffad5d3ed44de92600899ac73a9673084da7b70"
+SRC_URI[md5sum] = "b1c4dcbdddbcd43eaa70a1a8d7ea3ca6"
+SRC_URI[sha256sum] = "0635ff73aeec37592fb10dd429d7a33e4136fa2f12933b69b2e46c4897f36c66"
 
 GEM_NAME = "inspec"
 

--- a/recipes-rubygems/rubygems-json-schemer_2.5.0.bb
+++ b/recipes-rubygems/rubygems-json-schemer_2.5.0.bb
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: json_schemer"
+DESCRIPTION = "JSON Schema validator"
+HOMEPAGE = "https://github.com/davishmcclurg/json_schemer"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=d2196d988ac05bce6be7681eb952d9c2"
+
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+DEPENDS:class-native += "\
+    rubygems-bigdecimal-native \
+    rubygems-hana-native \
+    rubygems-regexp-parser-native \
+    rubygems-simpleidn-native \
+"
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "47002e3e537969c821afc1e5aefda5a4"
+SRC_URI[sha256sum] = "2f01fb4cce721a4e08dd068fc2030cffd0702a7f333f1ea2be6e8991f00ae396"
+
+GEM_NAME = "json_schemer"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+RDEPENDS:${PN}:class-target += "\
+    rubygems-bigdecimal \
+    rubygems-hana \
+    rubygems-regexp-parser \
+    rubygems-simpleidn \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-mcp_0.22.0.bb
+++ b/recipes-rubygems/rubygems-mcp_0.22.0.bb
@@ -7,18 +7,16 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=5498bbc0155db622ff063f9f7396da88"
 
 EXTRA_DEPENDS:append = " "
-EXTRA_RDEPENDS:append = " \
-    bash \
-"
+EXTRA_RDEPENDS:append = " "
 
 DEPENDS:class-native += "\
-    rubygems-json-schema-native \
+    rubygems-json-schemer-native \
 "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "5bb723c6709ca8c84b7c5e3eabf22fa7"
-SRC_URI[sha256sum] = "4d8ec572c1536f53370196539d5272355fb6480ed969ea58a8d24917ee2562c8"
+SRC_URI[md5sum] = "4543eb5478e22efbd6fc9f33dab95cc9"
+SRC_URI[sha256sum] = "e2ef603207c7e2c691bef4d8d8ab35d9740bedf315949fdb6d9a25318d1a7025"
 
 GEM_NAME = "mcp"
 
@@ -27,7 +25,7 @@ inherit rubygentest
 inherit pkgconfig
 
 RDEPENDS:${PN}:class-target += "\
-    rubygems-json-schema \
+    rubygems-json-schemer \
 "
 
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-nokogiri_1.19.4.bb
+++ b/recipes-rubygems/rubygems-nokogiri_1.19.4.bb
@@ -24,8 +24,8 @@ GEM_INSTALL_FLAGS:append = " \
     --use-system-libraries \
 "
 
-SRC_URI[md5sum] = "f6ab9377b07a606b07d05514997dc8f3"
-SRC_URI[sha256sum] = "78312cbac32a40c812780d9678221b79d51288eec00054c1a8d15f7ce05960e8"
+SRC_URI[md5sum] = "0d54395ae619300970827b8b1d394f7c"
+SRC_URI[sha256sum] = "50c951611c92bca05c51411aef45f1cbc50f2821c4802758c5c6d34696533ab5"
 
 GEM_NAME = "nokogiri"
 

--- a/recipes-rubygems/rubygems-ohai_19.1.40.bb
+++ b/recipes-rubygems/rubygems-ohai_19.1.40.bb
@@ -27,8 +27,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "da79b5ddfef76aa4df3f5fc35f62f538"
-SRC_URI[sha256sum] = "a15f3fd2298321a494c536a7af0e97020d71e4034963d42598bd4f33eacd7758"
+SRC_URI[md5sum] = "601b8cee268cf85500dc88483fa2c679"
+SRC_URI[sha256sum] = "ea9ace2ebac2a193061315c39e49f63f3304b8ae56ecbd3daa005149d195ed7b"
 
 GEM_NAME = "ohai"
 

--- a/recipes-rubygems/rubygems-retriable_4.2.0.bb
+++ b/recipes-rubygems/rubygems-retriable_4.2.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "2aef87e90b610583dd075038d644f837"
-SRC_URI[sha256sum] = "6c25151721cba9d5d1c0aa9dbb38012aee36dd84752069f13dec98e7f8b51cec"
+SRC_URI[md5sum] = "5622ac787066fe981bc061b36ea52ce9"
+SRC_URI[sha256sum] = "90c3b257472a1c02f2a3dfa64dd35a420f7a624cef1a5981e20fdac5730f8cdc"
 
 GEM_NAME = "retriable"
 

--- a/recipes-rubygems/rubygems-rubocop_1.88.0.bb
+++ b/recipes-rubygems/rubygems-rubocop_1.88.0.bb
@@ -24,8 +24,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "ba2a40dec95779df511eabf98d483785"
-SRC_URI[sha256sum] = "b9d9ddf55116a513f8ef2c7ae660662d8b49301f118d3f0df61865b33a5c188d"
+SRC_URI[md5sum] = "87c9afda06edfef7b887195093012a61"
+SRC_URI[sha256sum] = "e420ddf1662d0ef34bc8a2910ac4b396a7ddda0b51a708264405241734b08e0b"
 
 GEM_NAME = "rubocop"
 

--- a/recipes-rubygems/rubygems-rubyzip_3.4.0.bb
+++ b/recipes-rubygems/rubygems-rubyzip_3.4.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "1ae45adfd98dad9703bd5dc119c7a34a"
-SRC_URI[sha256sum] = "2ed92112c7c43ba2b2527f35e6d99d9c2c99270b640aad5227516436481b1e4e"
+SRC_URI[md5sum] = "2c848dbdba2380748f87867a50e8278e"
+SRC_URI[sha256sum] = "6de39bc9eba302b635a476d16c9e16b0872ad24517c2f98f2b3a7ea23caff57b"
 
 GEM_NAME = "rubyzip"
 

--- a/recipes-rubygems/rubygems-simpleidn_0.2.3.bb
+++ b/recipes-rubygems/rubygems-simpleidn_0.2.3.bb
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+SUMMARY = "RubyGem: simpleidn"
+DESCRIPTION = "This gem allows easy conversion from punycode ACE strings to unicode UTF-8 strings and vice-versa."
+HOMEPAGE = "https://github.com/mmriis/simpleidn"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENCE;md5=125a8c5aa0f0043945e84c8bdbf84257"
+
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "270e236fc9772a0d7dc96e5a82a9372d"
+SRC_URI[sha256sum] = "08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29"
+
+GEM_NAME = "simpleidn"
+
+inherit rubygems
+inherit rubygentest
+inherit pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-sys-filesystem_1.6.0.bb
+++ b/recipes-rubygems/rubygems-sys-filesystem_1.6.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c0645dbdf182b91051c4f7dd8d95fc33"
-SRC_URI[sha256sum] = "6f995890a734b9f0aa55df5e09d99adeb9fd1c288f2c4097269a1f8c95e15033"
+SRC_URI[md5sum] = "49376a622b14ddbaa07bb8f8554cdc75"
+SRC_URI[sha256sum] = "e2a7183e147e9b95aaa1217d65b3e3b479861c554acd18ec36aebb91398b45f6"
 
 GEM_NAME = "sys-filesystem"
 

--- a/recipes-rubygems/rubygems-websocket-driver_0.8.2.bb
+++ b/recipes-rubygems/rubygems-websocket-driver_0.8.2.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "2f2d177f5c67edfb0c1931098e8b7b5c"
-SRC_URI[sha256sum] = "5ab238238ce230e5d4b262d2be39624c867914eab99171dc4952b58b577c2d96"
+SRC_URI[md5sum] = "f1c67afc338ffcfc83b1a0370892b9b6"
+SRC_URI[sha256sum] = "97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146"
 
 GEM_NAME = "websocket-driver"
 


### PR DESCRIPTION
* faraday: update to 2.14.3
* train-core: update to 3.16.5
* rubyzip: update to 3.4.0
* nokogiri: update to 1.19.4
* aws-partitions: update to 1.1262.0
* train: update to 3.16.5
* inspec-core: update to 5.24.24
* aws-sdk-s3: update to 1.226.0
* i18n: update to 1.15.2
* aws-sdk-ecs: update to 1.238.0
* aws-sdk-route53resolver: update to 1.101.0
* inspec: update to 5.24.24
* aws-sdk-kafka: update to 1.115.0
* aws-sdk-synthetics: update to 1.86.0
* rubocop: update to 1.88.0
* retriable: update to 4.2.0
* aws-sdk-glue: update to 1.263.0
* aws-sdk-eks: update to 1.170.0
* aws-sdk-mq: update to 1.98.0
* aws-sdk-cognitoidentityprovider: update to 1.145.0
* aws-sdk-lambda: update to 1.185.0
* aws-sdk-guardduty: update to 1.155.0
* google-apis-discovery_v1: update to 0.21.0
* aws-sdk-wafv2: update to 1.132.0
* aws-sdk-rds: update to 1.316.0
* aws-sdk-ec2: update to 1.625.0
* aws-sdk-batch: update to 1.146.0
* aws-sdk-cloudwatchlogs: update to 1.157.0
* ohai: update to 19.1.40
* aws-sdk-applicationautoscaling: update to 1.124.0
* websocket-driver: update to 0.8.2
* sys-filesystem: update to 1.6.0
* inspec-bin: update to 5.24.24