### PR TITLE
rubygems.bbclass: clear LIBPATHENV to stop leaking target libdir into LD_LIBRARY_PATH

### DIFF
--- a/classes/rubygems.bbclass
+++ b/classes/rubygems.bbclass
@@ -167,6 +167,10 @@ python do_arch_patch_config() {
         "LD": d.expand("${LD}"),
         "LDFLAGS": d.expand("${LDFLAGS}"),
         "libdir": d.getVar("STAGING_LIBDIR"),
+        # Clear LIBPATHENV -- mkmf otherwise leaks the target libdir into
+        # LD_LIBRARY_PATH, crashing the native compiler (SIGBUS) when host
+        # and target arch match.
+        "LIBPATHENV": "",
         "libexecdir": "$(exec_prefix)/libexec",
         "NM": d.expand("${NM}"),
         "OBJDUMP": d.expand("${OBJDUMP}"),


### PR DESCRIPTION
`do_arch_patch_config` points the native ruby's `rbconfig.rb` `libdir` at the target sysroot. `mkmf`'s `libpath_env` then exports that libdir via `LD_LIBRARY_PATH` (`CONFIG["LIBPATHENV"]`) to every compiler subprocess it spawns for `extconf.rb` probes.

On a host whose architecture matches the target's, the host loader accepts the target's `libc.so.6` and loads it into the native compiler alongside the host's own, different-version `ld.so`. Mixing glibc versions like this crashes early in glibc init — in our case a deterministic `SIGBUS` on every native-extension gem build (`json`, `nokogiri`, `nio4r`, `puma`, `llhttp`, `pg`, 100% reproducible).

Minimal repro, no ruby/gcc involved:
```sh
LD_LIBRARY_PATH=<target sysroot>/usr/lib /bin/echo hello   # SIGBUS
```

Fix: add `"LIBPATHENV": ""` to the `_map` in `do_arch_patch_config`. `mkmf`'s `config_string()` treats `""` as unset, so `libpath_env` stops injecting `LD_LIBRARY_PATH`. The `-L` flags mkmf needs come from `libdir` separately and are unaffected.

May not reproduce on x86_64 CI (host/target arch mismatch means the loader rejects the wrong-machine `libc.so.6`), but the leak itself is wrong regardless.

Verified: all 6 previously-100%-failing gems now install on the first attempt (qemuarm64, aarch64 host), zero retries, 1597/1597 tasks succeeded.
